### PR TITLE
[#2837] Add Device Registry specific Notification API

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -250,6 +250,11 @@
         <artifactId>hono-client-notification</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-client-notification-kafka</artifactId>
+        <version>${project.version}</version>
+      </dependency>
 
       <!-- Californium -->
       <dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -245,6 +245,11 @@
         <artifactId>hono-client-application-kafka</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-client-notification</artifactId>
+        <version>${project.version}</version>
+      </dependency>
 
       <!-- Californium -->
       <dependency>

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/HonoTopic.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/HonoTopic.java
@@ -33,8 +33,8 @@ public final class HonoTopic {
      * Creates a new topic from the given topic type and tenant ID.
      *
      * @param type The type of the topic.
-     * @param suffix The suffix after the type specific topic part. For types other than {@link Type#COMMAND_INTERNAL}
-     *              this is the internal ID of the tenant that the topic belongs to.
+     * @param suffix The suffix after the type specific topic part. For messaging API types this is the internal ID of
+     *            the tenant that the topic belongs to.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     public HonoTopic(final Type type, final String suffix) {
@@ -67,6 +67,8 @@ public final class HonoTopic {
             type = Type.COMMAND_RESPONSE;
         } else if (topicString.startsWith(Type.COMMAND_INTERNAL.prefix)) {
             type = Type.COMMAND_INTERNAL;
+        } else if (topicString.startsWith(Type.NOTIFICATION.prefix)) {
+            type = Type.NOTIFICATION;
         }
         if (type != null) {
             final String suffix = topicString.substring(type.prefix.length());
@@ -79,17 +81,16 @@ public final class HonoTopic {
     /**
      * Gets the tenantId from the topic.
      *
-     * @return The tenantId or {@code null} in case of a {@link Type#COMMAND_INTERNAL} topic.
+     * @return The tenantId for a messaging API type or {@code null} in case of an internal topic.
      */
     public String getTenantId() {
-        return type == Type.COMMAND_INTERNAL ? null : suffix;
+        return Type.MESSAGING_API_TYPES.contains(type) ? suffix : null;
     }
 
     /**
      * Gets the suffix after the type specific topic part.
      * <p>
-     * For types other than {@link Type#COMMAND_INTERNAL} this is the internal ID
-     * of the tenant that the topic belongs to.
+     * For messaging API types this is the internal ID of the tenant that the topic belongs to.
      *
      * @return The suffix.
      */
@@ -142,13 +143,14 @@ public final class HonoTopic {
         EVENT(EventConstants.EVENT_ENDPOINT),
         COMMAND(CommandConstants.COMMAND_ENDPOINT),
         COMMAND_RESPONSE(CommandConstants.COMMAND_RESPONSE_ENDPOINT),
-        COMMAND_INTERNAL(CommandConstants.INTERNAL_COMMAND_ENDPOINT);
+        COMMAND_INTERNAL(CommandConstants.INTERNAL_COMMAND_ENDPOINT),
+        NOTIFICATION("notification");
 
         /**
          * A list of the types of topics that include a tenant identifier.
          */
-        public static final List<Type> TENANT_RELATED_TYPES = List.of(TELEMETRY, EVENT, COMMAND, COMMAND_RESPONSE);
-        private static final String SEPARATOR = ".";
+        public static final List<Type> MESSAGING_API_TYPES = List.of(TELEMETRY, EVENT, COMMAND, COMMAND_RESPONSE);
+        public static final String SEPARATOR = ".";
         private static final String NAMESPACE = "hono";
 
         /**

--- a/clients/notification-kafka/pom.xml
+++ b/clients/notification-kafka/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.hono</groupId>
+    <artifactId>hono-clients-parent</artifactId>
+    <version>1.11.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>hono-client-notification-kafka</artifactId>
+
+  <name>Hono Notification Client (Kafka)</name>
+  <description>Clients for sending and receiving Hono's notifications with Kafka</description>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-notification</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-kafka-common</artifactId>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>kafka-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/KafkaBasedNotificationReceiver.java
+++ b/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/KafkaBasedNotificationReceiver.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.notification;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.eclipse.hono.client.kafka.AbstractKafkaConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.HonoKafkaConsumer;
+import org.eclipse.hono.notification.AbstractNotification;
+import org.eclipse.hono.notification.NotificationReceiver;
+import org.eclipse.hono.util.Strings;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.Json;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+
+/**
+ * A client for receiving notifications with Kafka.
+ */
+public class KafkaBasedNotificationReceiver implements NotificationReceiver {
+
+    private final Vertx vertx;
+    private final Map<String, String> consumerConfig = new HashMap<>();
+    private final Map<Class<? extends AbstractNotification>, Handler<? extends AbstractNotification>> handlerPerType = new HashMap<>();
+    private final Set<String> topics = new HashSet<>();
+
+    private Supplier<Consumer<String, Buffer>> kafkaConsumerSupplier;
+    private HonoKafkaConsumer honoKafkaConsumer;
+    private boolean started = false;
+
+    /**
+     * Creates a client for consuming notifications.
+     *
+     * @param vertx The vert.x instance to be used.
+     * @param consumerConfig The configuration for the Kafka consumer.
+     *
+     * @throws NullPointerException if any parameter is {@code null}.
+     * @throws IllegalArgumentException if consumerConfig does not contain a valid configuration (at least a bootstrap
+     *             server).
+     */
+    public KafkaBasedNotificationReceiver(final Vertx vertx, final Map<String, String> consumerConfig) {
+
+        Objects.requireNonNull(vertx);
+        Objects.requireNonNull(consumerConfig);
+
+        if (Strings.isNullOrEmpty(consumerConfig.get(AbstractKafkaConfigProperties.PROPERTY_BOOTSTRAP_SERVERS))) {
+            throw new IllegalArgumentException("No Kafka configuration found!");
+        }
+
+        this.vertx = vertx;
+        this.consumerConfig.putAll(consumerConfig);
+    }
+
+    // visible for testing
+    void setKafkaConsumerFactory(final Supplier<Consumer<String, Buffer>> kafkaConsumerSupplier) {
+        this.kafkaConsumerSupplier = Objects.requireNonNull(kafkaConsumerSupplier);
+    }
+
+    @Override
+    public Future<Void> start() {
+        honoKafkaConsumer = new HonoKafkaConsumer(vertx, topics, getRecordHandler(), consumerConfig);
+        Optional.ofNullable(kafkaConsumerSupplier).ifPresent(honoKafkaConsumer::setKafkaConsumerSupplier);
+        return honoKafkaConsumer
+                .start()
+                .onSuccess(ok -> started = true);
+    }
+
+    @Override
+    public <T extends AbstractNotification> void registerConsumer(final Class<T> notificationType,
+            final Handler<T> consumer) {
+
+        if (started) {
+            throw new IllegalStateException("consumers cannot be added when consumer is already started.");
+        }
+
+        topics.add(NotificationTopicHelper.getTopicName(notificationType));
+        handlerPerType.put(notificationType, consumer);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private Handler<KafkaConsumerRecord<String, Buffer>> getRecordHandler() {
+        return record -> {
+            final AbstractNotification notification = Json.decodeValue(record.value(), AbstractNotification.class);
+            final Handler handler = handlerPerType.get(notification.getClass());
+            if (handler != null) {
+                handler.handle(notification);
+            }
+        };
+    }
+
+    @Override
+    public Future<Void> stop() {
+        return stopKafkaConsumer()
+                .onComplete(v -> topics.clear())
+                .onComplete(v -> handlerPerType.clear())
+                .onComplete(v -> started = false)
+                .mapEmpty();
+    }
+
+    private Future<Void> stopKafkaConsumer() {
+        if (honoKafkaConsumer != null) {
+            return honoKafkaConsumer.stop();
+        } else {
+            return Future.succeededFuture();
+        }
+    }
+
+}

--- a/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/KafkaBasedNotificationSender.java
+++ b/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/KafkaBasedNotificationSender.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.notification;
+
+import java.net.HttpURLConnection;
+import java.util.Objects;
+
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.notification.AbstractNotification;
+import org.eclipse.hono.notification.NotificationSender;
+import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import io.vertx.kafka.client.producer.RecordMetadata;
+
+/**
+ * A client for publishing notifications with Kafka.
+ */
+public class KafkaBasedNotificationSender implements NotificationSender {
+
+    public static final String PRODUCER_NAME = "notification";
+    private final KafkaProducerConfigProperties config;
+    private final KafkaProducerFactory<String, JsonObject> producerFactory;
+    private boolean stopped = false;
+
+    /**
+     * Creates an instance.
+     *
+     * @param producerFactory The factory to use for creating Kafka producers.
+     * @param kafkaProducerConfig The Kafka producer configuration properties to use.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public KafkaBasedNotificationSender(final KafkaProducerFactory<String, JsonObject> producerFactory,
+            final KafkaProducerConfigProperties kafkaProducerConfig) {
+        Objects.requireNonNull(producerFactory);
+        Objects.requireNonNull(kafkaProducerConfig);
+
+        this.producerFactory = producerFactory;
+        this.config = kafkaProducerConfig;
+    }
+
+    @Override
+    public Future<Void> publish(final AbstractNotification notification) {
+
+        Objects.requireNonNull(notification);
+
+        if (stopped) {
+            return Future.failedFuture(
+                    new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "sender already stopped"));
+        }
+
+        try {
+
+            final String topic = NotificationTopicHelper.getTopicName(notification.getClass());
+            final String key = getKey(notification);
+            final JsonObject value = JsonObject.mapFrom(notification);
+            final KafkaProducerRecord<String, JsonObject> record = KafkaProducerRecord.create(topic, key, value);
+
+            final Promise<RecordMetadata> sendPromise = Promise.promise();
+            producerFactory.getOrCreateProducer(PRODUCER_NAME, config).send(record, sendPromise);
+
+            return sendPromise.future()
+                    .recover(t -> Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, t)))
+                    .mapEmpty();
+        } catch (RuntimeException ex) {
+            return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, ex));
+        }
+    }
+
+    private String getKey(final AbstractNotification notification) {
+        if (notification instanceof TenantChangeNotification) {
+            return ((TenantChangeNotification) notification).getTenantId();
+        } else if (notification instanceof DeviceChangeNotification) {
+            return ((DeviceChangeNotification) notification).getDeviceId();
+        } else if (notification instanceof CredentialsChangeNotification) {
+            return ((CredentialsChangeNotification) notification).getDeviceId();
+        } else {
+            throw new IllegalArgumentException("unknown notification type");
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Starts the producer.
+     */
+    @Override
+    public Future<Void> start() {
+        stopped = false;
+        producerFactory.getOrCreateProducer(PRODUCER_NAME, config);
+        return Future.succeededFuture();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Closes the producer.
+     */
+    @Override
+    public Future<Void> stop() {
+        stopped = true;
+        return producerFactory.closeProducer(PRODUCER_NAME);
+    }
+
+}

--- a/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/NotificationTopicHelper.java
+++ b/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/NotificationTopicHelper.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.notification;
+
+import org.eclipse.hono.client.kafka.HonoTopic;
+import org.eclipse.hono.notification.AbstractNotification;
+import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
+
+/**
+ * Utility methods to determine the Kafka topic for a given type of notifications.
+ */
+public final class NotificationTopicHelper {
+
+    private NotificationTopicHelper() {
+        // prevent instantiation
+    }
+
+    /**
+     * Gets the topic name to consume notifications from.
+     *
+     * @param notificationType The class of the notifications to consume.
+     * @param <T> The type of notifications to consume.
+     * @return The topic name.
+     * @throws IllegalArgumentException If the given type is not a known subclass of {@link AbstractNotification}.
+     */
+    public static <T extends AbstractNotification> String getTopicName(final Class<T> notificationType) {
+        final String address;
+        if (TenantChangeNotification.class.equals(notificationType)) {
+            address = TenantChangeNotification.ADDRESS;
+        } else if (DeviceChangeNotification.class.equals(notificationType)) {
+            address = DeviceChangeNotification.ADDRESS;
+        } else if (CredentialsChangeNotification.class.equals(notificationType)) {
+            address = CredentialsChangeNotification.ADDRESS;
+        } else {
+            throw new IllegalArgumentException("Unknown notification type " + notificationType.getName());
+        }
+
+        return getTopicNameForAddress(address);
+    }
+
+    private static String getTopicNameForAddress(final String address) {
+        return new HonoTopic(HonoTopic.Type.NOTIFICATION, address).toString();
+    }
+}

--- a/clients/notification-kafka/src/test/java/org/eclipse/hono/client/notification/KafkaBasedNotificationSenderTest.java
+++ b/clients/notification-kafka/src/test/java/org/eclipse/hono/client/notification/KafkaBasedNotificationSenderTest.java
@@ -1,0 +1,249 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client.notification;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static com.google.common.truth.Truth.assertThat;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.kafka.test.KafkaClientUnitTestHelper;
+import org.eclipse.hono.notification.AbstractNotification;
+import org.eclipse.hono.notification.NotificationConstants;
+import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.LifecycleChange;
+import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.kafka.client.serialization.JsonObjectSerializer;
+
+/**
+ * Verifies behavior of {@link KafkaBasedNotificationSender}.
+ */
+@ExtendWith(VertxExtension.class)
+public class KafkaBasedNotificationSenderTest {
+
+    private static final Instant CREATION_TIME = Instant.parse("2007-12-03T10:15:30Z");
+    private static final LifecycleChange CHANGE = LifecycleChange.CREATE;
+    private static final String TENANT_ID = "my-tenant";
+    private static final String DEVICE_ID = "my-device";
+    private static final boolean ENABLED = false;
+
+    private final KafkaProducerConfigProperties config = new KafkaProducerConfigProperties();
+
+    /**
+     * Sets up the fixture.
+     */
+    @BeforeEach
+    public void setUp() {
+        config.setProducerConfig(Map.of("hono.kafka.producerConfig.bootstrap.servers", "localhost:9092"));
+    }
+
+    /**
+     * Verifies that {@link KafkaBasedNotificationSender#start()} creates a producer and *
+     * {@link KafkaBasedNotificationSender#stop()} closes it.
+     */
+    @Test
+    public void testLifecycle() {
+        final MockProducer<String, JsonObject> mockProducer = newMockProducer();
+        final CachingKafkaProducerFactory<String, JsonObject> factory = newProducerFactory(mockProducer);
+        final KafkaBasedNotificationSender sender = new KafkaBasedNotificationSender(factory, config);
+
+        assertThat(factory.getProducer(KafkaBasedNotificationSender.PRODUCER_NAME).isPresent()).isFalse();
+        sender.start();
+        assertThat(factory.getProducer(KafkaBasedNotificationSender.PRODUCER_NAME).isPresent()).isTrue();
+        sender.stop();
+        assertThat(factory.getProducer(KafkaBasedNotificationSender.PRODUCER_NAME).isPresent()).isFalse();
+    }
+
+    /**
+     * Verifies that the expected Kafka record is created when publishing a {@link TenantChangeNotification}.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testProducerRecordForTenantNotification(final VertxTestContext ctx) {
+
+        // GIVEN a sender
+        final MockProducer<String, JsonObject> mockProducer = newMockProducer();
+        final KafkaBasedNotificationSender sender = newSender(mockProducer);
+
+        // WHEN publishing a notification
+        final TenantChangeNotification notification = new TenantChangeNotification(CHANGE, TENANT_ID, CREATION_TIME,
+                ENABLED);
+        sender.publish(notification)
+                .onComplete(ctx.succeeding(v -> {
+                    // THEN the producer record is created from the given values
+                    ctx.verify(() -> {
+                        final ProducerRecord<String, JsonObject> record = mockProducer.history().get(0);
+
+                        assertThat(record.topic())
+                                .isEqualTo(NotificationTopicHelper.getTopicName(notification.getClass()));
+                        assertThat(record.key()).isEqualTo(TENANT_ID);
+                        assertThat(record.value().getString(NotificationConstants.JSON_FIELD_TYPE))
+                                .isEqualTo(((AbstractNotification) notification).getType());
+                    });
+                    ctx.completeNow();
+                }));
+    }
+
+    /**
+     * Verifies that the expected Kafka record is created when publishing a {@link DeviceChangeNotification}.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testProducerRecordForDeviceNotification(final VertxTestContext ctx) {
+
+        // GIVEN a sender
+        final MockProducer<String, JsonObject> mockProducer = newMockProducer();
+        final KafkaBasedNotificationSender sender = newSender(mockProducer);
+
+        // WHEN publishing a notification
+        final DeviceChangeNotification notification = new DeviceChangeNotification(CHANGE, TENANT_ID, DEVICE_ID,
+                CREATION_TIME, ENABLED);
+        sender.publish(notification)
+                .onComplete(ctx.succeeding(v -> {
+                    // THEN the producer record is created from the given values
+                    ctx.verify(() -> {
+                        final ProducerRecord<String, JsonObject> record = mockProducer.history().get(0);
+
+                        assertThat(record.topic())
+                                .isEqualTo(NotificationTopicHelper.getTopicName(notification.getClass()));
+                        assertThat(record.key()).isEqualTo(DEVICE_ID);
+                        assertThat(record.value().getString(NotificationConstants.JSON_FIELD_TYPE))
+                                .isEqualTo(((AbstractNotification) notification).getType());
+                    });
+                    ctx.completeNow();
+                }));
+    }
+
+    /**
+     * Verifies that the expected Kafka record is created when publishing a {@link CredentialsChangeNotification}.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testProducerRecordForCredentialsNotification(final VertxTestContext ctx) {
+
+        // GIVEN a sender
+        final MockProducer<String, JsonObject> mockProducer = newMockProducer();
+        final KafkaBasedNotificationSender sender = newSender(mockProducer);
+
+        // WHEN publishing a notification
+        final CredentialsChangeNotification notification = new CredentialsChangeNotification(TENANT_ID, DEVICE_ID,
+                CREATION_TIME);
+        sender.publish(notification)
+                .onComplete(ctx.succeeding(v -> {
+                    // THEN the producer record is created from the given values
+                    ctx.verify(() -> {
+                        final ProducerRecord<String, JsonObject> record = mockProducer.history().get(0);
+
+                        assertThat(record.topic())
+                                .isEqualTo(NotificationTopicHelper.getTopicName(notification.getClass()));
+                        assertThat(record.key()).isEqualTo(DEVICE_ID);
+                        assertThat(record.value().getString(NotificationConstants.JSON_FIELD_TYPE))
+                                .isEqualTo(((AbstractNotification) notification).getType());
+                    });
+                    ctx.completeNow();
+                }));
+    }
+
+    /**
+     * Verifies that the send method returns the underlying error wrapped in a {@link ServerErrorException}.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testSendFailsWithTheExpectedError(final VertxTestContext ctx) {
+
+        // GIVEN a sender sending a message
+        final RuntimeException expectedError = new RuntimeException("boom");
+        final MockProducer<String, JsonObject> mockProducer = new MockProducer<>(false, new StringSerializer(),
+                new JsonObjectSerializer());
+        final KafkaBasedNotificationSender sender = newSender(mockProducer);
+
+        sender.publish(new TenantChangeNotification(CHANGE, TENANT_ID, CREATION_TIME, ENABLED))
+                .onComplete(ctx.failing(t -> {
+                    ctx.verify(() -> {
+                        // THEN it fails with the expected error
+                        assertThat(t).isInstanceOf(ServerErrorException.class);
+                        assertThat(((ServerErrorException) t).getErrorCode()).isEqualTo(503);
+                        assertThat(t.getCause()).isEqualTo(expectedError);
+                    });
+                    ctx.completeNow();
+                }));
+
+        // WHEN the send operation fails
+        mockProducer.errorNext(expectedError);
+
+    }
+
+    /**
+     * Verifies that the constructor throws a nullpointer exception if a parameter is {@code null}.
+     */
+    @Test
+    public void testThatConstructorThrowsOnMissingParameter() {
+        final MockProducer<String, JsonObject> mockProducer = newMockProducer();
+
+        final KafkaProducerFactory<String, JsonObject> factory = newProducerFactory(mockProducer);
+
+        assertThrows(NullPointerException.class, () -> new KafkaBasedNotificationSender(null, config));
+        assertThrows(NullPointerException.class, () -> new KafkaBasedNotificationSender(factory, null));
+
+    }
+
+    /**
+     * Verifies that {@link KafkaBasedNotificationSender#publish(AbstractNotification)} throws a nullpointer exception
+     * if a mandatory parameter is {@code null}.
+     */
+    @Test
+    public void testThatSendThrowsOnMissingMandatoryParameter() {
+        final MockProducer<String, JsonObject> mockProducer = newMockProducer();
+        final KafkaBasedNotificationSender sender = newSender(mockProducer);
+
+        assertThrows(NullPointerException.class, () -> sender.publish(null));
+
+    }
+
+    private MockProducer<String, JsonObject> newMockProducer() {
+        return new MockProducer<>(true, new StringSerializer(), new JsonObjectSerializer());
+    }
+
+    private CachingKafkaProducerFactory<String, JsonObject> newProducerFactory(
+            final MockProducer<String, JsonObject> mockProducer) {
+        return CachingKafkaProducerFactory
+                .testFactory((n, c) -> KafkaClientUnitTestHelper.newKafkaProducer(mockProducer));
+    }
+
+    private KafkaBasedNotificationSender newSender(final MockProducer<String, JsonObject> mockProducer) {
+        final CachingKafkaProducerFactory<String, JsonObject> factory = newProducerFactory(mockProducer);
+        return new KafkaBasedNotificationSender(factory, config);
+    }
+
+}

--- a/clients/notification/pom.xml
+++ b/clients/notification/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.hono</groupId>
+    <artifactId>hono-clients-parent</artifactId>
+    <version>1.11.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>hono-client-notification</artifactId>
+
+  <name>Hono Notification Client</name>
+  <description>Clients for Hono's notifications</description>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.vertx</groupId>
+          <artifactId>vertx-proton</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.opentracing</groupId>
+          <artifactId>opentracing-noop</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-handler</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-handler-proxy</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-resolver</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-resolver-dns</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http2</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+</project>

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/AbstractNotification.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/AbstractNotification.java
@@ -80,11 +80,4 @@ public abstract class AbstractNotification {
         return creationTime;
     }
 
-    /**
-     * Gets the address to be used for messaging.
-     *
-     * @return The address.
-     */
-    @JsonIgnore
-    public abstract String getAddress();
 }

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/AbstractNotification.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/AbstractNotification.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import org.eclipse.hono.annotation.HonoTimestamp;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+
+/**
+ * A Hono internal notification that is published by one component to inform other components about events.
+ *
+ * Notifications are always sent as JSON.
+ *
+ * Subclasses must be added to {@link NotificationTypeResolver} for automatic handling of the type by Jackson.
+ */
+@JsonInclude(value = JsonInclude.Include.NON_NULL)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = NotificationConstants.JSON_FIELD_TYPE, visible = true)
+@JsonTypeIdResolver(NotificationTypeResolver.class)
+public abstract class AbstractNotification {
+
+    private final String source;
+    private final Instant creationTime;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param source The canonical name of the component that publishes the notification.
+     * @param creationTime The creation time of the event.
+     * @throws NullPointerException If any of the parameters are {@code null}.
+     */
+    protected AbstractNotification(final String source, final Instant creationTime) {
+        this.source = Objects.requireNonNull(source);
+        this.creationTime = Objects.requireNonNull(creationTime);
+    }
+
+    /**
+     * Gets the type of the notification.
+     *
+     * @return The type name.
+     */
+    @JsonIgnore
+    public abstract String getType();
+
+    /**
+     * Gets the canonical name of the component that publishes the notification.
+     *
+     * @return The name of the component.
+     */
+    @JsonGetter(NotificationConstants.JSON_FIELD_SOURCE)
+    public String getSource() {
+        return source;
+    }
+
+    /**
+     * Gets the creation time of the notification.
+     *
+     * @return The point in time.
+     */
+    @JsonGetter(NotificationConstants.JSON_FIELD_CREATION_TIME)
+    @HonoTimestamp
+    public Instant getCreationTime() {
+        return creationTime;
+    }
+
+    /**
+     * Gets the address to be used for messaging.
+     *
+     * @return The address.
+     */
+    @JsonIgnore
+    public abstract String getAddress();
+}

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationConstants.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationConstants.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification;
+
+import org.eclipse.hono.util.Constants;
+
+/**
+ * Constants used by the notification API.
+ */
+public class NotificationConstants {
+
+    public static final String CONTENT_TYPE = "application/json";
+    /**
+     * The field name of the JSON object that indicates the class into the object can be decoded.
+     */
+    public static final String JSON_FIELD_TYPE = "type";
+    /**
+     * The field name of the JSON object that indicates the component that publishes the notification.
+     */
+    public static final String JSON_FIELD_SOURCE = "source";
+    /**
+     * The field name of the JSON object that indicates the creation time of the notification.
+     */
+    public static final String JSON_FIELD_CREATION_TIME = "creation-time";
+
+    /**
+     * The canonical name of the Device Registry to indicate the component that publishes a notification.
+     */
+    public static final String SOURCE_DEVICE_REGISTRY = "device-registry";
+    /**
+     * The field name of the JSON object that indicates the change.
+     */
+    public static final String JSON_FIELD_DATA_CHANGE = "change";
+    /**
+     * The field name of the JSON object that indicates if the entity is enabled.
+     */
+    public static final String JSON_FIELD_DATA_ENABLED = "enabled";
+    /**
+     * The field name of the JSON object that indicates the tenant ID.
+     */
+    public static final String JSON_FIELD_TENANT_ID = Constants.JSON_FIELD_TENANT_ID;
+    /**
+     * The field name of the JSON object that indicates the device ID.
+     */
+    public static final String JSON_FIELD_DEVICE_ID = Constants.JSON_FIELD_DEVICE_ID;
+
+    private NotificationConstants() {
+        // prevent instantiation
+    }
+
+}

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationReceiver.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationReceiver.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification;
+
+import org.eclipse.hono.util.Lifecycle;
+
+import io.vertx.core.Handler;
+
+/**
+ * A client that supports receiving Hono's (internal) notifications.
+ *
+ */
+public interface NotificationReceiver extends Lifecycle {
+
+    /**
+     * Registers a notification consumer for a specific type of notifications.
+     *
+     * @param notificationType The class of the notifications to consume.
+     * @param consumer The handler to be invoked with the received notification.
+     * @param <T> The type of notifications to consume.
+     */
+    <T extends AbstractNotification> void registerConsumer(Class<T> notificationType, Handler<T> consumer);
+}

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationSender.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationSender.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification;
+
+import org.eclipse.hono.util.Lifecycle;
+
+import io.vertx.core.Future;
+
+/**
+ * A client for publishing Hono internal notifications.
+ *
+ */
+public interface NotificationSender extends Lifecycle {
+
+    /**
+     * Publish a notification that inform consuming components about an event in the publishing component.
+     *
+     * @param notification The notification to be published.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if the notification has been published.
+     *         <p>
+     *         The future will be failed with a {@code org.eclipse.hono.client.ServerErrorException} if the data could
+     *         not be sent. The error code contained in the exception indicates the cause of the failure.
+     * @throws NullPointerException if notification is {@code null}.
+     */
+    Future<Void> publish(AbstractNotification notification);
+}

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationTypeResolver.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationTypeResolver.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification;
+
+import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+
+/**
+ * Type resolver for notifications.
+ * <p>
+ * This type resolver knows the types {@link TenantChangeNotification}, {@link DeviceChangeNotification} and
+ * {@link CredentialsChangeNotification}.
+ */
+public final class NotificationTypeResolver extends TypeIdResolverBase {
+
+    private JavaType baseType;
+
+    @Override
+    public void init(final JavaType baseType) {
+        this.baseType = baseType;
+    }
+
+    @Override
+    public JsonTypeInfo.Id getMechanism() {
+        return JsonTypeInfo.Id.NAME;
+    }
+
+    @Override
+    public String idFromValue(final Object obj) {
+        return idFromValueAndType(obj, obj.getClass());
+    }
+
+    @Override
+    public String idFromValueAndType(final Object obj, final Class<?> subType) {
+
+        if (obj instanceof AbstractNotification) {
+            return ((AbstractNotification) obj).getType();
+        }
+        return null;
+    }
+
+    @Override
+    public JavaType typeFromId(final DatabindContext context, final String id) {
+        switch (id) {
+        case TenantChangeNotification.TYPE:
+            return context.constructSpecializedType(this.baseType, TenantChangeNotification.class);
+        case DeviceChangeNotification.TYPE:
+            return context.constructSpecializedType(this.baseType, DeviceChangeNotification.class);
+        case CredentialsChangeNotification.TYPE:
+            return context.constructSpecializedType(this.baseType, CredentialsChangeNotification.class);
+        default:
+            return null;
+        }
+    }
+}

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/CredentialsChangeNotification.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/CredentialsChangeNotification.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import org.eclipse.hono.annotation.HonoTimestamp;
+import org.eclipse.hono.notification.AbstractNotification;
+import org.eclipse.hono.notification.NotificationConstants;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Notification that informs about changes on credentials.
+ *
+ * The notification only informs that credentials for a device have been changed but not about details of the change.
+ * Components that consume this notification could either query the Device Registry to get more information, or assume
+ * that the used credentials have become invalid. For example a protocol adapter can simply disconnect the device to
+ * enforce re-authentication.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CredentialsChangeNotification extends AbstractNotification {
+
+    public static final String TYPE = "credentials-change-v1";
+    public static final String ADDRESS = DeviceChangeNotification.ADDRESS;
+
+    @JsonProperty(value = NotificationConstants.JSON_FIELD_TENANT_ID, required = true)
+    private final String tenantId;
+
+    @JsonProperty(value = NotificationConstants.JSON_FIELD_DEVICE_ID, required = true)
+    private final String deviceId;
+
+    @JsonCreator
+    CredentialsChangeNotification(
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_SOURCE, required = true) final String source,
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_CREATION_TIME, required = true) @HonoTimestamp final Instant creationTime,
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_TENANT_ID, required = true) final String tenantId,
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_DEVICE_ID, required = true) final String deviceId) {
+
+        super(source, creationTime);
+
+        this.tenantId = Objects.requireNonNull(tenantId);
+        this.deviceId = Objects.requireNonNull(deviceId);
+    }
+
+    /**
+     * Creates an instance.
+     *
+     * @param tenantId The tenant ID of the device.
+     * @param deviceId The ID of the device.
+     * @param creationTime The creation time of the event.
+     * @throws NullPointerException If any of the parameters are {@code null}.
+     */
+    public CredentialsChangeNotification(final String tenantId, final String deviceId, final Instant creationTime) {
+        this(NotificationConstants.SOURCE_DEVICE_REGISTRY, creationTime, tenantId, deviceId);
+    }
+
+    /**
+     * Gets the tenant ID of the changed device.
+     *
+     * @return The tenant ID.
+     */
+    public final String getTenantId() {
+        return tenantId;
+    }
+
+    /**
+     * Gets the ID of the changed device.
+     *
+     * @return The device ID.
+     */
+    public final String getDeviceId() {
+        return deviceId;
+    }
+
+    @Override
+    public final String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public String getAddress() {
+        return ADDRESS;
+    }
+
+}

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/CredentialsChangeNotification.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/CredentialsChangeNotification.java
@@ -92,9 +92,4 @@ public class CredentialsChangeNotification extends AbstractNotification {
         return TYPE;
     }
 
-    @Override
-    public String getAddress() {
-        return ADDRESS;
-    }
-
 }

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/DeviceChangeNotification.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/DeviceChangeNotification.java
@@ -118,9 +118,4 @@ public class DeviceChangeNotification extends AbstractNotification {
         return TYPE;
     }
 
-    @Override
-    public String getAddress() {
-        return ADDRESS;
-    }
-
 }

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/DeviceChangeNotification.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/DeviceChangeNotification.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import org.eclipse.hono.annotation.HonoTimestamp;
+import org.eclipse.hono.notification.AbstractNotification;
+import org.eclipse.hono.notification.NotificationConstants;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Notification that informs about changes on a device.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DeviceChangeNotification extends AbstractNotification {
+
+    public static final String TYPE = "device-change-v1";
+    public static final String ADDRESS = "registry-device";
+
+    @JsonProperty(value = NotificationConstants.JSON_FIELD_DATA_CHANGE, required = true)
+    private final LifecycleChange change;
+
+    @JsonProperty(value = NotificationConstants.JSON_FIELD_TENANT_ID, required = true)
+    private final String tenantId;
+
+    @JsonProperty(value = NotificationConstants.JSON_FIELD_DEVICE_ID, required = true)
+    private final String deviceId;
+
+    @JsonProperty(value = NotificationConstants.JSON_FIELD_DATA_ENABLED, required = true)
+    private final boolean enabled;
+
+    @JsonCreator
+    DeviceChangeNotification(
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_SOURCE, required = true) final String source,
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_CREATION_TIME, required = true) @HonoTimestamp final Instant creationTime,
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_DATA_CHANGE, required = true) final LifecycleChange change,
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_TENANT_ID, required = true) final String tenantId,
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_DEVICE_ID, required = true) final String deviceId,
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_DATA_ENABLED, required = true) final boolean enabled) {
+
+        super(source, creationTime);
+
+        this.change = Objects.requireNonNull(change);
+        this.tenantId = Objects.requireNonNull(tenantId);
+        this.deviceId = Objects.requireNonNull(deviceId);
+        this.enabled = enabled;
+    }
+
+    /**
+     * Creates an instance.
+     *
+     * @param change The type of change to notify about.
+     * @param tenantId The tenant ID of the device.
+     * @param deviceId The ID of the device.
+     * @param creationTime The creation time of the event.
+     * @param enabled {@code true} if the device is enabled.
+     * @throws NullPointerException If any of the parameters are {@code null}.
+     */
+    public DeviceChangeNotification(final LifecycleChange change, final String tenantId, final String deviceId,
+            final Instant creationTime, final boolean enabled) {
+        this(NotificationConstants.SOURCE_DEVICE_REGISTRY, creationTime, change, tenantId, deviceId, enabled);
+    }
+
+    /**
+     * Gets the change that caused the notification.
+     *
+     * @return The change.
+     */
+    public final LifecycleChange getChange() {
+        return change;
+    }
+
+    /**
+     * Gets the tenant ID of the changed device.
+     *
+     * @return The tenant ID.
+     */
+    public final String getTenantId() {
+        return tenantId;
+    }
+
+    /**
+     * Gets the ID of the changed device.
+     *
+     * @return The device ID.
+     */
+    public final String getDeviceId() {
+        return deviceId;
+    }
+
+    /**
+     * Checks if the device is enabled.
+     *
+     * @return {@code true} if this device is enabled.
+     */
+    public final boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public final String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public String getAddress() {
+        return ADDRESS;
+    }
+
+}

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/LifecycleChange.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/LifecycleChange.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+/**
+ * Type of change that causes a notification to be published.
+ */
+public enum LifecycleChange {
+    CREATE,
+    UPDATE,
+    DELETE
+}

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/TenantChangeNotification.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/TenantChangeNotification.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import org.eclipse.hono.annotation.HonoTimestamp;
+import org.eclipse.hono.notification.AbstractNotification;
+import org.eclipse.hono.notification.NotificationConstants;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Notification that informs about changes on a tenant.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TenantChangeNotification extends AbstractNotification {
+
+    public static final String TYPE = "tenant-change-v1";
+    public static final String ADDRESS = "registry-tenant";
+
+    @JsonProperty(value = NotificationConstants.JSON_FIELD_DATA_CHANGE, required = true)
+    private final LifecycleChange change;
+
+    @JsonProperty(value = NotificationConstants.JSON_FIELD_TENANT_ID, required = true)
+    private final String tenantId;
+
+    @JsonProperty(value = NotificationConstants.JSON_FIELD_DATA_ENABLED, required = true)
+    private final boolean enabled;
+
+    @JsonCreator
+    TenantChangeNotification(
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_SOURCE, required = true) final String source,
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_CREATION_TIME, required = true) @HonoTimestamp final Instant creationTime,
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_DATA_CHANGE, required = true) final LifecycleChange change,
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_TENANT_ID, required = true) final String tenantId,
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_DATA_ENABLED, required = true) final boolean enabled) {
+
+        super(source, creationTime);
+
+        this.change = Objects.requireNonNull(change);
+        this.tenantId = Objects.requireNonNull(tenantId);
+        this.enabled = enabled;
+    }
+
+    /**
+     * Creates an instance.
+     *
+     * @param change The type of change to notify about.
+     * @param tenantId The ID of the tenant.
+     * @param creationTime The creation time of the event.
+     * @param enabled {@code true} if the device is enabled.
+     * @throws NullPointerException If any of the parameters are {@code null}.
+     */
+    public TenantChangeNotification(final LifecycleChange change, final String tenantId, final Instant creationTime,
+            final boolean enabled) {
+        this(NotificationConstants.SOURCE_DEVICE_REGISTRY, creationTime, change, tenantId, enabled);
+    }
+
+    /**
+     * Gets the change that caused the notification.
+     *
+     * @return The change.
+     */
+    public final LifecycleChange getChange() {
+        return change;
+    }
+
+    /**
+     * Gets the ID of the changed tenant.
+     *
+     * @return The tenant ID.
+     */
+    public final String getTenantId() {
+        return tenantId;
+    }
+
+    /**
+     * Checks if the tenant is enabled.
+     *
+     * @return {@code true} if this tenant is enabled.
+     */
+    public final boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public final String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public String getAddress() {
+        return ADDRESS;
+    }
+
+}

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/TenantChangeNotification.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/TenantChangeNotification.java
@@ -103,9 +103,4 @@ public class TenantChangeNotification extends AbstractNotification {
         return TYPE;
     }
 
-    @Override
-    public String getAddress() {
-        return ADDRESS;
-    }
-
 }

--- a/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/CredentialsChangeNotificationTest.java
+++ b/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/CredentialsChangeNotificationTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.time.Instant;
+
+import org.eclipse.hono.notification.AbstractNotification;
+import org.eclipse.hono.notification.NotificationConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Tests verifying the behavior of {@link CredentialsChangeNotification}.
+ *
+ */
+public class CredentialsChangeNotificationTest {
+
+    private static final String CREATION_TIME = "2007-12-03T10:15:30Z";
+    private static final String TENANT_ID = "my-tenant";
+    private static final String DEVICE_ID = "my-device";
+
+    private AbstractNotification notification;
+
+    /**
+     * Sets up the notification.
+     */
+    @BeforeEach
+    public void setUp() {
+        notification = new CredentialsChangeNotification(TENANT_ID, DEVICE_ID, Instant.parse(CREATION_TIME));
+    }
+
+    /**
+     * Verifies that the expected properties are contained in the JSON.
+     */
+    @Test
+    public void testThatValuesAreContainedInJson() {
+
+        final JsonObject json = JsonObject.mapFrom(notification);
+
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_SOURCE))
+                .isEqualTo(NotificationConstants.SOURCE_DEVICE_REGISTRY);
+        assertThat(json.getInstant(NotificationConstants.JSON_FIELD_CREATION_TIME).toString()).isEqualTo(CREATION_TIME);
+
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_TYPE)).isEqualTo(CredentialsChangeNotification.TYPE);
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_TENANT_ID)).isEqualTo(TENANT_ID);
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_DEVICE_ID)).isEqualTo(DEVICE_ID);
+    }
+
+    /**
+     * Verifies that the serialization did not change: the JSON contains the static values and only the expected keys.
+     */
+    @Test
+    public void testThatSerializationIsStable() {
+
+        final JsonObject json = JsonObject.mapFrom(notification);
+        assertThat(json).isNotNull();
+
+        // When adding new properties to the data object, make sure not to break the existing API because messages might
+        // be persisted. For breaking changes add a new object mapper class instead.
+        final int expectedPropertiesCount = 5;
+        assertWithMessage("JSON contains unknown fields").that(json.size()).isEqualTo(expectedPropertiesCount);
+
+        assertThat(json.getString("type")).isEqualTo("credentials-change-v1");
+        assertThat(json.getString("source")).isEqualTo("device-registry");
+        assertThat(json.getString("creation-time")).isEqualTo(CREATION_TIME);
+
+        assertThat(json.getString("tenant-id")).isNotNull();
+        assertThat(json.getString("device-id")).isNotNull();
+
+    }
+
+    /**
+     * Verifies that a serialized notification is deserialized correctly.
+     */
+    @Test
+    public void testDeserialization() {
+
+        final AbstractNotification abstractNotification = Json
+                .decodeValue(JsonObject.mapFrom(notification).toBuffer(), AbstractNotification.class);
+
+        assertThat(abstractNotification).isNotNull();
+        assertThat(abstractNotification).isInstanceOf(CredentialsChangeNotification.class);
+        final CredentialsChangeNotification newNotification = (CredentialsChangeNotification) abstractNotification;
+
+        assertThat(newNotification.getSource()).isEqualTo(NotificationConstants.SOURCE_DEVICE_REGISTRY);
+        assertThat(newNotification.getCreationTime()).isEqualTo(Instant.parse(CREATION_TIME));
+
+        assertThat(newNotification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(newNotification.getDeviceId()).isEqualTo(DEVICE_ID);
+    }
+
+}

--- a/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/DeviceChangeNotificationTest.java
+++ b/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/DeviceChangeNotificationTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.time.Instant;
+
+import org.eclipse.hono.notification.AbstractNotification;
+import org.eclipse.hono.notification.NotificationConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Tests verifying the behavior of {@link DeviceChangeNotification}.
+ *
+ */
+public class DeviceChangeNotificationTest {
+
+    private static final String CREATION_TIME = "2007-12-03T10:15:30Z";
+    private static final String TENANT_ID = "my-tenant";
+    private static final String DEVICE_ID = "my-device";
+    private static final LifecycleChange CHANGE = LifecycleChange.CREATE;
+    private static final boolean ENABLED = false;
+
+    private AbstractNotification notification;
+
+    /**
+     * Sets up the notification.
+     */
+    @BeforeEach
+    public void setUp() {
+        notification = new DeviceChangeNotification(CHANGE, TENANT_ID, DEVICE_ID, Instant.parse(CREATION_TIME), ENABLED);
+    }
+
+    /**
+     * Verifies that the expected properties are contained in the JSON.
+     */
+    @Test
+    public void testThatValuesAreContainedInJson() {
+
+        final JsonObject json = JsonObject.mapFrom(notification);
+
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_SOURCE))
+                .isEqualTo(NotificationConstants.SOURCE_DEVICE_REGISTRY);
+        assertThat(json.getInstant(NotificationConstants.JSON_FIELD_CREATION_TIME).toString()).isEqualTo(CREATION_TIME);
+
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_TYPE)).isEqualTo(DeviceChangeNotification.TYPE);
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_DATA_CHANGE)).isEqualTo(CHANGE.toString());
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_TENANT_ID)).isEqualTo(TENANT_ID);
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_DEVICE_ID)).isEqualTo(DEVICE_ID);
+        assertThat(json.getBoolean(NotificationConstants.JSON_FIELD_DATA_ENABLED)).isEqualTo(ENABLED);
+    }
+
+    /**
+     * Verifies that the serialization did not change: the JSON contains the static values and only the expected keys.
+     */
+    @Test
+    public void testThatSerializationIsStable() {
+
+        final JsonObject json = JsonObject.mapFrom(notification);
+        assertThat(json).isNotNull();
+
+        // When adding new properties to the data object, make sure not to break the existing API because messages might
+        // be persisted. For breaking changes add a new object mapper class instead.
+        final int expectedPropertiesCount = 7;
+        assertWithMessage("JSON contains unknown fields").that(json.size()).isEqualTo(expectedPropertiesCount);
+
+        assertThat(json.getString("type")).isEqualTo("device-change-v1");
+        assertThat(json.getString("source")).isEqualTo("device-registry");
+        assertThat(json.getString("creation-time")).isEqualTo(CREATION_TIME);
+
+        assertThat(json.getString("change")).isEqualTo("CREATE");
+        assertThat(json.getString("tenant-id")).isNotNull();
+        assertThat(json.getString("device-id")).isNotNull();
+        assertThat(json.getString("enabled")).isNotNull();
+
+    }
+
+    /**
+     * Verifies that a serialized notification is deserialized correctly.
+     */
+    @Test
+    public void testDeserialization() {
+
+        final AbstractNotification abstractNotification = Json
+                .decodeValue(JsonObject.mapFrom(notification).toBuffer(), AbstractNotification.class);
+
+        assertThat(abstractNotification).isNotNull();
+        assertThat(abstractNotification).isInstanceOf(DeviceChangeNotification.class);
+        final DeviceChangeNotification newNotification = (DeviceChangeNotification) abstractNotification;
+
+        assertThat(newNotification.getSource()).isEqualTo(NotificationConstants.SOURCE_DEVICE_REGISTRY);
+        assertThat(newNotification.getCreationTime()).isEqualTo(Instant.parse(CREATION_TIME));
+
+        assertThat(newNotification.getChange()).isEqualTo(CHANGE);
+        assertThat(newNotification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(newNotification.getDeviceId()).isEqualTo(DEVICE_ID);
+        assertThat(newNotification.isEnabled()).isEqualTo(ENABLED);
+    }
+
+}

--- a/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/TenantChangeNotificationTest.java
+++ b/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/TenantChangeNotificationTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.time.Instant;
+
+import org.eclipse.hono.notification.AbstractNotification;
+import org.eclipse.hono.notification.NotificationConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Tests verifying the behavior of {@link TenantChangeNotification}.
+ *
+ */
+public class TenantChangeNotificationTest {
+
+    private static final String CREATION_TIME = "2007-12-03T10:15:30Z";
+    private static final String TENANT_ID = "my-tenant";
+    private static final boolean ENABLED = false;
+    private static final LifecycleChange CHANGE = LifecycleChange.CREATE;
+
+    private AbstractNotification notification;
+
+    /**
+     * Sets up the notification.
+     */
+    @BeforeEach
+    public void setUp() {
+        notification = new TenantChangeNotification(CHANGE, TENANT_ID, Instant.parse(CREATION_TIME), ENABLED);
+    }
+
+    /**
+     * Verifies that the expected properties are contained in the JSON.
+     */
+    @Test
+    public void testThatValuesAreContainedInJson() {
+
+        final JsonObject json = JsonObject.mapFrom(notification);
+
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_SOURCE))
+                .isEqualTo(NotificationConstants.SOURCE_DEVICE_REGISTRY);
+        assertThat(json.getInstant(NotificationConstants.JSON_FIELD_CREATION_TIME).toString()).isEqualTo(CREATION_TIME);
+
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_TYPE)).isEqualTo(TenantChangeNotification.TYPE);
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_TENANT_ID)).isEqualTo(TENANT_ID);
+        assertThat(json.getBoolean(NotificationConstants.JSON_FIELD_DATA_ENABLED)).isEqualTo(ENABLED);
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_DATA_CHANGE)).isEqualTo(CHANGE.toString());
+    }
+
+    /**
+     * Verifies that the serialization did not change: the JSON contains the static values and only the expected keys.
+     */
+    @Test
+    public void testThatSerializationIsStable() {
+
+        final JsonObject json = JsonObject.mapFrom(notification);
+        assertThat(json).isNotNull();
+
+        // When adding new properties to the data object, make sure not to break the existing API because messages might
+        // be persisted. For breaking changes add a new object mapper class instead.
+        final int expectedPropertiesCount = 6;
+        assertWithMessage("JSON contains unknown fields").that(json.size()).isEqualTo(expectedPropertiesCount);
+
+        assertThat(json.getString("type")).isEqualTo("tenant-change-v1");
+        assertThat(json.getString("source")).isEqualTo("device-registry");
+        assertThat(json.getString("creation-time")).isEqualTo(CREATION_TIME);
+
+        assertThat(json.getString("change")).isEqualTo("CREATE");
+        assertThat(json.getString("tenant-id")).isNotNull();
+        assertThat(json.getString("enabled")).isNotNull();
+
+    }
+
+    /**
+     * Verifies that a serialized notification is deserialized correctly.
+     */
+    @Test
+    public void testDeserialization() {
+
+        final AbstractNotification abstractNotification = Json
+                .decodeValue(JsonObject.mapFrom(notification).toBuffer(), AbstractNotification.class);
+
+        assertThat(abstractNotification).isNotNull();
+        assertThat(abstractNotification).isInstanceOf(TenantChangeNotification.class);
+        final TenantChangeNotification newNotification = (TenantChangeNotification) abstractNotification;
+
+        assertThat(newNotification.getSource()).isEqualTo(NotificationConstants.SOURCE_DEVICE_REGISTRY);
+        assertThat(newNotification.getCreationTime()).isEqualTo(Instant.parse(CREATION_TIME));
+
+        assertThat(newNotification.getChange()).isEqualTo(CHANGE);
+        assertThat(newNotification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(newNotification.isEnabled()).isEqualTo(ENABLED);
+    }
+
+}

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -37,6 +37,7 @@
     <module>command-amqp</module>
     <module>command-kafka</module>
     <module>kafka-common</module>
+    <module>notification</module>
     <module>registry</module>
     <module>registry-amqp</module>
     <module>telemetry</module>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -12,7 +12,7 @@
     SPDX-License-Identifier: EPL-2.0
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.eclipse.hono</groupId>
@@ -38,6 +38,7 @@
     <module>command-kafka</module>
     <module>kafka-common</module>
     <module>notification</module>
+    <module>notification-kafka</module>
     <module>registry</module>
     <module>registry-amqp</module>
     <module>telemetry</module>

--- a/services/device-registry-base/pom.xml
+++ b/services/device-registry-base/pom.xml
@@ -36,6 +36,10 @@
       <artifactId>hono-service-base</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-notification</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-crypto</artifactId>
     </dependency>

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/notification/NotificationFactory.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/notification/NotificationFactory.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.deviceregistry.notification;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Objects;
+
+import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.LifecycleChange;
+import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
+
+/**
+ * A factory that creates notifications that inform about events happening in the Device Registry.
+ *
+ * The factory adds the point in time when the notification is created as the creation time. The notification should be
+ * created as soon as possible/reasonable after the event happened.
+ */
+public class NotificationFactory {
+
+    private final Clock clock;
+
+    /**
+     * Creates an instance.
+     *
+     * Notifications created by this instance will use the system clock to get the creation time.
+     */
+    public NotificationFactory() {
+        clock = Clock.systemUTC();
+    }
+
+    // visible for testing
+    NotificationFactory(final Clock clock) {
+        this.clock = clock;
+    }
+
+    /**
+     * Creates a notification to inform about the creation of a tenant.
+     *
+     * @param tenantId The ID of the created tenant.
+     * @param enabled {@code true} if the tenant is enabled.
+     * @return The notification with the current creation time.
+     * @throws NullPointerException If tenantId is {@code null}.
+     */
+    public TenantChangeNotification tenantCreated(final String tenantId, final boolean enabled) {
+        Objects.requireNonNull(tenantId);
+
+        return new TenantChangeNotification(LifecycleChange.CREATE, tenantId, Instant.now(clock), enabled);
+    }
+
+    /**
+     * Creates a notification to inform about the update of a tenant.
+     *
+     * @param tenantId The ID of the changed tenant.
+     * @param enabled {@code true} if the tenant is enabled.
+     * @return The notification with the current creation time.
+     * @throws NullPointerException If tenantId is {@code null}.
+     */
+    public TenantChangeNotification tenantChanged(final String tenantId, final boolean enabled) {
+        Objects.requireNonNull(tenantId);
+
+        return new TenantChangeNotification(LifecycleChange.UPDATE, tenantId, Instant.now(clock), enabled);
+    }
+
+    /**
+     * Creates a notification to inform about the deletion of a tenant.
+     *
+     * @param tenantId The ID of the deleted tenant.
+     * @return The notification with the current creation time.
+     * @throws NullPointerException If tenantId is {@code null}.
+     */
+    public TenantChangeNotification tenantDeleted(final String tenantId) {
+        Objects.requireNonNull(tenantId);
+
+        return new TenantChangeNotification(LifecycleChange.DELETE, tenantId, Instant.now(clock), false);
+    }
+
+    /**
+     * Creates a notification to inform about the creation of a device.
+     *
+     * @param tenantId The tenant ID of the created device.
+     * @param deviceId The ID of the created device.
+     * @param enabled {@code true} if the device is enabled.
+     * @return The notification with the current creation time.
+     * @throws NullPointerException If tenantId or deviceId are {@code null}.
+     */
+    public DeviceChangeNotification deviceCreated(final String tenantId, final String deviceId,
+            final boolean enabled) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+
+        return new DeviceChangeNotification(LifecycleChange.CREATE, tenantId, deviceId, Instant.now(clock), enabled);
+    }
+
+    /**
+     * Creates a notification to inform about the update of a device.
+     *
+     * @param tenantId The tenant ID of the changed device.
+     * @param deviceId The ID of the changed device.
+     * @param enabled {@code true} if the device is enabled.
+     * @return The notification with the current creation time.
+     * @throws NullPointerException If tenantId or deviceId are {@code null}.
+     */
+    public DeviceChangeNotification deviceChanged(final String tenantId, final String deviceId,
+            final boolean enabled) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+
+        return new DeviceChangeNotification(LifecycleChange.UPDATE, tenantId, deviceId, Instant.now(clock), enabled);
+    }
+
+    /**
+     * Creates a notification to inform about the deletion of a device.
+     *
+     * @param tenantId The tenant ID of the deleted device.
+     * @param deviceId The ID of the deleted device.
+     * @return The notification with the current creation time.
+     * @throws NullPointerException If tenantId or deviceId are {@code null}.
+     */
+    public DeviceChangeNotification deviceDeleted(final String tenantId, final String deviceId) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+
+        return new DeviceChangeNotification(LifecycleChange.DELETE, tenantId, deviceId, Instant.now(clock), false);
+    }
+
+    /**
+     * Creates a notification to inform about the update of credentials.
+     *
+     * @param tenantId The tenant ID of the changed credentials.
+     * @param deviceId The device ID of the changed credentials.
+     * @return The notification with the current creation time.
+     * @throws NullPointerException If tenantId or deviceId are {@code null}.
+     */
+    public CredentialsChangeNotification credentialsChanged(final String tenantId, final String deviceId) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+
+        return new CredentialsChangeNotification(tenantId, deviceId, Instant.now(clock));
+    }
+
+}

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/notification/NotificationFactoryTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/notification/NotificationFactoryTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.deviceregistry.notification;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.LifecycleChange;
+import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the behavior of {@link NotificationFactory}.
+ */
+public class NotificationFactoryTest {
+
+    private static final String TENANT_ID = "my-tenant";
+    private static final String DEVICE_ID = "my-device";
+    private static final Instant CREATION_TIME = Instant.parse("2007-12-03T10:15:30Z");
+    private static final boolean ENABLED = false;
+
+    private static Clock clock;
+
+    /**
+     * Sets up a fixed clock.
+     */
+    @BeforeAll
+    public static void setUp() {
+        clock = Clock.fixed(CREATION_TIME, ZoneId.of("UTC"));
+    }
+
+    /**
+     * Verifies that the expected notification is created by {@link NotificationFactory#tenantCreated(String, boolean)}.
+     */
+    @Test
+    public void testTenantCreated() {
+        final TenantChangeNotification notification = new NotificationFactory(clock).tenantCreated(TENANT_ID, ENABLED);
+
+        assertThat(notification.getChange()).isEqualTo(LifecycleChange.CREATE);
+        assertThat(notification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(notification.getCreationTime()).isEqualTo(CREATION_TIME);
+        assertThat(notification.isEnabled()).isEqualTo(ENABLED);
+    }
+
+    /**
+     * Verifies that the expected notification is created by {@link NotificationFactory#tenantChanged(String, boolean)}.
+     */
+    @Test
+    public void testTenantChanged() {
+        final TenantChangeNotification notification = new NotificationFactory(clock).tenantChanged(TENANT_ID,
+                ENABLED);
+
+        assertThat(notification.getChange()).isEqualTo(LifecycleChange.UPDATE);
+        assertThat(notification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(notification.getCreationTime()).isEqualTo(CREATION_TIME);
+        assertThat(notification.isEnabled()).isEqualTo(ENABLED);
+    }
+
+    /**
+     * Verifies that the expected notification is created by {@link NotificationFactory#tenantDeleted(String)}.
+     */
+    @Test
+    public void testTenantDeleted() {
+        final TenantChangeNotification notification = new NotificationFactory(clock).tenantDeleted(TENANT_ID);
+
+        assertThat(notification.getChange()).isEqualTo(LifecycleChange.DELETE);
+        assertThat(notification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(notification.getCreationTime()).isEqualTo(CREATION_TIME);
+    }
+
+    /**
+     * Verifies that the expected notification is created by
+     * {@link NotificationFactory#deviceCreated(String, String, boolean)}.
+     */
+    @Test
+    public void testDeviceCreated() {
+        final DeviceChangeNotification notification = new NotificationFactory(clock).deviceCreated(TENANT_ID, DEVICE_ID,
+                ENABLED);
+
+        assertThat(notification.getChange()).isEqualTo(LifecycleChange.CREATE);
+        assertThat(notification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(notification.getDeviceId()).isEqualTo(DEVICE_ID);
+        assertThat(notification.getCreationTime()).isEqualTo(CREATION_TIME);
+        assertThat(notification.isEnabled()).isEqualTo(ENABLED);
+    }
+
+    /**
+     * Verifies that the expected notification is created by
+     * {@link NotificationFactory#deviceChanged(String, String, boolean)}.
+     */
+    @Test
+    public void testDeviceChanged() {
+        final DeviceChangeNotification notification = new NotificationFactory(clock).deviceChanged(TENANT_ID, DEVICE_ID,
+                ENABLED);
+
+        assertThat(notification.getChange()).isEqualTo(LifecycleChange.UPDATE);
+        assertThat(notification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(notification.getDeviceId()).isEqualTo(DEVICE_ID);
+        assertThat(notification.getCreationTime()).isEqualTo(CREATION_TIME);
+        assertThat(notification.isEnabled()).isEqualTo(ENABLED);
+    }
+
+    /**
+     * Verifies that the expected notification is created by {@link NotificationFactory#deviceDeleted(String, String)}.
+     */
+    @Test
+    public void testDeviceDeleted() {
+        final DeviceChangeNotification notification = new NotificationFactory(clock).deviceDeleted(TENANT_ID,
+                DEVICE_ID);
+
+        assertThat(notification.getChange()).isEqualTo(LifecycleChange.DELETE);
+        assertThat(notification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(notification.getDeviceId()).isEqualTo(DEVICE_ID);
+        assertThat(notification.getCreationTime()).isEqualTo(CREATION_TIME);
+    }
+
+    /**
+     * Verifies that the expected notification is created by
+     * {@link NotificationFactory#credentialsChanged(String, String)}.
+     */
+    @Test
+    public void testCredentialsChanged() {
+        final CredentialsChangeNotification notification = new NotificationFactory(clock).credentialsChanged(TENANT_ID,
+                DEVICE_ID);
+
+        assertThat(notification.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(notification.getDeviceId()).isEqualTo(DEVICE_ID);
+        assertThat(notification.getCreationTime()).isEqualTo(CREATION_TIME);
+    }
+
+}

--- a/test-utils/kafka-test-utils/src/main/java/org/eclipse/hono/kafka/test/KafkaClientUnitTestHelper.java
+++ b/test-utils/kafka-test-utils/src/main/java/org/eclipse/hono/kafka/test/KafkaClientUnitTestHelper.java
@@ -45,15 +45,16 @@ public class KafkaClientUnitTestHelper {
      * Returns a new {@link KafkaProducer}.
      *
      * @param producer The mock producer to wrap.
+     * @param <K> The type of the key.
+     * @param <V> The type of the value.
      * @return The new Kafka producer.
      */
-    public static KafkaProducer<String, Buffer> newKafkaProducer(final MockProducer<String, Buffer> producer) {
+    public static <K, V> KafkaProducer<K, V> newKafkaProducer(final MockProducer<K, V> producer) {
 
         final VertxInternal vertxMock = mock(VertxInternal.class);
         final ContextInternal context = VertxMockSupport.mockContextInternal(vertxMock);
-        doAnswer(invocation -> {
-            return Promise.promise();
-        }).when(context).promise();
+        doAnswer(invocation -> Promise.promise())
+                .when(context).promise();
 
         doAnswer(invocation -> {
             final Promise<RecordMetadata> result = Promise.promise();
@@ -70,7 +71,7 @@ public class KafkaClientUnitTestHelper {
      * Returns a new {@link MockProducer}.
      *
      * @param autoComplete If true, the producer automatically completes all requests successfully and executes the
-     *            callback. Otherwise the {@link MockProducer#completeNext()} or
+     *            callback. Otherwise, the {@link MockProducer#completeNext()} or
      *            {@link MockProducer#errorNext(RuntimeException)} must be invoked after sending a message.
      * @return The new mock producer.
      */

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -993,7 +993,7 @@ public final class IntegrationTestSupport {
             final Promise<Void> adminClientClosedPromise = Promise.promise();
             LOGGER.debug("deleting topics for temporary tenants {}", tenantsToDeleteTopicsForNow);
             final List<String> topicNames = tenantsToDeleteTopicsForNow.stream()
-                    .flatMap(tenant -> HonoTopic.Type.TENANT_RELATED_TYPES.stream()
+                    .flatMap(tenant -> HonoTopic.Type.MESSAGING_API_TYPES.stream()
                             .map(type -> new HonoTopic(type, tenant).toString()))
                     .collect(Collectors.toList());
             adminClient.deleteTopics(topicNames, ar -> {


### PR DESCRIPTION
This comes from the discussion in #2905. It contains:

- a Notification API for the Device Registry
- client implementations of the Device Registry Notification API for Kafka

The would put the AMQP based notification receiver in the existing module _hono-client-registry-amqp_.

This is an alternative to #2917.