### PR TITLE
[#2837] Add Generic Notification API and implementation for the Device Registry

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -245,6 +245,11 @@
         <artifactId>hono-client-application-kafka</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-client-notification</artifactId>
+        <version>${project.version}</version>
+      </dependency>
 
       <!-- Californium -->
       <dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -252,7 +252,17 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-client-notification-kafka</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
         <artifactId>hono-client-notification-registry</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-client-notification-registry-kafka</artifactId>
         <version>${project.version}</version>
       </dependency>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -250,6 +250,11 @@
         <artifactId>hono-client-notification</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-client-notification-registry</artifactId>
+        <version>${project.version}</version>
+      </dependency>
 
       <!-- Californium -->
       <dependency>

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/HonoTopic.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/HonoTopic.java
@@ -33,8 +33,8 @@ public final class HonoTopic {
      * Creates a new topic from the given topic type and tenant ID.
      *
      * @param type The type of the topic.
-     * @param suffix The suffix after the type specific topic part. For types other than {@link Type#COMMAND_INTERNAL}
-     *              this is the internal ID of the tenant that the topic belongs to.
+     * @param suffix The suffix after the type specific topic part. For messaging API types this is the internal ID of
+     *            the tenant that the topic belongs to.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     public HonoTopic(final Type type, final String suffix) {
@@ -67,6 +67,8 @@ public final class HonoTopic {
             type = Type.COMMAND_RESPONSE;
         } else if (topicString.startsWith(Type.COMMAND_INTERNAL.prefix)) {
             type = Type.COMMAND_INTERNAL;
+        } else if (topicString.startsWith(Type.NOTIFICATION.prefix)) {
+            type = Type.NOTIFICATION;
         }
         if (type != null) {
             final String suffix = topicString.substring(type.prefix.length());
@@ -79,17 +81,16 @@ public final class HonoTopic {
     /**
      * Gets the tenantId from the topic.
      *
-     * @return The tenantId or {@code null} in case of a {@link Type#COMMAND_INTERNAL} topic.
+     * @return The tenantId for a messaging API type or {@code null} in case of an internal topic.
      */
     public String getTenantId() {
-        return type == Type.COMMAND_INTERNAL ? null : suffix;
+        return Type.MESSAGING_API_TYPES.contains(type) ? suffix : null;
     }
 
     /**
      * Gets the suffix after the type specific topic part.
      * <p>
-     * For types other than {@link Type#COMMAND_INTERNAL} this is the internal ID
-     * of the tenant that the topic belongs to.
+     * For messaging API types this is the internal ID of the tenant that the topic belongs to.
      *
      * @return The suffix.
      */
@@ -142,13 +143,14 @@ public final class HonoTopic {
         EVENT(EventConstants.EVENT_ENDPOINT),
         COMMAND(CommandConstants.COMMAND_ENDPOINT),
         COMMAND_RESPONSE(CommandConstants.COMMAND_RESPONSE_ENDPOINT),
-        COMMAND_INTERNAL(CommandConstants.INTERNAL_COMMAND_ENDPOINT);
+        COMMAND_INTERNAL(CommandConstants.INTERNAL_COMMAND_ENDPOINT),
+        NOTIFICATION("notification");
 
         /**
          * A list of the types of topics that include a tenant identifier.
          */
-        public static final List<Type> TENANT_RELATED_TYPES = List.of(TELEMETRY, EVENT, COMMAND, COMMAND_RESPONSE);
-        private static final String SEPARATOR = ".";
+        public static final List<Type> MESSAGING_API_TYPES = List.of(TELEMETRY, EVENT, COMMAND, COMMAND_RESPONSE);
+        public static final String SEPARATOR = ".";
         private static final String NAMESPACE = "hono";
 
         /**

--- a/clients/notification-kafka/pom.xml
+++ b/clients/notification-kafka/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.hono</groupId>
+    <artifactId>hono-clients-parent</artifactId>
+    <version>1.11.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>hono-client-notification-kafka</artifactId>
+
+  <name>Hono Notification Client (Kafka)</name>
+  <description>Clients for sending and receiving Hono's notifications with Kafka</description>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-notification</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-kafka-common</artifactId>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>kafka-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/AbstractKafkaBasedNotificationSender.java
+++ b/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/AbstractKafkaBasedNotificationSender.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.notification;
+
+import java.net.HttpURLConnection;
+import java.util.Objects;
+
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.util.MessagingType;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import io.vertx.kafka.client.producer.RecordMetadata;
+
+/**
+ * A client for publishing Hono internal notifications with Kafka.
+ *
+ */
+public abstract class AbstractKafkaBasedNotificationSender implements NotificationSender {
+
+    private static final String PRODUCER_NAME = "notification";
+
+    private final KafkaProducerConfigProperties config;
+    private final KafkaProducerFactory<String, JsonObject> producerFactory;
+
+    private boolean stopped = false;
+
+    /**
+     * Creates a new Kafka-based event sender.
+     *
+     * @param producerFactory The factory to use for creating Kafka producers.
+     * @param kafkaProducerConfig The Kafka producer configuration properties to use.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public AbstractKafkaBasedNotificationSender(
+            final KafkaProducerFactory<String, JsonObject> producerFactory,
+            final KafkaProducerConfigProperties kafkaProducerConfig) {
+        Objects.requireNonNull(producerFactory);
+        Objects.requireNonNull(kafkaProducerConfig);
+
+        this.producerFactory = producerFactory;
+        this.config = kafkaProducerConfig;
+    }
+
+    @Override
+    public Future<Void> publish(final Notification notification, final SpanContext context) {
+
+        Objects.requireNonNull(notification);
+
+        if (stopped) {
+            return Future.failedFuture(
+                    new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "sender already stopped"));
+        }
+
+        try {
+
+            final String topic = getTopic(notification);
+            final String key = getKey(notification);
+            final JsonObject value = JsonObject.mapFrom(notification);
+            final KafkaProducerRecord<String, JsonObject> record = KafkaProducerRecord.create(topic, key, value);
+
+            final Promise<RecordMetadata> sendPromise = Promise.promise();
+            producerFactory.getOrCreateProducer(PRODUCER_NAME, config).send(record, sendPromise);
+
+            return sendPromise.future()
+                    .recover(t -> Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, t)))
+                    .mapEmpty();
+        } catch (RuntimeException ex) {
+            return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, ex));
+        }
+    }
+
+    /**
+     * Gets the record key to be used for a given notification.
+     *
+     * @param notification The notification to determine the key for.
+     * @return The record key.
+     */
+    protected abstract String getKey(Notification notification);
+
+    /**
+     * Gets the topic to be used for a given notification.
+     *
+     * @param notification The notification to determine the topic for.
+     * @return The topic.
+     */
+    protected abstract String getTopic(Notification notification);
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Starts the producer.
+     */
+    @Override
+    public Future<Void> start() {
+        stopped = false;
+        producerFactory.getOrCreateProducer(PRODUCER_NAME, config);
+        return Future.succeededFuture();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Closes the producer.
+     */
+    @Override
+    public Future<Void> stop() {
+        stopped = true;
+        return producerFactory.closeProducer(PRODUCER_NAME);
+    }
+
+    @Override
+    public String toString() {
+        return AbstractKafkaBasedNotificationSender.class.getName() + " via Kafka";
+    }
+
+    @Override
+    public final MessagingType getMessagingType() {
+        return MessagingType.kafka;
+    }
+
+}

--- a/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/KafkaBasedNotificationReceiver.java
+++ b/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/KafkaBasedNotificationReceiver.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.notification;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.eclipse.hono.client.kafka.AbstractKafkaConfigProperties;
+import org.eclipse.hono.client.kafka.HonoTopic;
+import org.eclipse.hono.client.kafka.consumer.HonoKafkaConsumer;
+import org.eclipse.hono.util.Strings;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+
+/**
+ * A client for receiving notifications with Kafka.
+ */
+public abstract class KafkaBasedNotificationReceiver implements NotificationReceiver {
+
+    private final Vertx vertx;
+    private final Map<String, String> consumerConfig = new HashMap<>();
+    @SuppressWarnings("rawtypes")
+    private final Map<Class<? extends Notification>, Handler> handlerPerType = new HashMap<>();
+    private final Set<String> topics = new HashSet<>();
+
+    private Supplier<Consumer<String, Buffer>> kafkaConsumerSupplier;
+    private HonoKafkaConsumer honoKafkaConsumer;
+    private boolean started = false;
+
+    /**
+     * Creates a client for consuming notifications.
+     *
+     * @param vertx The vert.x instance to be used.
+     * @param consumerConfig The configuration for the Kafka consumer.
+     *
+     * @throws NullPointerException if any parameter is {@code null}.
+     * @throws IllegalArgumentException if consumerConfig does not contain a valid configuration (at least a bootstrap
+     *             server).
+     */
+    public KafkaBasedNotificationReceiver(final Vertx vertx, final Map<String, String> consumerConfig) {
+
+        Objects.requireNonNull(vertx);
+        Objects.requireNonNull(consumerConfig);
+
+        if (Strings.isNullOrEmpty(consumerConfig.get(AbstractKafkaConfigProperties.PROPERTY_BOOTSTRAP_SERVERS))) {
+            throw new IllegalArgumentException("No Kafka configuration found!");
+        }
+
+        this.vertx = vertx;
+        this.consumerConfig.putAll(consumerConfig);
+    }
+
+    // visible for testing
+    void setKafkaConsumerFactory(final Supplier<Consumer<String, Buffer>> kafkaConsumerSupplier) {
+        this.kafkaConsumerSupplier = Objects.requireNonNull(kafkaConsumerSupplier);
+    }
+
+    @Override
+    public Future<Void> start() {
+        honoKafkaConsumer = new HonoKafkaConsumer(vertx, topics, getRecordHandler(), consumerConfig);
+        Optional.ofNullable(kafkaConsumerSupplier).ifPresent(honoKafkaConsumer::setKafkaConsumerSupplier);
+        return honoKafkaConsumer
+                .start()
+                .onSuccess(ok -> started = true);
+    }
+
+    @Override
+    public <T extends Notification> void registerConsumer(final Class<T> notificationType, final Handler<T> consumer) {
+
+        if (started) {
+            throw new IllegalStateException("consumers cannot be added when consumer is already started.");
+        }
+
+        final String address = getAddressForType(notificationType);
+        topics.add(new HonoTopic(HonoTopic.Type.NOTIFICATION, address).toString());
+        handlerPerType.put(notificationType, consumer);
+    }
+
+    private Handler<KafkaConsumerRecord<String, Buffer>> getRecordHandler() {
+        return record -> handleNotification(decodeNotification(record.value()));
+    }
+
+    /**
+     * Returns the address to consume notifications of the given type from.
+     *
+     * @param notificationType The class of the notifications to consume.
+     * @param <T> The type of notifications to consume.
+     * @return The address to consume notifications from as returned by {@link Notification#getAddress()}.
+     */
+    protected abstract <T extends Notification> String getAddressForType(Class<T> notificationType);
+
+    /**
+     * Decodes the received notification from JSON.
+     * <p>
+     * Subclasses can leverage {@link TypeIdResolver} or {@link JsonSubTypes} to decode abstract notifications.
+     *
+     * @param json A buffer containing the notification serialized as a JSON object.
+     * @return A notification object.
+     */
+    protected abstract Notification decodeNotification(Buffer json);
+
+    // visible for testing
+    @SuppressWarnings("unchecked")
+    void handleNotification(final Notification abstractNotification) {
+        for (final var entry : handlerPerType.entrySet()) {
+            final Class<? extends Notification> type = entry.getKey();
+
+            if (type.isInstance(abstractNotification)) {
+                entry.getValue().handle(abstractNotification);
+                break;
+            }
+        }
+    }
+
+    @Override
+    public Future<Void> stop() {
+        return stopKafkaConsumer()
+                .onComplete(v -> topics.clear())
+                .onComplete(v -> handlerPerType.clear())
+                .onComplete(v -> started = false)
+                .mapEmpty();
+    }
+
+    private Future<Void> stopKafkaConsumer() {
+        if (honoKafkaConsumer != null) {
+            return honoKafkaConsumer.stop();
+        } else {
+            return Future.succeededFuture();
+        }
+    }
+
+}

--- a/clients/notification-kafka/src/test/java/org/eclipse/hono/client/notification/KafkaBasedNotificationReceiverTest.java
+++ b/clients/notification-kafka/src/test/java/org/eclipse/hono/client/notification/KafkaBasedNotificationReceiverTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.notification;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import org.eclipse.hono.client.kafka.AbstractKafkaConfigProperties;
+import org.eclipse.hono.client.kafka.HonoTopic;
+import org.eclipse.hono.kafka.test.KafkaMockConsumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Verifies behavior of {@link KafkaBasedNotificationReceiver}.
+ */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public class KafkaBasedNotificationReceiverTest {
+
+    public static final String TOPIC = new HonoTopic(HonoTopic.Type.NOTIFICATION, TestNotification.ADDRESS).toString();
+    public static final int PARTITION = 0;
+
+    private final Map<String, String> consumerConfig = new HashMap<>();
+
+    private Vertx vertx;
+    private KafkaMockConsumer mockConsumer;
+
+    /**
+     *
+     * Sets up fixture.
+     *
+     * @param vertx The vert.x instance to use.
+     */
+    @BeforeEach
+    void setUp(final Vertx vertx) {
+        this.vertx = vertx;
+
+        mockConsumer = new KafkaMockConsumer(OffsetResetStrategy.EARLIEST);
+
+        consumerConfig.put(AbstractKafkaConfigProperties.PROPERTY_BOOTSTRAP_SERVERS, "kafka");
+        consumerConfig.put("client.id", "application-test-consumer");
+
+    }
+
+    /**
+     * Verifies that the consumer is successfully created by the receiver.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testCreateConsumer(final VertxTestContext ctx) {
+
+        final var receiver = createReceiver();
+
+        receiver.registerConsumer(TestNotification.class, notification -> {
+                });
+
+        receiver.start()
+                .onComplete(ctx.succeeding(v -> ctx.verify(() -> {
+                    final Set<String> subscription = mockConsumer.subscription();
+                    assertThat(subscription).isNotNull();
+                    assertThat(subscription).contains(TOPIC);
+                    assertThat(mockConsumer.closed()).isFalse();
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the underlying Kafka consumer is closed when the receiver is stopped.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testStopClosesConsumer(final VertxTestContext ctx) {
+
+        final var receiver = createReceiver();
+
+        receiver.registerConsumer(TestNotification.class, notification -> {
+        });
+
+        receiver.start()
+                .compose(v -> receiver.stop())
+                .onComplete(ctx.succeeding(v -> ctx.verify(() -> {
+                    assertThat(mockConsumer.closed()).isTrue();
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the receiver decodes and handles a notification it receives.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testThatNotificationIsHandled(final VertxTestContext ctx) {
+
+        final var receiver = createReceiver();
+
+        receiver.registerConsumer(TestNotification.class, notification -> {
+            ctx.verify(() -> {
+                assertThat(notification).isNotNull();
+                assertThat(notification.getType()).isEqualTo(TestNotification.TYPE);
+                assertThat(notification.getAddress()).isEqualTo(TestNotification.ADDRESS);
+                assertThat(notification.getSource()).isEqualTo(TestNotification.SOURCE);
+                assertThat(notification.getTimestamp()).isEqualTo(TestNotification.TIMESTAMP);
+                ctx.completeNow();
+            });
+        });
+
+        receiver.start()
+                .onComplete(ctx.succeeding(v -> ctx.verify(() -> mockConsumer.schedulePollTask(() -> {
+                    final ConsumerRecord<String, Buffer> record = new ConsumerRecord<>(TOPIC, PARTITION, 0L, null,
+                            JsonObject.mapFrom(new TestNotification()).toBuffer());
+                    mockConsumer.addRecord(record);
+                }))));
+    }
+
+    private KafkaBasedNotificationReceiver createReceiver() {
+
+        final TopicPartition topicPartition = new TopicPartition(TOPIC, PARTITION);
+        mockConsumer.updateBeginningOffsets(Map.of(topicPartition, 0L));
+        mockConsumer.updatePartitions(topicPartition, KafkaMockConsumer.DEFAULT_NODE);
+        mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(topicPartition));
+
+        final KafkaBasedNotificationReceiver client = new TestNotificationReceiver(vertx, consumerConfig);
+        client.setKafkaConsumerFactory(() -> mockConsumer);
+
+        return client;
+    }
+
+    static class TestNotification implements Notification {
+
+        public static final String TYPE = "test-type";
+        public static final String ADDRESS = "test-topic";
+        public static final String SOURCE = "test-source";
+        public static final Instant TIMESTAMP = Instant.parse("2020-08-11T11:38:00Z");
+
+        final String source;
+        final Instant timestamp;
+
+        TestNotification() {
+            this(SOURCE, TIMESTAMP);
+        }
+
+        // used for decoding from JSON
+        TestNotification(
+                @JsonProperty(value = NotificationConstants.JSON_FIELD_SOURCE) final String source,
+                @JsonProperty(value = NotificationConstants.JSON_FIELD_TIMESTAMP) final Instant timestamp) {
+            this.source = source;
+            this.timestamp = timestamp;
+        }
+
+        @Override
+        public String getType() {
+            return TYPE;
+        }
+
+        @Override
+        public String getAddress() {
+            return ADDRESS;
+        }
+
+        @Override
+        public String getSource() {
+            return source;
+        }
+
+        @Override
+        public Instant getTimestamp() {
+            return timestamp;
+        }
+    }
+
+    static class TestNotificationReceiver extends KafkaBasedNotificationReceiver {
+
+        TestNotificationReceiver(final Vertx vertx, final Map<String, String> consumerConfig) {
+            super(vertx, consumerConfig);
+        }
+
+        @Override
+        protected <T extends Notification> String getAddressForType(final Class<T> notificationType) {
+            return TestNotification.ADDRESS;
+        }
+
+        @Override
+        protected Notification decodeNotification(final Buffer json) {
+            return Json.decodeValue(json, TestNotification.class);
+        }
+    }
+}

--- a/clients/notification-registry-kafka/pom.xml
+++ b/clients/notification-registry-kafka/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.hono</groupId>
+    <artifactId>hono-clients-parent</artifactId>
+    <version>1.11.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>hono-client-notification-registry-kafka</artifactId>
+
+  <name>Hono Registry Client (Kafka)</name>
+  <description>An Kafka based implementation of the Hono Registry Client</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-notification-registry</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-notification-kafka</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-kafka-common</artifactId>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>kafka-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/clients/notification-registry-kafka/src/main/java/org/eclipse/hono/client/notification/KafkaBasedRegistryNotificationReceiver.java
+++ b/clients/notification-registry-kafka/src/main/java/org/eclipse/hono/client/notification/KafkaBasedRegistryNotificationReceiver.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.notification;
+
+import java.util.Map;
+
+import org.eclipse.hono.notification.deviceregistry.AbstractDeviceRegistryNotification;
+import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.Json;
+
+/**
+ * A client for receiving Device Registry notifications with Kafka.
+ */
+public class KafkaBasedRegistryNotificationReceiver extends KafkaBasedNotificationReceiver {
+
+    /**
+     * Creates a client for consuming Device Registry notifications.
+     *
+     * @param vertx The vert.x instance to be used.
+     * @param consumerConfig The configuration for the Kafka consumer.
+     *
+     * @throws NullPointerException if any parameter is {@code null}.
+     * @throws IllegalArgumentException if consumerConfig does not contain a valid configuration (at least a bootstrap
+     *             server).
+     */
+    public KafkaBasedRegistryNotificationReceiver(final Vertx vertx, final Map<String, String> consumerConfig) {
+        super(vertx, consumerConfig);
+    }
+
+    @Override
+    protected <T extends Notification> String getAddressForType(final Class<T> notificationType) {
+        if (TenantChangeNotification.class.equals(notificationType)) {
+            return TenantChangeNotification.ADDRESS;
+        } else if (DeviceChangeNotification.class.equals(notificationType)) {
+            return DeviceChangeNotification.ADDRESS;
+        } else if (CredentialsChangeNotification.class.equals(notificationType)) {
+            return CredentialsChangeNotification.ADDRESS;
+        }
+        throw new IllegalArgumentException("Unknown notification type " + notificationType.getName());
+    }
+
+    @Override
+    protected AbstractDeviceRegistryNotification decodeNotification(final Buffer json) {
+        return Json.decodeValue(json, AbstractDeviceRegistryNotification.class);
+    }
+
+}

--- a/clients/notification-registry-kafka/src/test/java/org/eclipse/hono/client/notification/KafkaBasedRegistryNotificationReceiverTest.java
+++ b/clients/notification-registry-kafka/src/test/java/org/eclipse/hono/client/notification/KafkaBasedRegistryNotificationReceiverTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.notification;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import org.eclipse.hono.client.kafka.AbstractKafkaConfigProperties;
+import org.eclipse.hono.client.kafka.HonoTopic;
+import org.eclipse.hono.kafka.test.KafkaMockConsumer;
+import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.LifecycleChange;
+import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Verifies behavior of {@link KafkaBasedRegistryNotificationReceiver}.
+ */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public class KafkaBasedRegistryNotificationReceiverTest {
+
+    public static final String TOPIC = new HonoTopic(HonoTopic.Type.NOTIFICATION, TenantChangeNotification.ADDRESS)
+            .toString();
+    public static final int PARTITION = 0;
+
+    private final Map<String, String> consumerConfig = new HashMap<>();
+
+    private Vertx vertx;
+    private KafkaMockConsumer mockConsumer;
+
+    /**
+     *
+     * Sets up fixture.
+     *
+     * @param vertx The vert.x instance to use.
+     */
+    @BeforeEach
+    void setUp(final Vertx vertx) {
+        this.vertx = vertx;
+
+        mockConsumer = new KafkaMockConsumer(OffsetResetStrategy.EARLIEST);
+
+        consumerConfig.put(AbstractKafkaConfigProperties.PROPERTY_BOOTSTRAP_SERVERS, "kafka");
+        consumerConfig.put("client.id", "application-test-consumer");
+
+    }
+
+    /**
+     * Verifies that the consumer is successfully created by the receiver.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testCreateConsumer(final VertxTestContext ctx) {
+
+        final var receiver = createReceiver();
+
+        receiver.registerConsumer(TenantChangeNotification.class, notification -> {
+                });
+
+        receiver.start()
+                .onComplete(ctx.succeeding(v -> ctx.verify(() -> {
+                    final Set<String> subscription = mockConsumer.subscription();
+                    assertThat(subscription).isNotNull();
+                    assertThat(subscription).contains(TOPIC);
+                    assertThat(mockConsumer.closed()).isFalse();
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the underlying Kafka consumer is closed when the receiver is stopped.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testStopClosesConsumer(final VertxTestContext ctx) {
+
+        final var receiver = createReceiver();
+
+        receiver.registerConsumer(TenantChangeNotification.class, notification -> {
+        });
+
+        receiver.start()
+                .compose(v -> receiver.stop())
+                .onComplete(ctx.succeeding(v -> ctx.verify(() -> {
+                    assertThat(mockConsumer.closed()).isTrue();
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the receiver decodes and handles a notification it receives.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testThatNotificationIsHandled(final VertxTestContext ctx) {
+
+        final var receiver = createReceiver();
+
+        receiver.registerConsumer(TenantChangeNotification.class, notification -> ctx.verify(() -> {
+            assertThat(notification).isNotNull();
+            ctx.completeNow();
+        }));
+
+        receiver.start()
+                .onComplete(ctx.succeeding(v -> ctx.verify(() -> mockConsumer.schedulePollTask(() -> {
+                    final TenantChangeNotification tenantChangeNotification = new TenantChangeNotification(
+                            LifecycleChange.CREATE, "my-tenant", Instant.parse("2007-12-03T10:15:30Z"), false);
+                    final ConsumerRecord<String, Buffer> record = new ConsumerRecord<>(TOPIC, PARTITION, 0L, null,
+                            JsonObject.mapFrom(tenantChangeNotification).toBuffer());
+                    mockConsumer.addRecord(record);
+                }))));
+    }
+
+    /**
+     * Verifies that correct handler is invoked for a notification.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testThatCorrectHandlerIsInvoked(final VertxTestContext ctx) {
+        final DeviceChangeNotification deviceChangeNotification = new DeviceChangeNotification(LifecycleChange.CREATE,
+                "my-tenant", "my-device", Instant.parse("2007-12-03T10:15:30Z"), false);
+
+        final TenantChangeNotification tenantChangeNotification = new TenantChangeNotification(LifecycleChange.CREATE,
+                "my-tenant", Instant.parse("2007-12-03T10:15:30Z"), false);
+
+        final Checkpoint handlerInvokedCheckpoint = ctx.checkpoint(2);
+
+        final var receiver = createReceiver();
+
+        receiver.registerConsumer(TenantChangeNotification.class,
+                notification -> ctx.verify(() -> {
+                    assertThat(notification).isInstanceOf(TenantChangeNotification.class);
+                    handlerInvokedCheckpoint.flag();
+                }));
+
+        receiver.registerConsumer(DeviceChangeNotification.class,
+                notification -> ctx.verify(() -> {
+                    assertThat(notification).isInstanceOf(DeviceChangeNotification.class);
+                    handlerInvokedCheckpoint.flag();
+                }));
+
+        receiver.handleNotification(deviceChangeNotification);
+        receiver.handleNotification(tenantChangeNotification);
+
+    }
+
+    private KafkaBasedNotificationReceiver createReceiver() {
+
+        final TopicPartition topicPartition = new TopicPartition(TOPIC, PARTITION);
+        mockConsumer.updateBeginningOffsets(Map.of(topicPartition, 0L));
+        mockConsumer.updatePartitions(topicPartition, KafkaMockConsumer.DEFAULT_NODE);
+        mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(topicPartition));
+
+        final KafkaBasedNotificationReceiver client = new KafkaBasedRegistryNotificationReceiver(vertx, consumerConfig);
+        client.setKafkaConsumerFactory(() -> mockConsumer);
+
+        return client;
+    }
+
+}

--- a/clients/notification-registry/pom.xml
+++ b/clients/notification-registry/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.hono</groupId>
+    <artifactId>hono-clients-parent</artifactId>
+    <version>1.11.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>hono-client-notification-registry</artifactId>
+
+  <name>Hono Device Registry Notification Client</name>
+  <description>Clients for Hono's device registry notifications</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-notification</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/clients/notification-registry/src/main/java/org/eclipse/hono/notification/deviceregistry/AbstractDeviceRegistryNotification.java
+++ b/clients/notification-registry/src/main/java/org/eclipse/hono/notification/deviceregistry/AbstractDeviceRegistryNotification.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import org.eclipse.hono.client.notification.Notification;
+
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+
+/**
+ * Base class for the notifications of the Device Registry.
+ */
+@JsonTypeIdResolver(NotificationTypeResolver.class)
+public abstract class AbstractDeviceRegistryNotification implements Notification {
+
+    private final String source;
+    private final Instant timestamp;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param source The canonical name of the component that publishes the notification.
+     * @param timestamp The timestamp of the event (Unix epoch, UTC, in milliseconds).
+     * @throws NullPointerException If any of the parameters are {@code null}.
+     */
+    protected AbstractDeviceRegistryNotification(final String source, final Instant timestamp) {
+        this.source = Objects.requireNonNull(source);
+        this.timestamp = Objects.requireNonNull(timestamp);
+    }
+
+
+    @Override
+    public abstract String getType();
+
+    @Override
+    public String getSource() {
+        return source;
+    }
+
+    @Override
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+}

--- a/clients/notification-registry/src/main/java/org/eclipse/hono/notification/deviceregistry/CredentialsChangeNotification.java
+++ b/clients/notification-registry/src/main/java/org/eclipse/hono/notification/deviceregistry/CredentialsChangeNotification.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import org.eclipse.hono.annotation.HonoTimestamp;
+import org.eclipse.hono.client.notification.NotificationConstants;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Notification that informs about changes on credentials.
+ *
+ * The notification only informs that credentials for a device have been changed but not about details of the change.
+ * Components that consume this notification could either query the Device Registry to get more information, or assume
+ * that the used credentials have become invalid. For example a protocol adapter can simply disconnect the device to
+ * enforce re-authentication.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CredentialsChangeNotification extends AbstractDeviceRegistryNotification {
+
+    public static final String TYPE = "credentials-change-v1";
+    public static final String ADDRESS = DeviceChangeNotification.ADDRESS;
+
+    @JsonProperty(value = RegistryNotificationConstants.JSON_FIELD_TENANT_ID, required = true)
+    private final String tenantId;
+
+    @JsonProperty(value = RegistryNotificationConstants.JSON_FIELD_DEVICE_ID, required = true)
+    private final String deviceId;
+
+    @JsonCreator
+    CredentialsChangeNotification(
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_SOURCE, required = true) final String source,
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_TIMESTAMP, required = true) @HonoTimestamp final Instant timestamp,
+            @JsonProperty(value = RegistryNotificationConstants.JSON_FIELD_TENANT_ID, required = true) final String tenantId,
+            @JsonProperty(value = RegistryNotificationConstants.JSON_FIELD_DEVICE_ID, required = true) final String deviceId) {
+
+        super(source, timestamp);
+
+        this.tenantId = Objects.requireNonNull(tenantId);
+        this.deviceId = Objects.requireNonNull(deviceId);
+    }
+
+    /**
+     * Creates an instance.
+     *
+     * @param tenantId The tenant ID of the device.
+     * @param deviceId The ID of the device.
+     * @param timestamp The timestamp of the event (Unix epoch, UTC, in milliseconds).
+     * @throws NullPointerException If any of the parameters are {@code null}.
+     */
+    public CredentialsChangeNotification(final String tenantId, final String deviceId, final Instant timestamp) {
+        this(RegistryNotificationConstants.SOURCE_DEVICE_REGISTRY, timestamp, tenantId, deviceId);
+    }
+
+    /**
+     * Gets the tenant ID of the changed device.
+     *
+     * @return The tenant ID.
+     */
+    public final String getTenantId() {
+        return tenantId;
+    }
+
+    /**
+     * Gets the ID of the changed device.
+     *
+     * @return The device ID.
+     */
+    public final String getDeviceId() {
+        return deviceId;
+    }
+
+    @Override
+    public final String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public String getAddress() {
+        return ADDRESS;
+    }
+
+}

--- a/clients/notification-registry/src/main/java/org/eclipse/hono/notification/deviceregistry/DeviceChangeNotification.java
+++ b/clients/notification-registry/src/main/java/org/eclipse/hono/notification/deviceregistry/DeviceChangeNotification.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import org.eclipse.hono.annotation.HonoTimestamp;
+import org.eclipse.hono.client.notification.NotificationConstants;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Notification that informs about changes on a device.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DeviceChangeNotification extends AbstractDeviceRegistryNotification {
+
+    public static final String TYPE = "device-change-v1";
+    public static final String ADDRESS = "registry-device";
+
+    @JsonProperty(value = RegistryNotificationConstants.JSON_FIELD_DATA_CHANGE, required = true)
+    private final LifecycleChange change;
+
+    @JsonProperty(value = RegistryNotificationConstants.JSON_FIELD_TENANT_ID, required = true)
+    private final String tenantId;
+
+    @JsonProperty(value = RegistryNotificationConstants.JSON_FIELD_DEVICE_ID, required = true)
+    private final String deviceId;
+
+    @JsonProperty(value = RegistryNotificationConstants.JSON_FIELD_DATA_ENABLED, required = true)
+    private final boolean enabled;
+
+    @JsonCreator
+    DeviceChangeNotification(
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_SOURCE, required = true) final String source,
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_TIMESTAMP, required = true) @HonoTimestamp final Instant timestamp,
+            @JsonProperty(value = RegistryNotificationConstants.JSON_FIELD_DATA_CHANGE, required = true) final LifecycleChange change,
+            @JsonProperty(value = RegistryNotificationConstants.JSON_FIELD_TENANT_ID, required = true) final String tenantId,
+            @JsonProperty(value = RegistryNotificationConstants.JSON_FIELD_DEVICE_ID, required = true) final String deviceId,
+            @JsonProperty(value = RegistryNotificationConstants.JSON_FIELD_DATA_ENABLED, required = true) final boolean enabled) {
+
+        super(source, timestamp);
+
+        this.change = Objects.requireNonNull(change);
+        this.tenantId = Objects.requireNonNull(tenantId);
+        this.deviceId = Objects.requireNonNull(deviceId);
+        this.enabled = enabled;
+    }
+
+    /**
+     * Creates an instance.
+     *
+     * @param change The type of change to notify about.
+     * @param tenantId The tenant ID of the device.
+     * @param deviceId The ID of the device.
+     * @param timestamp The timestamp of the event (Unix epoch, UTC, in milliseconds).
+     * @param enabled {@code true} if the device is enabled.
+     * @throws NullPointerException If any of the parameters are {@code null}.
+     */
+    public DeviceChangeNotification(final LifecycleChange change, final String tenantId, final String deviceId,
+            final Instant timestamp, final boolean enabled) {
+        this(RegistryNotificationConstants.SOURCE_DEVICE_REGISTRY, timestamp, change, tenantId, deviceId, enabled);
+    }
+
+    /**
+     * Gets the change that caused the notification.
+     *
+     * @return The change.
+     */
+    public final LifecycleChange getChange() {
+        return change;
+    }
+
+    /**
+     * Gets the tenant ID of the changed device.
+     *
+     * @return The tenant ID.
+     */
+    public final String getTenantId() {
+        return tenantId;
+    }
+
+    /**
+     * Gets the ID of the changed device.
+     *
+     * @return The device ID.
+     */
+    public final String getDeviceId() {
+        return deviceId;
+    }
+
+    /**
+     * Checks if the device is enabled.
+     *
+     * @return {@code true} if this device is enabled.
+     */
+    public final boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public final String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public String getAddress() {
+        return ADDRESS;
+    }
+
+}

--- a/clients/notification-registry/src/main/java/org/eclipse/hono/notification/deviceregistry/LifecycleChange.java
+++ b/clients/notification-registry/src/main/java/org/eclipse/hono/notification/deviceregistry/LifecycleChange.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+/**
+ * Type of change that causes a notification to be published.
+ */
+public enum LifecycleChange {
+    CREATE,
+    UPDATE,
+    DELETE
+}

--- a/clients/notification-registry/src/main/java/org/eclipse/hono/notification/deviceregistry/NotificationTypeResolver.java
+++ b/clients/notification-registry/src/main/java/org/eclipse/hono/notification/deviceregistry/NotificationTypeResolver.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+
+/**
+ * Type resolver for notifications.
+ * <p>
+ * This type resolver knows the types {@link TenantChangeNotification}, {@link DeviceChangeNotification} and
+ * {@link CredentialsChangeNotification}.
+ */
+public final class NotificationTypeResolver extends TypeIdResolverBase {
+
+    private JavaType baseType;
+
+    @Override
+    public void init(final JavaType baseType) {
+        this.baseType = baseType;
+    }
+
+    @Override
+    public JsonTypeInfo.Id getMechanism() {
+        return JsonTypeInfo.Id.NAME;
+    }
+
+    @Override
+    public String idFromValue(final Object obj) {
+        return idFromValueAndType(obj, obj.getClass());
+    }
+
+    @Override
+    public String idFromValueAndType(final Object obj, final Class<?> subType) {
+
+        if (obj instanceof AbstractDeviceRegistryNotification) {
+            return ((AbstractDeviceRegistryNotification) obj).getType();
+        }
+        return null;
+    }
+
+    @Override
+    public JavaType typeFromId(final DatabindContext context, final String id) {
+        switch (id) {
+        case TenantChangeNotification.TYPE:
+            return context.constructSpecializedType(this.baseType, TenantChangeNotification.class);
+        case DeviceChangeNotification.TYPE:
+            return context.constructSpecializedType(this.baseType, DeviceChangeNotification.class);
+        case CredentialsChangeNotification.TYPE:
+            return context.constructSpecializedType(this.baseType, CredentialsChangeNotification.class);
+        default:
+            return null;
+        }
+    }
+}

--- a/clients/notification-registry/src/main/java/org/eclipse/hono/notification/deviceregistry/RegistryNotificationConstants.java
+++ b/clients/notification-registry/src/main/java/org/eclipse/hono/notification/deviceregistry/RegistryNotificationConstants.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+import org.eclipse.hono.util.Constants;
+
+/**
+ * Constants used for notifications of the Device Registry.
+ */
+public final class RegistryNotificationConstants {
+
+    /**
+     * The canonical name of the Device Registry to indicate the component that publishes a notification.
+     */
+    public static final String SOURCE_DEVICE_REGISTRY = "device-registry";
+
+    /**
+     * The field name of the JSON object that indicates the change.
+     */
+    public static final String JSON_FIELD_DATA_CHANGE = "change";
+    /**
+     * The field name of the JSON object that indicates if the entity is enabled.
+     */
+    public static final String JSON_FIELD_DATA_ENABLED = "enabled";
+    /**
+     * The field name of the JSON object that indicates the tenant ID.
+     */
+    public static final String JSON_FIELD_TENANT_ID = Constants.JSON_FIELD_TENANT_ID;
+    /**
+     * The field name of the JSON object that indicates the device ID.
+     */
+    public static final String JSON_FIELD_DEVICE_ID = Constants.JSON_FIELD_DEVICE_ID;
+
+    private RegistryNotificationConstants() {
+        // prevent instantiation
+    }
+
+}

--- a/clients/notification-registry/src/main/java/org/eclipse/hono/notification/deviceregistry/TenantChangeNotification.java
+++ b/clients/notification-registry/src/main/java/org/eclipse/hono/notification/deviceregistry/TenantChangeNotification.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import org.eclipse.hono.annotation.HonoTimestamp;
+import org.eclipse.hono.client.notification.NotificationConstants;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Notification that informs about changes on a tenant.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TenantChangeNotification extends AbstractDeviceRegistryNotification {
+
+    public static final String TYPE = "tenant-change-v1";
+    public static final String ADDRESS = "registry-tenant";
+
+    @JsonProperty(value = RegistryNotificationConstants.JSON_FIELD_DATA_CHANGE, required = true)
+    private final LifecycleChange change;
+
+    @JsonProperty(value = RegistryNotificationConstants.JSON_FIELD_TENANT_ID, required = true)
+    private final String tenantId;
+
+    @JsonProperty(value = RegistryNotificationConstants.JSON_FIELD_DATA_ENABLED, required = true)
+    private final boolean enabled;
+
+    @JsonCreator
+    TenantChangeNotification(
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_SOURCE, required = true) final String source,
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_TIMESTAMP, required = true) @HonoTimestamp final Instant timestamp,
+            @JsonProperty(value = RegistryNotificationConstants.JSON_FIELD_DATA_CHANGE, required = true) final LifecycleChange change,
+            @JsonProperty(value = RegistryNotificationConstants.JSON_FIELD_TENANT_ID, required = true) final String tenantId,
+            @JsonProperty(value = RegistryNotificationConstants.JSON_FIELD_DATA_ENABLED, required = true) final boolean enabled) {
+
+        super(source, timestamp);
+
+        this.change = Objects.requireNonNull(change);
+        this.tenantId = Objects.requireNonNull(tenantId);
+        this.enabled = enabled;
+    }
+
+    /**
+     * Creates an instance.
+     *
+     * @param change The type of change to notify about.
+     * @param tenantId The ID of the tenant.
+     * @param timestamp The timestamp of the event (Unix epoch, UTC, in milliseconds).
+     * @param enabled {@code true} if the device is enabled.
+     * @throws NullPointerException If any of the parameters are {@code null}.
+     */
+    public TenantChangeNotification(final LifecycleChange change, final String tenantId, final Instant timestamp,
+            final boolean enabled) {
+        this(RegistryNotificationConstants.SOURCE_DEVICE_REGISTRY, timestamp, change, tenantId, enabled);
+    }
+
+    /**
+     * Gets the change that caused the notification.
+     *
+     * @return The change.
+     */
+    public final LifecycleChange getChange() {
+        return change;
+    }
+
+    /**
+     * Gets the ID of the changed tenant.
+     *
+     * @return The tenant ID.
+     */
+    public final String getTenantId() {
+        return tenantId;
+    }
+
+    /**
+     * Checks if the tenant is enabled.
+     *
+     * @return {@code true} if this tenant is enabled.
+     */
+    public final boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public final String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public String getAddress() {
+        return ADDRESS;
+    }
+
+}

--- a/clients/notification-registry/src/test/java/org/eclipse/hono/notification/deviceregistry/AbstractDeviceRegistryNotificationTest.java
+++ b/clients/notification-registry/src/test/java/org/eclipse/hono/notification/deviceregistry/AbstractDeviceRegistryNotificationTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.time.Instant;
+
+import org.eclipse.hono.client.notification.NotificationConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Tests verifying the behavior of {@link AbstractDeviceRegistryNotification}.
+ *
+ */
+public class AbstractDeviceRegistryNotificationTest {
+
+    private static final String SOURCE = "the-component";
+    private static final String TIMESTAMP = "2007-12-03T10:15:30Z";
+    private static final String TYPE = "test-notification";
+    private static final String TOPIC = "test-topic";
+
+    private AbstractDeviceRegistryNotification notification;
+
+    /**
+     * Sets up the notification.
+     */
+    @BeforeEach
+    public void setUp() {
+        notification = new AbstractDeviceRegistryNotification(SOURCE, Instant.parse(TIMESTAMP)) {
+
+            @Override
+            public String getType() {
+                return TYPE;
+            }
+
+            @Override
+            public String getAddress() {
+                return TOPIC;
+            }
+        };
+    }
+
+    /**
+     * Verifies that the expected properties are contained in the JSON.
+     */
+    @Test
+    public void testThatValuesAreContainedInJson() {
+
+        final JsonObject json = JsonObject.mapFrom(notification);
+
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_SOURCE)).isEqualTo(SOURCE);
+        assertThat(json.getInstant(NotificationConstants.JSON_FIELD_TIMESTAMP).toString()).isEqualTo(TIMESTAMP);
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_TYPE)).isEqualTo(TYPE);
+
+    }
+
+    /**
+     * Verifies that the serialization did not change: the JSON contains the static values and only the expected keys.
+     */
+    @Test
+    public void testThatSerializationIsStable() {
+
+        final JsonObject json = JsonObject.mapFrom(notification);
+        assertThat(json).isNotNull();
+
+        // When adding new properties to the data object, make sure not to break the existing API because messages might
+        // be persisted. For breaking changes add a new object mapper class instead.
+        final int expectedPropertiesCount = 3;
+        assertWithMessage("JSON contains unknown fields").that(json.size()).isEqualTo(expectedPropertiesCount);
+
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_TYPE)).isNotNull();
+        assertThat(json.getString("source")).isNotNull();
+        assertThat(json.getInstant("timestamp")).isNotNull();
+
+    }
+
+}

--- a/clients/notification-registry/src/test/java/org/eclipse/hono/notification/deviceregistry/CredentialsChangeNotificationTest.java
+++ b/clients/notification-registry/src/test/java/org/eclipse/hono/notification/deviceregistry/CredentialsChangeNotificationTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.time.Instant;
+
+import org.eclipse.hono.client.notification.NotificationConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Tests verifying the behavior of {@link CredentialsChangeNotification}.
+ *
+ */
+public class CredentialsChangeNotificationTest {
+
+    private static final String TIMESTAMP = "2007-12-03T10:15:30Z";
+    private static final String TENANT_ID = "my-tenant";
+    private static final String DEVICE_ID = "my-device";
+
+    private AbstractDeviceRegistryNotification notification;
+
+    /**
+     * Sets up the notification.
+     */
+    @BeforeEach
+    public void setUp() {
+        notification = new CredentialsChangeNotification(TENANT_ID, DEVICE_ID, Instant.parse(TIMESTAMP));
+    }
+
+    /**
+     * Verifies that the expected properties are contained in the JSON.
+     */
+    @Test
+    public void testThatValuesAreContainedInJson() {
+
+        final JsonObject json = JsonObject.mapFrom(notification);
+
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_SOURCE))
+                .isEqualTo(RegistryNotificationConstants.SOURCE_DEVICE_REGISTRY);
+        assertThat(json.getInstant(NotificationConstants.JSON_FIELD_TIMESTAMP).toString()).isEqualTo(TIMESTAMP);
+
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_TYPE)).isEqualTo(CredentialsChangeNotification.TYPE);
+        assertThat(json.getString(RegistryNotificationConstants.JSON_FIELD_TENANT_ID)).isEqualTo(TENANT_ID);
+        assertThat(json.getString(RegistryNotificationConstants.JSON_FIELD_DEVICE_ID)).isEqualTo(DEVICE_ID);
+    }
+
+    /**
+     * Verifies that the serialization did not change: the JSON contains the static values and only the expected keys.
+     */
+    @Test
+    public void testThatSerializationIsStable() {
+
+        final JsonObject json = JsonObject.mapFrom(notification);
+        assertThat(json).isNotNull();
+
+        // When adding new properties to the data object, make sure not to break the existing API because messages might
+        // be persisted. For breaking changes add a new object mapper class instead.
+        final int expectedPropertiesCount = 5;
+        assertWithMessage("JSON contains unknown fields").that(json.size()).isEqualTo(expectedPropertiesCount);
+
+        assertThat(json.getString("type")).isEqualTo("credentials-change-v1");
+        assertThat(json.getString("source")).isEqualTo("device-registry");
+        assertThat(json.getString("timestamp")).isEqualTo(TIMESTAMP);
+
+        assertThat(json.getString("tenant-id")).isNotNull();
+        assertThat(json.getString("device-id")).isNotNull();
+
+    }
+
+    /**
+     * Verifies that a serialized notification is deserialized correctly.
+     */
+    @Test
+    public void testDeserialization() {
+
+        final AbstractDeviceRegistryNotification abstractNotification = Json
+                .decodeValue(JsonObject.mapFrom(notification).toBuffer(), AbstractDeviceRegistryNotification.class);
+
+        assertThat(abstractNotification).isNotNull();
+        assertThat(abstractNotification).isInstanceOf(CredentialsChangeNotification.class);
+        final CredentialsChangeNotification newNotification = (CredentialsChangeNotification) abstractNotification;
+
+        assertThat(newNotification.getSource()).isEqualTo(RegistryNotificationConstants.SOURCE_DEVICE_REGISTRY);
+        assertThat(newNotification.getTimestamp()).isEqualTo(Instant.parse(TIMESTAMP));
+
+        assertThat(newNotification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(newNotification.getDeviceId()).isEqualTo(DEVICE_ID);
+    }
+
+}

--- a/clients/notification-registry/src/test/java/org/eclipse/hono/notification/deviceregistry/DeviceChangeNotificationTest.java
+++ b/clients/notification-registry/src/test/java/org/eclipse/hono/notification/deviceregistry/DeviceChangeNotificationTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.time.Instant;
+
+import org.eclipse.hono.client.notification.NotificationConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Tests verifying the behavior of {@link DeviceChangeNotification}.
+ *
+ */
+public class DeviceChangeNotificationTest {
+
+    private static final String TIMESTAMP = "2007-12-03T10:15:30Z";
+    private static final String TENANT_ID = "my-tenant";
+    private static final String DEVICE_ID = "my-device";
+    private static final LifecycleChange CHANGE = LifecycleChange.CREATE;
+    private static final boolean ENABLED = false;
+
+    private AbstractDeviceRegistryNotification notification;
+
+    /**
+     * Sets up the notification.
+     */
+    @BeforeEach
+    public void setUp() {
+        notification = new DeviceChangeNotification(CHANGE, TENANT_ID, DEVICE_ID, Instant.parse(TIMESTAMP), ENABLED);
+    }
+
+    /**
+     * Verifies that the expected properties are contained in the JSON.
+     */
+    @Test
+    public void testThatValuesAreContainedInJson() {
+
+        final JsonObject json = JsonObject.mapFrom(notification);
+
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_SOURCE))
+                .isEqualTo(RegistryNotificationConstants.SOURCE_DEVICE_REGISTRY);
+        assertThat(json.getInstant(NotificationConstants.JSON_FIELD_TIMESTAMP).toString()).isEqualTo(TIMESTAMP);
+
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_TYPE)).isEqualTo(DeviceChangeNotification.TYPE);
+        assertThat(json.getString(RegistryNotificationConstants.JSON_FIELD_DATA_CHANGE)).isEqualTo(CHANGE.toString());
+        assertThat(json.getString(RegistryNotificationConstants.JSON_FIELD_TENANT_ID)).isEqualTo(TENANT_ID);
+        assertThat(json.getString(RegistryNotificationConstants.JSON_FIELD_DEVICE_ID)).isEqualTo(DEVICE_ID);
+        assertThat(json.getBoolean(RegistryNotificationConstants.JSON_FIELD_DATA_ENABLED)).isEqualTo(ENABLED);
+    }
+
+    /**
+     * Verifies that the serialization did not change: the JSON contains the static values and only the expected keys.
+     */
+    @Test
+    public void testThatSerializationIsStable() {
+
+        final JsonObject json = JsonObject.mapFrom(notification);
+        assertThat(json).isNotNull();
+
+        // When adding new properties to the data object, make sure not to break the existing API because messages might
+        // be persisted. For breaking changes add a new object mapper class instead.
+        final int expectedPropertiesCount = 7;
+        assertWithMessage("JSON contains unknown fields").that(json.size()).isEqualTo(expectedPropertiesCount);
+
+        assertThat(json.getString("type")).isEqualTo("device-change-v1");
+        assertThat(json.getString("source")).isEqualTo("device-registry");
+        assertThat(json.getString("timestamp")).isEqualTo(TIMESTAMP);
+
+        assertThat(json.getString("change")).isEqualTo("CREATE");
+        assertThat(json.getString("tenant-id")).isNotNull();
+        assertThat(json.getString("device-id")).isNotNull();
+        assertThat(json.getString("enabled")).isNotNull();
+
+    }
+
+    /**
+     * Verifies that a serialized notification is deserialized correctly.
+     */
+    @Test
+    public void testDeserialization() {
+
+        final AbstractDeviceRegistryNotification abstractNotification = Json
+                .decodeValue(JsonObject.mapFrom(notification).toBuffer(), AbstractDeviceRegistryNotification.class);
+
+        assertThat(abstractNotification).isNotNull();
+        assertThat(abstractNotification).isInstanceOf(DeviceChangeNotification.class);
+        final DeviceChangeNotification newNotification = (DeviceChangeNotification) abstractNotification;
+
+        assertThat(newNotification.getSource()).isEqualTo(RegistryNotificationConstants.SOURCE_DEVICE_REGISTRY);
+        assertThat(newNotification.getTimestamp()).isEqualTo(Instant.parse(TIMESTAMP));
+
+        assertThat(newNotification.getChange()).isEqualTo(CHANGE);
+        assertThat(newNotification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(newNotification.getDeviceId()).isEqualTo(DEVICE_ID);
+        assertThat(newNotification.isEnabled()).isEqualTo(ENABLED);
+    }
+
+}

--- a/clients/notification-registry/src/test/java/org/eclipse/hono/notification/deviceregistry/TenantChangeNotificationTest.java
+++ b/clients/notification-registry/src/test/java/org/eclipse/hono/notification/deviceregistry/TenantChangeNotificationTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.time.Instant;
+
+import org.eclipse.hono.client.notification.NotificationConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Tests verifying the behavior of {@link TenantChangeNotification}.
+ *
+ */
+public class TenantChangeNotificationTest {
+
+    private static final String TIMESTAMP = "2007-12-03T10:15:30Z";
+    private static final String TENANT_ID = "my-tenant";
+    private static final boolean ENABLED = false;
+    private static final LifecycleChange CHANGE = LifecycleChange.CREATE;
+
+    private AbstractDeviceRegistryNotification notification;
+
+    /**
+     * Sets up the notification.
+     */
+    @BeforeEach
+    public void setUp() {
+        notification = new TenantChangeNotification(CHANGE, TENANT_ID, Instant.parse(TIMESTAMP), ENABLED);
+    }
+
+    /**
+     * Verifies that the expected properties are contained in the JSON.
+     */
+    @Test
+    public void testThatValuesAreContainedInJson() {
+
+        final JsonObject json = JsonObject.mapFrom(notification);
+
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_SOURCE))
+                .isEqualTo(RegistryNotificationConstants.SOURCE_DEVICE_REGISTRY);
+        assertThat(json.getInstant(NotificationConstants.JSON_FIELD_TIMESTAMP).toString()).isEqualTo(TIMESTAMP);
+
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_TYPE)).isEqualTo(TenantChangeNotification.TYPE);
+        assertThat(json.getString(RegistryNotificationConstants.JSON_FIELD_TENANT_ID)).isEqualTo(TENANT_ID);
+        assertThat(json.getBoolean(RegistryNotificationConstants.JSON_FIELD_DATA_ENABLED)).isEqualTo(ENABLED);
+        assertThat(json.getString(RegistryNotificationConstants.JSON_FIELD_DATA_CHANGE)).isEqualTo(CHANGE.toString());
+    }
+
+    /**
+     * Verifies that the serialization did not change: the JSON contains the static values and only the expected keys.
+     */
+    @Test
+    public void testThatSerializationIsStable() {
+
+        final JsonObject json = JsonObject.mapFrom(notification);
+        assertThat(json).isNotNull();
+
+        // When adding new properties to the data object, make sure not to break the existing API because messages might
+        // be persisted. For breaking changes add a new object mapper class instead.
+        final int expectedPropertiesCount = 6;
+        assertWithMessage("JSON contains unknown fields").that(json.size()).isEqualTo(expectedPropertiesCount);
+
+        assertThat(json.getString("type")).isEqualTo("tenant-change-v1");
+        assertThat(json.getString("source")).isEqualTo("device-registry");
+        assertThat(json.getString("timestamp")).isEqualTo(TIMESTAMP);
+
+        assertThat(json.getString("change")).isEqualTo("CREATE");
+        assertThat(json.getString("tenant-id")).isNotNull();
+        assertThat(json.getString("enabled")).isNotNull();
+
+    }
+
+    /**
+     * Verifies that a serialized notification is deserialized correctly.
+     */
+    @Test
+    public void testDeserialization() {
+
+        final AbstractDeviceRegistryNotification abstractNotification = Json
+                .decodeValue(JsonObject.mapFrom(notification).toBuffer(), AbstractDeviceRegistryNotification.class);
+
+        assertThat(abstractNotification).isNotNull();
+        assertThat(abstractNotification).isInstanceOf(TenantChangeNotification.class);
+        final TenantChangeNotification newNotification = (TenantChangeNotification) abstractNotification;
+
+        assertThat(newNotification.getSource()).isEqualTo(RegistryNotificationConstants.SOURCE_DEVICE_REGISTRY);
+        assertThat(newNotification.getTimestamp()).isEqualTo(Instant.parse(TIMESTAMP));
+
+        assertThat(newNotification.getChange()).isEqualTo(CHANGE);
+        assertThat(newNotification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(newNotification.isEnabled()).isEqualTo(ENABLED);
+    }
+
+}

--- a/clients/notification/pom.xml
+++ b/clients/notification/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.hono</groupId>
+    <artifactId>hono-clients-parent</artifactId>
+    <version>1.11.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>hono-client-notification</artifactId>
+
+  <name>Hono Notification API Client</name>
+  <description>Clients for Hono's internal notifications</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.vertx</groupId>
+          <artifactId>vertx-proton</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.opentracing</groupId>
+          <artifactId>opentracing-noop</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-handler</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-handler-proxy</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-resolver</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-resolver-dns</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http2</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+
+</project>

--- a/clients/notification/src/main/java/org/eclipse/hono/client/notification/Notification.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/client/notification/Notification.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.notification;
+
+import java.time.Instant;
+
+import org.eclipse.hono.annotation.HonoTimestamp;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * A Hono internal notification that is published by one component to inform other components about events.
+ *
+ * Notifications are always sent as JSON.
+ *
+ * Implementing classes need to declare a {@code com.fasterxml.jackson.databind.jsontype.TypeIdResolver} for automatic
+ * handling of the type by Jackson.
+ */
+@JsonInclude(value = JsonInclude.Include.NON_NULL)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = NotificationConstants.JSON_FIELD_TYPE, visible = true)
+public interface Notification {
+
+    /**
+     * Gets the type of the notification.
+     *
+     * @return The type name.
+     */
+    @JsonIgnore
+    String getType();
+
+    /**
+     * Gets the address to be used for messaging.
+     *
+     * @return The address.
+     */
+    @JsonIgnore
+    String getAddress();
+
+    /**
+     * Gets the canonical name of the component that publishes the notification.
+     *
+     * @return The name of the component.
+     */
+    @JsonGetter(NotificationConstants.JSON_FIELD_SOURCE)
+    String getSource();
+
+    /**
+     * Gets the timestamp of the notification.
+     *
+     * @return The point in time.
+     */
+    @JsonGetter(NotificationConstants.JSON_FIELD_TIMESTAMP)
+    @HonoTimestamp
+    Instant getTimestamp();
+
+}

--- a/clients/notification/src/main/java/org/eclipse/hono/client/notification/NotificationConstants.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/client/notification/NotificationConstants.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.notification;
+
+/**
+ * Constants used by the notification API.
+ */
+public final class NotificationConstants {
+
+    public static final String CONTENT_TYPE = "application/json";
+    public static final String JSON_FIELD_TYPE = "type";
+    public static final String JSON_FIELD_SOURCE = "source";
+    public static final String JSON_FIELD_TIMESTAMP = "timestamp";
+
+    private NotificationConstants() {
+        // prevent instantiation
+    }
+
+}

--- a/clients/notification/src/main/java/org/eclipse/hono/client/notification/NotificationReceiver.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/client/notification/NotificationReceiver.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.notification;
+
+import org.eclipse.hono.util.Lifecycle;
+
+import io.vertx.core.Handler;
+
+/**
+ * A client that supports receiving Hono's (internal) notifications.
+ *
+ */
+public interface NotificationReceiver extends Lifecycle {
+
+    /**
+     * Registers a notification consumer for a specific type of notifications.
+     *
+     * @param notificationType The class of the notifications to consume.
+     * @param consumer The handler to be invoked with the received notification.
+     * @param <T> The type of notifications to consume.
+     */
+    <T extends Notification> void registerConsumer(Class<T> notificationType, Handler<T> consumer);
+}

--- a/clients/notification/src/main/java/org/eclipse/hono/client/notification/NotificationSender.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/client/notification/NotificationSender.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.notification;
+
+import org.eclipse.hono.util.Lifecycle;
+import org.eclipse.hono.util.MessagingClient;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+
+/**
+ * A client for publishing Hono internal notifications.
+ *
+ */
+public interface NotificationSender extends MessagingClient, Lifecycle {
+
+    /**
+     * Publish a notification that inform consuming components about an event in the publishing component.
+     *
+     * @param notification The notification to be published.
+     * @param context The currently active OpenTracing span (may be {@code null}). An implementation should use this as
+     *            the parent for any span it creates for tracing the execution of this operation.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if the notification has been published.
+     *         <p>
+     *         The future will be failed with a {@code org.eclipse.hono.client.ServerErrorException} if the data could
+     *         not be sent. The error code contained in the exception indicates the cause of the failure.
+     * @throws NullPointerException if notification is {@code null}.
+     */
+    Future<Void> publish(Notification notification, SpanContext context);
+}

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -38,7 +38,9 @@
     <module>command-kafka</module>
     <module>kafka-common</module>
     <module>notification</module>
+    <module>notification-kafka</module>
     <module>notification-registry</module>
+    <module>notification-registry-kafka</module>
     <module>registry</module>
     <module>registry-amqp</module>
     <module>telemetry</module>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -37,6 +37,7 @@
     <module>command-amqp</module>
     <module>command-kafka</module>
     <module>kafka-common</module>
+    <module>notification</module>
     <module>registry</module>
     <module>registry-amqp</module>
     <module>telemetry</module>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -38,6 +38,7 @@
     <module>command-kafka</module>
     <module>kafka-common</module>
     <module>notification</module>
+    <module>notification-registry</module>
     <module>registry</module>
     <module>registry-amqp</module>
     <module>telemetry</module>

--- a/services/device-registry-base/pom.xml
+++ b/services/device-registry-base/pom.xml
@@ -37,11 +37,11 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>
-      <artifactId>hono-client-notification</artifactId>
+      <artifactId>hono-client-notification-registry</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>
-      <artifactId>hono-client-notification-registry</artifactId>
+      <artifactId>hono-client-notification-registry-kafka</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>

--- a/services/device-registry-base/pom.xml
+++ b/services/device-registry-base/pom.xml
@@ -36,6 +36,14 @@
       <artifactId>hono-service-base</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-notification</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-notification-registry</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-crypto</artifactId>
     </dependency>

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/notification/KafkaBasedRegistryNotificationSender.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/notification/KafkaBasedRegistryNotificationSender.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.deviceregistry.notification;
+
+import org.eclipse.hono.client.kafka.HonoTopic;
+import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.notification.AbstractKafkaBasedNotificationSender;
+import org.eclipse.hono.client.notification.Notification;
+import org.eclipse.hono.notification.deviceregistry.AbstractDeviceRegistryNotification;
+import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A client for publishing notifications from Hono's device registry with Kafka.
+ */
+public class KafkaBasedRegistryNotificationSender extends AbstractKafkaBasedNotificationSender {
+
+    /**
+     * Creates an instance.
+     *
+     * @param producerFactory The factory to use for creating Kafka producers.
+     * @param kafkaProducerConfig The Kafka producer configuration properties to use.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public KafkaBasedRegistryNotificationSender(final KafkaProducerFactory<String, JsonObject> producerFactory,
+            final KafkaProducerConfigProperties kafkaProducerConfig) {
+        super(producerFactory, kafkaProducerConfig);
+    }
+
+    @Override
+    protected String getKey(final Notification notification) {
+        if (notification instanceof TenantChangeNotification) {
+            return ((TenantChangeNotification) notification).getTenantId();
+        } else if (notification instanceof DeviceChangeNotification) {
+            return ((DeviceChangeNotification) notification).getDeviceId();
+        } else if (notification instanceof CredentialsChangeNotification) {
+            return ((CredentialsChangeNotification) notification).getDeviceId();
+        } else {
+            throw new IllegalArgumentException("unknown notification type");
+        }
+    }
+
+    @Override
+    protected String getTopic(final Notification notification) {
+
+        if (notification instanceof AbstractDeviceRegistryNotification) {
+            final AbstractDeviceRegistryNotification registryNotification = (AbstractDeviceRegistryNotification) notification;
+            return new HonoTopic(HonoTopic.Type.NOTIFICATION, registryNotification.getAddress()).toString();
+        } else {
+            throw new IllegalArgumentException("unknown notification type");
+        }
+    }
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/notification/NotificationFactory.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/notification/NotificationFactory.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.deviceregistry.notification;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Objects;
+
+import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.LifecycleChange;
+import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
+
+/**
+ * A factory that creates notifications that inform about events happening in the Device Registry.
+ *
+ * The factory adds the point in time when the notification is created as the timestamp. The notification should be
+ * created as soon as possible/reasonable after the event happened.
+ */
+public class NotificationFactory {
+
+    private final Clock clock;
+
+    /**
+     * Creates an instance.
+     *
+     * Notifications created by this instance will use the system clock to create timestamps.
+     */
+    public NotificationFactory() {
+        clock = Clock.systemUTC();
+    }
+
+    // visible for testing
+    NotificationFactory(final Clock clock) {
+        this.clock = clock;
+    }
+
+    /**
+     * Creates a notification to inform about the creation of a tenant.
+     *
+     * @param tenantId The ID of the created tenant.
+     * @param enabled {@code true} if the tenant is enabled.
+     * @return The notification with the current timestamp.
+     * @throws NullPointerException If tenantId is {@code null}.
+     */
+    public TenantChangeNotification tenantCreated(final String tenantId, final boolean enabled) {
+        Objects.requireNonNull(tenantId);
+
+        return new TenantChangeNotification(LifecycleChange.CREATE, tenantId, Instant.now(clock), enabled);
+    }
+
+    /**
+     * Creates a notification to inform about the update of a tenant.
+     *
+     * @param tenantId The ID of the changed tenant.
+     * @param enabled {@code true} if the tenant is enabled.
+     * @return The notification with the current timestamp.
+     * @throws NullPointerException If tenantId is {@code null}.
+     */
+    public TenantChangeNotification tenantChanged(final String tenantId, final boolean enabled) {
+        Objects.requireNonNull(tenantId);
+
+        return new TenantChangeNotification(LifecycleChange.UPDATE, tenantId, Instant.now(clock), enabled);
+    }
+
+    /**
+     * Creates a notification to inform about the deletion of a tenant.
+     *
+     * @param tenantId The ID of the deleted tenant.
+     * @return The notification with the current timestamp.
+     * @throws NullPointerException If tenantId is {@code null}.
+     */
+    public TenantChangeNotification tenantDeleted(final String tenantId) {
+        Objects.requireNonNull(tenantId);
+
+        return new TenantChangeNotification(LifecycleChange.DELETE, tenantId, Instant.now(clock), false);
+    }
+
+    /**
+     * Creates a notification to inform about the creation of a device.
+     *
+     * @param tenantId The tenant ID of the created device.
+     * @param deviceId The ID of the created device.
+     * @param enabled {@code true} if the device is enabled.
+     * @return The notification with the current timestamp.
+     * @throws NullPointerException If tenantId or deviceId are {@code null}.
+     */
+    public DeviceChangeNotification deviceCreated(final String tenantId, final String deviceId,
+            final boolean enabled) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+
+        return new DeviceChangeNotification(LifecycleChange.CREATE, tenantId, deviceId, Instant.now(clock), enabled);
+    }
+
+    /**
+     * Creates a notification to inform about the update of a device.
+     *
+     * @param tenantId The tenant ID of the changed device.
+     * @param deviceId The ID of the changed device.
+     * @param enabled {@code true} if the device is enabled.
+     * @return The notification with the current timestamp.
+     * @throws NullPointerException If tenantId or deviceId are {@code null}.
+     */
+    public DeviceChangeNotification deviceChanged(final String tenantId, final String deviceId,
+            final boolean enabled) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+
+        return new DeviceChangeNotification(LifecycleChange.UPDATE, tenantId, deviceId, Instant.now(clock), enabled);
+    }
+
+    /**
+     * Creates a notification to inform about the deletion of a device.
+     *
+     * @param tenantId The tenant ID of the deleted device.
+     * @param deviceId The ID of the deleted device.
+     * @return The notification with the current timestamp.
+     * @throws NullPointerException If tenantId or deviceId are {@code null}.
+     */
+    public DeviceChangeNotification deviceDeleted(final String tenantId, final String deviceId) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+
+        return new DeviceChangeNotification(LifecycleChange.DELETE, tenantId, deviceId, Instant.now(clock), false);
+    }
+
+    /**
+     * Creates a notification to inform about the update of credentials.
+     *
+     * @param tenantId The tenant ID of the changed credentials.
+     * @param deviceId The device ID of the changed credentials.
+     * @return The notification with the current timestamp.
+     * @throws NullPointerException If tenantId or deviceId are {@code null}.
+     */
+    public CredentialsChangeNotification credentialsChanged(final String tenantId, final String deviceId) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+
+        return new CredentialsChangeNotification(tenantId, deviceId, Instant.now(clock));
+    }
+
+}

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/notification/NotificationFactoryTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/notification/NotificationFactoryTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.deviceregistry.notification;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.LifecycleChange;
+import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the behavior of {@link NotificationFactory}.
+ */
+public class NotificationFactoryTest {
+
+    private static final String TENANT_ID = "my-tenant";
+    private static final String DEVICE_ID = "my-device";
+    private static final Instant TIMESTAMP = Instant.parse("2007-12-03T10:15:30Z");
+    private static final boolean ENABLED = false;
+
+    private static Clock clock;
+
+    /**
+     * Sets up a fixed clock.
+     */
+    @BeforeAll
+    public static void setUp() {
+        clock = Clock.fixed(TIMESTAMP, ZoneId.of("UTC"));
+    }
+
+    /**
+     * Verifies that the expected notification is created by {@link NotificationFactory#tenantCreated(String, boolean)}.
+     */
+    @Test
+    public void testTenantCreated() {
+        final TenantChangeNotification notification = new NotificationFactory(clock).tenantCreated(TENANT_ID,
+                ENABLED);
+
+        assertThat(notification.getChange()).isEqualTo(LifecycleChange.CREATE);
+        assertThat(notification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(notification.getTimestamp()).isEqualTo(TIMESTAMP);
+        assertThat(notification.isEnabled()).isEqualTo(ENABLED);
+    }
+
+    /**
+     * Verifies that the expected notification is created by {@link NotificationFactory#tenantChanged(String, boolean)}.
+     */
+    @Test
+    public void testTenantChanged() {
+        final TenantChangeNotification notification = new NotificationFactory(clock).tenantChanged(TENANT_ID,
+                ENABLED);
+
+        assertThat(notification.getChange()).isEqualTo(LifecycleChange.UPDATE);
+        assertThat(notification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(notification.getTimestamp()).isEqualTo(TIMESTAMP);
+        assertThat(notification.isEnabled()).isEqualTo(ENABLED);
+    }
+
+    /**
+     * Verifies that the expected notification is created by {@link NotificationFactory#tenantDeleted(String)}.
+     */
+    @Test
+    public void testTenantDeleted() {
+        final TenantChangeNotification notification = new NotificationFactory(clock).tenantDeleted(TENANT_ID);
+
+        assertThat(notification.getChange()).isEqualTo(LifecycleChange.DELETE);
+        assertThat(notification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(notification.getTimestamp()).isEqualTo(TIMESTAMP);
+    }
+
+    /**
+     * Verifies that the expected notification is created by
+     * {@link NotificationFactory#deviceCreated(String, String, boolean)}.
+     */
+    @Test
+    public void testDeviceCreated() {
+        final DeviceChangeNotification notification = new NotificationFactory(clock).deviceCreated(TENANT_ID, DEVICE_ID,
+                ENABLED);
+
+        assertThat(notification.getChange()).isEqualTo(LifecycleChange.CREATE);
+        assertThat(notification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(notification.getDeviceId()).isEqualTo(DEVICE_ID);
+        assertThat(notification.getTimestamp()).isEqualTo(TIMESTAMP);
+        assertThat(notification.isEnabled()).isEqualTo(ENABLED);
+    }
+
+    /**
+     * Verifies that the expected notification is created by
+     * {@link NotificationFactory#deviceChanged(String, String, boolean)}.
+     */
+    @Test
+    public void testDeviceChanged() {
+        final DeviceChangeNotification notification = new NotificationFactory(clock).deviceChanged(TENANT_ID, DEVICE_ID,
+                ENABLED);
+
+        assertThat(notification.getChange()).isEqualTo(LifecycleChange.UPDATE);
+        assertThat(notification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(notification.getDeviceId()).isEqualTo(DEVICE_ID);
+        assertThat(notification.getTimestamp()).isEqualTo(TIMESTAMP);
+        assertThat(notification.isEnabled()).isEqualTo(ENABLED);
+    }
+
+    /**
+     * Verifies that the expected notification is created by {@link NotificationFactory#deviceDeleted(String, String)}.
+     */
+    @Test
+    public void testDeviceDeleted() {
+        final DeviceChangeNotification notification = new NotificationFactory(clock).deviceDeleted(TENANT_ID,
+                DEVICE_ID);
+
+        assertThat(notification.getChange()).isEqualTo(LifecycleChange.DELETE);
+        assertThat(notification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(notification.getDeviceId()).isEqualTo(DEVICE_ID);
+        assertThat(notification.getTimestamp()).isEqualTo(TIMESTAMP);
+    }
+
+    /**
+     * Verifies that the expected notification is created by
+     * {@link NotificationFactory#credentialsChanged(String, String)}.
+     */
+    @Test
+    public void testCredentialsChanged() {
+        final CredentialsChangeNotification notification = new NotificationFactory(clock).credentialsChanged(TENANT_ID,
+                DEVICE_ID);
+
+        assertThat(notification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(notification.getDeviceId()).isEqualTo(DEVICE_ID);
+        assertThat(notification.getTimestamp()).isEqualTo(TIMESTAMP);
+    }
+
+}

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -993,7 +993,7 @@ public final class IntegrationTestSupport {
             final Promise<Void> adminClientClosedPromise = Promise.promise();
             LOGGER.debug("deleting topics for temporary tenants {}", tenantsToDeleteTopicsForNow);
             final List<String> topicNames = tenantsToDeleteTopicsForNow.stream()
-                    .flatMap(tenant -> HonoTopic.Type.TENANT_RELATED_TYPES.stream()
+                    .flatMap(tenant -> HonoTopic.Type.MESSAGING_API_TYPES.stream()
                             .map(type -> new HonoTopic(type, tenant).toString()))
                     .collect(Collectors.toList());
             adminClient.deleteTopics(topicNames, ar -> {


### PR DESCRIPTION
This comes from the discussion in #2905. It contains: 
- a generic Notification API
- a concrete Notification API for the Device Registry
- abstract client implementations of the Notification API for Kafka 
- a concrete client implementation of the Device Registry Notification API for Kafka

The would put the AMQP based notification receiver for Device Registry notifications in the existing module _hono-client-registry-amqp_.

This is an alternative to #2918.