### PR TITLE
Refactor Kafka configuration properties.

### DIFF
--- a/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
+++ b/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
@@ -52,14 +52,14 @@ import org.eclipse.hono.client.command.kafka.KafkaBasedCommandResponseSender;
 import org.eclipse.hono.client.command.kafka.KafkaBasedInternalCommandConsumer;
 import org.eclipse.hono.client.kafka.KafkaAdminClientConfigProperties;
 import org.eclipse.hono.client.kafka.KafkaClientOptions;
-import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.MessagingKafkaConsumerConfigProperties;
 import org.eclipse.hono.client.kafka.metrics.KafkaClientMetricsSupport;
 import org.eclipse.hono.client.kafka.metrics.KafkaMetricsOptions;
 import org.eclipse.hono.client.kafka.metrics.MicrometerKafkaClientMetricsSupport;
 import org.eclipse.hono.client.kafka.metrics.NoopKafkaClientMetricsSupport;
 import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.client.registry.CredentialsClient;
 import org.eclipse.hono.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.client.registry.TenantClient;
@@ -131,8 +131,8 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
     private PrometheusBasedResourceLimitChecksConfig resourceLimitChecksConfig;
     private ConnectionEventProducerConfig connectionEventsConfig;
 
-    private KafkaProducerConfigProperties kafkaProducerConfig;
-    private KafkaConsumerConfigProperties kafkaConsumerConfig;
+    private MessagingKafkaProducerConfigProperties kafkaProducerConfig;
+    private MessagingKafkaConsumerConfigProperties kafkaConsumerConfig;
     private KafkaAdminClientConfigProperties kafkaAdminClientConfig;
 
     private Cache<Object, TenantResult<TenantObject>> tenantResponseCache;
@@ -222,11 +222,11 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
 
     @Inject
     void setKafkaClientOptions(final KafkaClientOptions options) {
-        this.kafkaProducerConfig = new KafkaProducerConfigProperties();
+        this.kafkaProducerConfig = new MessagingKafkaProducerConfigProperties();
         this.kafkaProducerConfig.setCommonClientConfig(options.commonClientConfig());
         this.kafkaProducerConfig.setProducerConfig(options.producerConfig());
 
-        this.kafkaConsumerConfig = new KafkaConsumerConfigProperties();
+        this.kafkaConsumerConfig = new MessagingKafkaConsumerConfigProperties();
         this.kafkaConsumerConfig.setCommonClientConfig(options.commonClientConfig());
         this.kafkaConsumerConfig.setConsumerConfig(options.consumerConfig());
 

--- a/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractAdapterConfig.java
+++ b/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractAdapterConfig.java
@@ -45,7 +45,7 @@ import org.eclipse.hono.client.command.amqp.ProtonBasedDeviceConnectionClient;
 import org.eclipse.hono.client.command.amqp.ProtonBasedInternalCommandConsumer;
 import org.eclipse.hono.client.command.kafka.KafkaBasedInternalCommandConsumer;
 import org.eclipse.hono.client.kafka.KafkaAdminClientConfigProperties;
-import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.MessagingKafkaConsumerConfigProperties;
 import org.eclipse.hono.client.kafka.metrics.KafkaClientMetricsSupport;
 import org.eclipse.hono.client.kafka.metrics.KafkaMetricsConfig;
 import org.eclipse.hono.client.kafka.metrics.MicrometerKafkaClientMetricsSupport;
@@ -130,7 +130,7 @@ public abstract class AbstractAdapterConfig extends AbstractMessagingClientConfi
         Objects.requireNonNull(samplerFactory);
 
         final KafkaAdminClientConfigProperties kafkaAdminClientConfig = kafkaAdminClientConfig();
-        final KafkaConsumerConfigProperties kafkaConsumerConfig = kafkaConsumerConfig();
+        final MessagingKafkaConsumerConfigProperties kafkaConsumerConfig = messagingKafkaConsumerConfig();
         final KafkaClientMetricsSupport kafkaClientMetricsSupport = kafkaClientMetricsSupport(kafkaMetricsConfig());
         final MessagingClientProviders messagingClientProviders = messagingClientProviders(samplerFactory, getTracer(),
                 vertx(), adapterProperties, kafkaClientMetricsSupport);

--- a/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractMessagingClientConfig.java
+++ b/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractMessagingClientConfig.java
@@ -21,11 +21,11 @@ import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.command.CommandResponseSender;
 import org.eclipse.hono.client.command.amqp.ProtonBasedCommandResponseSender;
 import org.eclipse.hono.client.command.kafka.KafkaBasedCommandResponseSender;
-import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.MessagingKafkaConsumerConfigProperties;
 import org.eclipse.hono.client.kafka.metrics.KafkaClientMetricsSupport;
 import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.client.telemetry.EventSender;
 import org.eclipse.hono.client.telemetry.TelemetrySender;
 import org.eclipse.hono.client.telemetry.amqp.ProtonBasedDownstreamSender;
@@ -78,9 +78,9 @@ public abstract class AbstractMessagingClientConfig implements ComponentNameProv
         final MessagingClientProvider<EventSender> eventSenderProvider = new MessagingClientProvider<>();
         final MessagingClientProvider<CommandResponseSender> commandResponseSenderProvider = new MessagingClientProvider<>();
 
-        if (kafkaProducerConfig().isConfigured()) {
+        if (messagingKafkaProducerConfig().isConfigured()) {
             log.info("Kafka Producer is configured, adding Kafka messaging clients");
-            final KafkaProducerConfigProperties producerConfig = kafkaProducerConfig();
+            final MessagingKafkaProducerConfigProperties producerConfig = messagingKafkaProducerConfig();
             final KafkaProducerFactory<String, Buffer> factory = CachingKafkaProducerFactory.sharedFactory(vertx);
             factory.setMetricsSupport(kafkaClientMetricsSupport);
 
@@ -122,8 +122,8 @@ public abstract class AbstractMessagingClientConfig implements ComponentNameProv
      */
     @ConfigurationProperties(prefix = "hono.kafka")
     @Bean
-    public KafkaProducerConfigProperties kafkaProducerConfig() {
-        final KafkaProducerConfigProperties configProperties = new KafkaProducerConfigProperties();
+    public MessagingKafkaProducerConfigProperties messagingKafkaProducerConfig() {
+        final MessagingKafkaProducerConfigProperties configProperties = new MessagingKafkaProducerConfigProperties();
         if (getComponentName() != null) {
             configProperties.setDefaultClientIdPrefix(getComponentName());
         }
@@ -137,8 +137,8 @@ public abstract class AbstractMessagingClientConfig implements ComponentNameProv
      */
     @ConfigurationProperties(prefix = "hono.kafka")
     @Bean
-    public KafkaConsumerConfigProperties kafkaConsumerConfig() {
-        final KafkaConsumerConfigProperties configProperties = new KafkaConsumerConfigProperties();
+    public MessagingKafkaConsumerConfigProperties messagingKafkaConsumerConfig() {
+        final MessagingKafkaConsumerConfigProperties configProperties = new MessagingKafkaConsumerConfigProperties();
         if (getComponentName() != null) {
             configProperties.setDefaultClientIdPrefix(getComponentName());
         }

--- a/cli/src/main/java/org/eclipse/hono/cli/AppConfiguration.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/AppConfiguration.java
@@ -19,10 +19,10 @@ import org.eclipse.hono.application.client.amqp.ProtonBasedApplicationClient;
 import org.eclipse.hono.application.client.kafka.KafkaMessageContext;
 import org.eclipse.hono.application.client.kafka.impl.KafkaApplicationClientImpl;
 import org.eclipse.hono.client.HonoConnection;
-import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.MessagingKafkaConsumerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -85,8 +85,8 @@ public class AppConfiguration {
     @ConfigurationProperties(prefix = "hono.kafka")
     @Profile("kafka")
     @Bean
-    public KafkaConsumerConfigProperties honoKafkaClientConfig() {
-        return new KafkaConsumerConfigProperties();
+    public MessagingKafkaConsumerConfigProperties messagingKafkaClientConfig() {
+        return new MessagingKafkaConsumerConfigProperties();
     }
 
     /**
@@ -97,8 +97,8 @@ public class AppConfiguration {
     @ConfigurationProperties(prefix = "hono.kafka")
     @Profile("kafka")
     @Bean
-    public KafkaProducerConfigProperties kafkaProducerConfig() {
-        return new KafkaProducerConfigProperties();
+    public MessagingKafkaProducerConfigProperties messagingKafkaProducerConfig() {
+        return new MessagingKafkaProducerConfigProperties();
     }
 
     /**
@@ -139,9 +139,9 @@ public class AppConfiguration {
     @Bean
     public ApplicationClient<KafkaMessageContext> kafkaApplicationClient(
             final Vertx vertx,
-            final KafkaConsumerConfigProperties kafkaConsumerConfigProperties,
+            final MessagingKafkaConsumerConfigProperties kafkaConsumerConfigProperties,
             final KafkaProducerFactory<String, Buffer> producerFactory,
-            final KafkaProducerConfigProperties kafkaProducerConfigProperties) {
+            final MessagingKafkaProducerConfigProperties kafkaProducerConfigProperties) {
         return new KafkaApplicationClientImpl(vertx, kafkaConsumerConfigProperties, producerFactory,
                 kafkaProducerConfigProperties);
     }

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaApplicationClientImpl.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaApplicationClientImpl.java
@@ -28,9 +28,9 @@ import org.eclipse.hono.application.client.kafka.KafkaApplicationClient;
 import org.eclipse.hono.application.client.kafka.KafkaMessageContext;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.consumer.HonoKafkaConsumer;
-import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.MessagingKafkaConsumerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopTracerFactory;
@@ -48,7 +48,7 @@ import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 public class KafkaApplicationClientImpl extends KafkaBasedCommandSender implements KafkaApplicationClient {
 
     private final Vertx vertx;
-    private final KafkaConsumerConfigProperties consumerConfig;
+    private final MessagingKafkaConsumerConfigProperties consumerConfig;
     private final List<MessageConsumer> consumersToCloseOnStop = new LinkedList<>();
     private Supplier<Consumer<String, Buffer>> kafkaConsumerSupplier;
 
@@ -65,9 +65,9 @@ public class KafkaApplicationClientImpl extends KafkaBasedCommandSender implemen
      */
     public KafkaApplicationClientImpl(
             final Vertx vertx,
-            final KafkaConsumerConfigProperties consumerConfig,
+            final MessagingKafkaConsumerConfigProperties consumerConfig,
             final KafkaProducerFactory<String, Buffer> producerFactory,
-            final KafkaProducerConfigProperties producerConfig) {
+            final MessagingKafkaProducerConfigProperties producerConfig) {
         this(vertx, consumerConfig, producerFactory, producerConfig, NoopTracerFactory.create());
     }
 
@@ -85,9 +85,9 @@ public class KafkaApplicationClientImpl extends KafkaBasedCommandSender implemen
      */
     public KafkaApplicationClientImpl(
             final Vertx vertx,
-            final KafkaConsumerConfigProperties consumerConfig,
+            final MessagingKafkaConsumerConfigProperties consumerConfig,
             final KafkaProducerFactory<String, Buffer> producerFactory,
-            final KafkaProducerConfigProperties producerConfig,
+            final MessagingKafkaProducerConfigProperties producerConfig,
             final Tracer tracer) {
         super(vertx, consumerConfig, producerFactory, producerConfig, tracer);
 

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
@@ -36,10 +36,10 @@ import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaRecordHelper;
 import org.eclipse.hono.client.kafka.consumer.HonoKafkaConsumer;
-import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.MessagingKafkaConsumerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.AbstractKafkaBasedMessageSender;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.MessageHelper;
 import org.slf4j.Logger;
@@ -70,7 +70,7 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
     private static final long DEFAULT_COMMAND_TIMEOUT_IN_MS = 10000;
 
     private final Vertx vertx;
-    private final KafkaConsumerConfigProperties consumerConfig;
+    private final MessagingKafkaConsumerConfigProperties consumerConfig;
     /**
      * Key is the tenant identifier, value the corresponding consumer for receiving the command responses.
      */
@@ -97,9 +97,9 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
      */
     public KafkaBasedCommandSender(
             final Vertx vertx,
-            final KafkaConsumerConfigProperties consumerConfig,
+            final MessagingKafkaConsumerConfigProperties consumerConfig,
             final KafkaProducerFactory<String, Buffer> producerFactory,
-            final KafkaProducerConfigProperties producerConfig,
+            final MessagingKafkaProducerConfigProperties producerConfig,
             final Tracer tracer) {
         super(producerFactory, "command-sender", producerConfig, tracer);
         this.vertx = Objects.requireNonNull(vertx);

--- a/clients/application-kafka/src/test/java/org/eclipse/hono/application/client/kafka/impl/KafkaApplicationClientImplTest.java
+++ b/clients/application-kafka/src/test/java/org/eclipse/hono/application/client/kafka/impl/KafkaApplicationClientImplTest.java
@@ -29,9 +29,9 @@ import org.eclipse.hono.application.client.kafka.KafkaMessageContext;
 import org.eclipse.hono.client.kafka.AbstractKafkaConfigProperties;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.HonoTopic.Type;
-import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.MessagingKafkaConsumerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.kafka.test.KafkaClientUnitTestHelper;
 import org.eclipse.hono.kafka.test.KafkaMockConsumer;
 import org.junit.jupiter.api.AfterEach;
@@ -83,10 +83,10 @@ public class KafkaApplicationClientImplTest {
 
         mockConsumer = new KafkaMockConsumer(OffsetResetStrategy.EARLIEST);
 
-        final KafkaConsumerConfigProperties consumerConfig = new KafkaConsumerConfigProperties();
+        final MessagingKafkaConsumerConfigProperties consumerConfig = new MessagingKafkaConsumerConfigProperties();
         consumerConfig.setCommonClientConfig(Map.of(AbstractKafkaConfigProperties.PROPERTY_BOOTSTRAP_SERVERS, "kafka"));
         consumerConfig.setConsumerConfig(Map.of("client.id", "application-test-consumer"));
-        final KafkaProducerConfigProperties producerConfig = new KafkaProducerConfigProperties();
+        final MessagingKafkaProducerConfigProperties producerConfig = new MessagingKafkaProducerConfigProperties();
         producerConfig.setCommonClientConfig(Map.of(AbstractKafkaConfigProperties.PROPERTY_BOOTSTRAP_SERVERS, "kafka"));
         producerConfig.setProducerConfig(Map.of("client.id", "application-test-sender"));
 

--- a/clients/application-kafka/src/test/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSenderTest.java
+++ b/clients/application-kafka/src/test/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSenderTest.java
@@ -40,9 +40,9 @@ import org.eclipse.hono.application.client.kafka.KafkaMessageContext;
 import org.eclipse.hono.client.SendMessageTimeoutException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.kafka.HonoTopic;
-import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.MessagingKafkaConsumerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.kafka.test.KafkaClientUnitTestHelper;
 import org.eclipse.hono.kafka.test.KafkaMockConsumer;
 import org.eclipse.hono.util.MessageHelper;
@@ -76,8 +76,8 @@ public class KafkaBasedCommandSenderTest {
     private static final Logger LOG = LoggerFactory.getLogger(KafkaBasedCommandSenderTest.class);
 
     private KafkaBasedCommandSender commandSender;
-    private KafkaConsumerConfigProperties consumerConfig;
-    private KafkaProducerConfigProperties producerConfig;
+    private MessagingKafkaConsumerConfigProperties consumerConfig;
+    private MessagingKafkaProducerConfigProperties producerConfig;
     private MockProducer<String, Buffer> mockProducer;
     private KafkaMockConsumer mockConsumer;
     private String tenantId;
@@ -93,9 +93,9 @@ public class KafkaBasedCommandSenderTest {
     @BeforeEach
     void setUp(final Vertx vertx) {
         this.vertx = vertx;
-        consumerConfig = new KafkaConsumerConfigProperties();
+        consumerConfig = new MessagingKafkaConsumerConfigProperties();
         mockConsumer = new KafkaMockConsumer(OffsetResetStrategy.LATEST);
-        producerConfig = new KafkaProducerConfigProperties();
+        producerConfig = new MessagingKafkaProducerConfigProperties();
         producerConfig.setProducerConfig(Map.of("client.id", "application-test-sender"));
 
         mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSender.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSender.java
@@ -21,8 +21,8 @@ import org.eclipse.hono.client.command.CommandResponseSender;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaRecordHelper;
 import org.eclipse.hono.client.kafka.producer.AbstractKafkaBasedMessageSender;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MessageHelper;
 
@@ -50,7 +50,7 @@ public class KafkaBasedCommandResponseSender extends AbstractKafkaBasedMessageSe
      */
     public KafkaBasedCommandResponseSender(
             final KafkaProducerFactory<String, Buffer> producerFactory,
-            final KafkaProducerConfigProperties producerConfig,
+            final MessagingKafkaProducerConfigProperties producerConfig,
             final Tracer tracer) {
         super(producerFactory, CommandConstants.COMMAND_RESPONSE_ENDPOINT, producerConfig, tracer);
     }

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumer.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumer.java
@@ -33,7 +33,7 @@ import org.eclipse.hono.client.command.CommandResponseSender;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaAdminClientConfigProperties;
 import org.eclipse.hono.client.kafka.KafkaRecordHelper;
-import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.MessagingKafkaConsumerConfigProperties;
 import org.eclipse.hono.client.kafka.metrics.KafkaClientMetricsSupport;
 import org.eclipse.hono.client.kafka.tracing.KafkaTracingHelper;
 import org.eclipse.hono.tracing.TracingHelper;
@@ -97,7 +97,7 @@ public class KafkaBasedInternalCommandConsumer implements Lifecycle {
     public KafkaBasedInternalCommandConsumer(
             final Vertx vertx,
             final KafkaAdminClientConfigProperties adminClientConfigProperties,
-            final KafkaConsumerConfigProperties consumerConfigProperties,
+            final MessagingKafkaConsumerConfigProperties consumerConfigProperties,
             final CommandResponseSender commandResponseSender,
             final String adapterInstanceId,
             final CommandHandlers commandHandlers,

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandSender.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandSender.java
@@ -25,8 +25,8 @@ import org.eclipse.hono.client.command.InternalCommandSender;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaRecordHelper;
 import org.eclipse.hono.client.kafka.producer.AbstractKafkaBasedMessageSender;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.util.MessageHelper;
 
 import io.opentracing.Tracer;
@@ -50,7 +50,7 @@ public class KafkaBasedInternalCommandSender extends AbstractKafkaBasedMessageSe
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     public KafkaBasedInternalCommandSender(final KafkaProducerFactory<String, Buffer> producerFactory,
-            final KafkaProducerConfigProperties producerConfig, final Tracer tracer) {
+            final MessagingKafkaProducerConfigProperties producerConfig, final Tracer tracer) {
         super(producerFactory, "internal-cmd-sender", producerConfig, tracer);
     }
 

--- a/clients/command-kafka/src/test/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSenderTest.java
+++ b/clients/command-kafka/src/test/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSenderTest.java
@@ -26,7 +26,7 @@ import org.eclipse.hono.client.command.CommandResponse;
 import org.eclipse.hono.client.command.Commands;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.kafka.test.KafkaClientUnitTestHelper;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MessageHelper;
@@ -49,14 +49,14 @@ import io.vertx.junit5.VertxTestContext;
 @ExtendWith(VertxExtension.class)
 public class KafkaBasedCommandResponseSenderTest {
     private final Tracer tracer = NoopTracerFactory.create();
-    private KafkaProducerConfigProperties kafkaProducerConfig;
+    private MessagingKafkaProducerConfigProperties kafkaProducerConfig;
 
     /**
      * Sets up the fixture.
      */
     @BeforeEach
     public void setUp() {
-        kafkaProducerConfig = new KafkaProducerConfigProperties();
+        kafkaProducerConfig = new MessagingKafkaProducerConfigProperties();
         kafkaProducerConfig.setProducerConfig(new HashMap<>());
     }
 

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaAdminClientConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaAdminClientConfigProperties.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.hono.client.kafka;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -73,11 +72,11 @@ public class KafkaAdminClientConfigProperties extends AbstractKafkaConfigPropert
     public final Map<String, String> getAdminClientConfig(final String adminClientName) {
         Objects.requireNonNull(adminClientName);
 
+        final Map<String, String> newConfig = new HashMap<>();
         if (commonClientConfig == null && adminClientConfig == null) {
-            return Collections.emptyMap();
+            return newConfig;
         }
 
-        final Map<String, String> newConfig = new HashMap<>();
         if (commonClientConfig != null) {
             newConfig.putAll(commonClientConfig);
         }

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/KafkaConsumerConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/KafkaConsumerConfigProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,8 +16,10 @@ package org.eclipse.hono.client.kafka.consumer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.Deserializer;
 import org.eclipse.hono.client.kafka.AbstractKafkaConfigProperties;
 
 /**
@@ -25,11 +27,6 @@ import org.eclipse.hono.client.kafka.AbstractKafkaConfigProperties;
  * <p>
  * This class is intended to be as agnostic to the provided properties as possible in order to be forward-compatible
  * with changes in new versions of the Kafka client.
- *
- * @see <a href="https://kafka.apache.org/documentation/#consumerconfigs">Kafka Consumer Configs</a>
- * @see <a href="https://www.eclipse.org/hono/docs/api/telemetry-kafka">Telemetry API for Kafka Specification</a>
- * @see <a href="https://www.eclipse.org/hono/docs/api/event-kafka">Event API for Kafka Specification</a>
- * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control-kafka/">Command &amp; Control API for Kafka Specification</a>
  */
 public class KafkaConsumerConfigProperties extends AbstractKafkaConfigProperties {
 
@@ -38,8 +35,26 @@ public class KafkaConsumerConfigProperties extends AbstractKafkaConfigProperties
      */
     public static final long DEFAULT_POLL_TIMEOUT = 100L; // ms
 
+    private final Class<? extends Deserializer<?>> keyDeserializerClass;
+    private final Class<? extends Deserializer<?>> valueDeserializerClass;
+
     private Map<String, String> consumerConfig;
     private long pollTimeout = DEFAULT_POLL_TIMEOUT;
+
+    /**
+     * Creates an instance.
+     *
+     * @param keyDeserializerClass The class to be used for deserializing the record keys, if {@code null} the
+     *            deserializer needs to be provided in the configuration at runtime.
+     * @param valueDeserializerClass The class to be used for deserializing the record values, if {@code null} the
+     *            deserializer needs to be provided in the configuration at runtime.
+     */
+    protected KafkaConsumerConfigProperties(final Class<? extends Deserializer<?>> keyDeserializerClass,
+            final Class<? extends Deserializer<?>> valueDeserializerClass) {
+
+        this.keyDeserializerClass = keyDeserializerClass;
+        this.valueDeserializerClass = valueDeserializerClass;
+    }
 
     /**
      * Sets the Kafka consumer config properties to be used.
@@ -54,40 +69,35 @@ public class KafkaConsumerConfigProperties extends AbstractKafkaConfigProperties
     /**
      * Checks if a configuration has been set.
      *
-     * @return {@code true} if the {@value #PROPERTY_BOOTSTRAP_SERVERS} property has been configured with a non-null value.
+     * @return {@code true} if the {@value #PROPERTY_BOOTSTRAP_SERVERS} property has been configured with a non-null
+     *         value.
      */
     public final boolean isConfigured() {
         return containsMinimalConfiguration(commonClientConfig) || containsMinimalConfiguration(consumerConfig);
     }
 
     /**
-     * Gets the Kafka consumer configuration to which additional properties were applied. The following properties are
-     * set here to the given configuration:
-     * <ul>
-     * <li>{@code key.deserializer=org.apache.kafka.common.serialization.StringDeserializer}: defines how message keys
-     * are deserialized</li>
-     * <li>{@code value.deserializer=io.vertx.kafka.client.serialization.BufferDeserializer}: defines how message values
-     * are deserialized</li>
-     * <li>{@code client.id}=${unique client id}: the client id will be set to a unique value containing the already set
-     * client id or alternatively the value set via {@link #setDefaultClientIdPrefix(String)}, the given consumerName
-     * and a newly created UUID.</li>
-     * </ul>
+     * Gets the Kafka consumer configuration. This includes changes made in {@link #adaptConfiguration(Map)}. The
+     * returned map will contain a property {@code client.id} which will be set to a unique value containing the already
+     * set client id or alternatively the value set via {@link #setDefaultClientIdPrefix(String)}, the given
+     * consumerName and a newly created UUID.
+     *
      * Note: This method should be called for each new consumer, ensuring that a unique client id is used.
      *
      * @param consumerName A name for the consumer to include in the added {@code client.id} property.
      * @return a copy of the consumer configuration with the applied properties or an empty map if neither a consumer
-     *         client configuration was set with {@link #setConsumerConfig(Map)} nor common configuration properties were
-     *         set with {@link #setCommonClientConfig(Map)}.
+     *         client configuration was set with {@link #setConsumerConfig(Map)} nor common configuration properties
+     *         were set with {@link #setCommonClientConfig(Map)}.
      * @throws NullPointerException if consumerName is {@code null}.
      */
     public final Map<String, String> getConsumerConfig(final String consumerName) {
         Objects.requireNonNull(consumerName);
 
+        final Map<String, String> newConfig = new HashMap<>();
         if (commonClientConfig == null && consumerConfig == null) {
-            return new HashMap<>();
+            return newConfig;
         }
 
-        final Map<String, String> newConfig = new HashMap<>();
         if (commonClientConfig != null) {
             newConfig.putAll(commonClientConfig);
         }
@@ -95,20 +105,35 @@ public class KafkaConsumerConfigProperties extends AbstractKafkaConfigProperties
             newConfig.putAll(consumerConfig);
         }
 
-        overrideConfigProperty(newConfig, ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
-                "org.apache.kafka.common.serialization.StringDeserializer");
+        adaptConfiguration(newConfig);
 
-        overrideConfigProperty(newConfig, ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
-                "io.vertx.kafka.client.serialization.BufferDeserializer");
+        Optional.ofNullable(keyDeserializerClass).ifPresent(serializerClass -> overrideConfigProperty(newConfig,
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, serializerClass.getName()));
+
+        Optional.ofNullable(valueDeserializerClass).ifPresent(serializerClass -> overrideConfigProperty(newConfig,
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, serializerClass.getName()));
 
         setUniqueClientId(newConfig, consumerName, ConsumerConfig.CLIENT_ID_CONFIG);
         return newConfig;
     }
 
     /**
+     * Adapt the properties. It is invoked by {@link #getConsumerConfig(String)} on the result of applying the consumer
+     * configuration on the common configuration.
+     * <p>
+     * Subclasses may overwrite this method to set expected configuration values. The default implementation does
+     * nothing.
+     *
+     * @param config The consumer configuration to be adapted.
+     */
+    protected void adaptConfiguration(final Map<String, String> config) {
+
+    }
+
+    /**
      * Sets the timeout for polling records.
      * <p>
-     * The default value of this property is {@link #DEFAULT_POLL_TIMEOUT}.
+     * The default value of this property is {@value #DEFAULT_POLL_TIMEOUT}.
      *
      * @param pollTimeoutMillis The maximum number of milliseconds to wait.
      * @throws IllegalArgumentException if poll timeout is negative.
@@ -124,12 +149,11 @@ public class KafkaConsumerConfigProperties extends AbstractKafkaConfigProperties
     /**
      * Gets the timeout for polling records.
      * <p>
-     * The default value of this property is {@link #DEFAULT_POLL_TIMEOUT}.
+     * The default value of this property is {@value #DEFAULT_POLL_TIMEOUT}.
      *
      * @return The maximum number of milliseconds to wait.
      */
     public final long getPollTimeout() {
         return pollTimeout;
     }
-
 }

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/MessagingKafkaConsumerConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/MessagingKafkaConsumerConfigProperties.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka.consumer;
+
+import org.apache.kafka.common.serialization.StringDeserializer;
+
+import io.vertx.kafka.client.serialization.BufferDeserializer;
+
+/**
+ * Configuration properties for Kafka consumers used for Hono's messaging.
+ *
+ * Record keys will be deserialized with {@link StringDeserializer}, the values with {@link BufferDeserializer}.
+ *
+ * @see <a href="https://kafka.apache.org/documentation/#consumerconfigs">Kafka Consumer Configs</a>
+ * @see <a href="https://www.eclipse.org/hono/docs/api/telemetry-kafka">Telemetry API for Kafka Specification</a>
+ * @see <a href="https://www.eclipse.org/hono/docs/api/event-kafka">Event API for Kafka Specification</a>
+ * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control-kafka/">Command &amp; Control API for Kafka Specification</a>
+ */
+public class MessagingKafkaConsumerConfigProperties extends KafkaConsumerConfigProperties {
+
+    /**
+     * Creates an instance.
+     */
+    public MessagingKafkaConsumerConfigProperties() {
+        super(StringDeserializer.class, BufferDeserializer.class);
+    }
+
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/AbstractKafkaBasedMessageSender.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/AbstractKafkaBasedMessageSender.java
@@ -59,7 +59,7 @@ public abstract class AbstractKafkaBasedMessageSender implements MessagingClient
     protected final Logger log = LoggerFactory.getLogger(getClass());
     protected final Tracer tracer;
 
-    private final KafkaProducerConfigProperties config;
+    private final MessagingKafkaProducerConfigProperties config;
     private final KafkaProducerFactory<String, Buffer> producerFactory;
     private final String producerName;
 
@@ -77,7 +77,7 @@ public abstract class AbstractKafkaBasedMessageSender implements MessagingClient
     public AbstractKafkaBasedMessageSender(
             final KafkaProducerFactory<String, Buffer> producerFactory,
             final String producerName,
-            final KafkaProducerConfigProperties config,
+            final MessagingKafkaProducerConfigProperties config,
             final Tracer tracer) {
         Objects.requireNonNull(producerFactory);
         Objects.requireNonNull(producerName);

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/CachingKafkaProducerFactory.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/CachingKafkaProducerFactory.java
@@ -152,7 +152,8 @@ public class CachingKafkaProducerFactory<K, V> implements KafkaProducerFactory<K
      * @return an existing or new producer.
      */
     @Override
-    public KafkaProducer<K, V> getOrCreateProducer(final String producerName, final KafkaProducerConfigProperties config) {
+    public KafkaProducer<K, V> getOrCreateProducer(final String producerName,
+            final KafkaProducerConfigProperties config) {
 
         final AtomicReference<KafkaProducer<K, V>> createdProducer = new AtomicReference<>();
         final KafkaProducer<K, V> kafkaProducer = activeProducers.computeIfAbsent(producerName, (name) -> {

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/MessagingKafkaProducerConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/MessagingKafkaProducerConfigProperties.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka.producer;
+
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+import io.vertx.kafka.client.serialization.BufferSerializer;
+
+/**
+ * Configuration properties for Kafka producers used for Hono's messaging.
+ *
+ * Record keys will be serialized with {@link StringSerializer}, the values with {@link BufferSerializer}.
+ *
+ * The properties that are required by Hono's messaging APIs are will be set in
+ * {@link MessagingKafkaProducerConfigProperties#adaptConfiguration(Map)}.
+ *
+ * @see <a href="https://kafka.apache.org/documentation/#producerconfigs">Kafka Producer Configs</a>
+ * @see <a href="https://www.eclipse.org/hono/docs/api/telemetry-kafka">Telemetry API for Kafka Specification</a>
+ * @see <a href="https://www.eclipse.org/hono/docs/api/event-kafka">Event API for Kafka Specification</a>
+ * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control-kafka/">Command &amp; Control API for Kafka Specification</a>
+ */
+public class MessagingKafkaProducerConfigProperties extends KafkaProducerConfigProperties {
+
+    /**
+     * Creates an instance.
+     */
+    public MessagingKafkaProducerConfigProperties() {
+        super(StringSerializer.class, BufferSerializer.class);
+    }
+
+    /**
+     * Sets the required properties.
+     *
+     * The following properties are set here to the given configuration:
+     * <ul>
+     * <li>{@code enable.idempotence=true}: enables idempotent producer behavior</li>
+     * </ul>
+     *
+     * @see <a href="https://kafka.apache.org/documentation/#enable.idempotence">The Kafka documentation -
+     *      "Producer Configs" - enable.idempotence</a>
+     */
+    @Override
+    protected final void adaptConfiguration(final Map<String, String> config) {
+        overrideConfigProperty(config, ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
+    }
+
+}

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/AsyncHandlingAutoCommitKafkaConsumerTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/AsyncHandlingAutoCommitKafkaConsumerTest.java
@@ -80,7 +80,7 @@ public class AsyncHandlingAutoCommitKafkaConsumerTest {
     private static final TopicPartition TOPIC_PARTITION = new TopicPartition(TOPIC, PARTITION);
     private static final TopicPartition TOPIC2_PARTITION = new TopicPartition(TOPIC2, PARTITION);
 
-    private KafkaConsumerConfigProperties consumerConfigProperties;
+    private MessagingKafkaConsumerConfigProperties consumerConfigProperties;
     private Vertx vertx;
     private KafkaMockConsumer mockConsumer;
     private AsyncHandlingAutoCommitKafkaConsumer consumer;
@@ -97,7 +97,7 @@ public class AsyncHandlingAutoCommitKafkaConsumerTest {
         mockConsumer = new KafkaMockConsumer(OffsetResetStrategy.LATEST);
 
         final Map<String, String> commonProperties = Map.of(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "servers");
-        consumerConfigProperties = new KafkaConsumerConfigProperties();
+        consumerConfigProperties = new MessagingKafkaConsumerConfigProperties();
         consumerConfigProperties.setCommonClientConfig(commonProperties);
     }
 

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumerTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumerTest.java
@@ -68,7 +68,7 @@ public class HonoKafkaConsumerTest {
     private static final TopicPartition topic2Partition = new TopicPartition(TOPIC2, PARTITION);
     private static final TopicPartition topic3Partition = new TopicPartition(TOPIC3, PARTITION);
 
-    private KafkaConsumerConfigProperties consumerConfigProperties;
+    private MessagingKafkaConsumerConfigProperties consumerConfigProperties;
     private Vertx vertx;
     private HonoKafkaConsumer consumer;
     private KafkaMockConsumer mockConsumer;
@@ -85,7 +85,7 @@ public class HonoKafkaConsumerTest {
         mockConsumer = new KafkaMockConsumer(OffsetResetStrategy.LATEST);
 
         final Map<String, String> commonProperties = Map.of(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "servers");
-        consumerConfigProperties = new KafkaConsumerConfigProperties();
+        consumerConfigProperties = new MessagingKafkaConsumerConfigProperties();
         consumerConfigProperties.setCommonClientConfig(commonProperties);
     }
 

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/MessagingKafkaConsumerConfigPropertiesTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/MessagingKafkaConsumerConfigPropertiesTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka.consumer;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the behavior of {@link MessagingKafkaConsumerConfigProperties}.
+ */
+public class MessagingKafkaConsumerConfigPropertiesTest {
+
+
+    /**
+     * Verifies that properties returned in {@link MessagingKafkaConsumerConfigProperties#getConsumerConfig(String)} ()}
+     * contain the predefined entries, overriding any corresponding properties given in
+     * {@link MessagingKafkaConsumerConfigProperties#setConsumerConfig(Map)}.
+     */
+    @Test
+    public void testThatGetConsumerConfigReturnsAdaptedConfig() {
+
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("key.deserializer", "foo");
+        properties.put("value.deserializer", "bar");
+        properties.put("enable.idempotence", "baz");
+
+        final MessagingKafkaConsumerConfigProperties config = new MessagingKafkaConsumerConfigProperties();
+        config.setConsumerConfig(properties);
+
+        final Map<String, String> consumerConfig = config.getConsumerConfig("consumerName");
+
+        assertThat(consumerConfig.get("key.deserializer"))
+                .isEqualTo("org.apache.kafka.common.serialization.StringDeserializer");
+        assertThat(consumerConfig.get("value.deserializer"))
+                .isEqualTo("io.vertx.kafka.client.serialization.BufferDeserializer");
+    }
+
+}

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/producer/CachingKafkaProducerFactoryTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/producer/CachingKafkaProducerFactoryTest.java
@@ -52,7 +52,7 @@ public class CachingKafkaProducerFactoryTest {
 
     private static final String PRODUCER_NAME = "test-producer";
 
-    private final KafkaProducerConfigProperties configProperties = new KafkaProducerConfigProperties();
+    private final MessagingKafkaProducerConfigProperties configProperties = new MessagingKafkaProducerConfigProperties();
 
     private CachingKafkaProducerFactory<String, Buffer> factory;
 

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/producer/MessagingKafkaProducerConfigPropertiesTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/producer/MessagingKafkaProducerConfigPropertiesTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka.producer;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the behavior of {@link MessagingKafkaProducerConfigProperties}.
+ */
+public class MessagingKafkaProducerConfigPropertiesTest {
+
+    /**
+     * Verifies that properties returned in {@link MessagingKafkaProducerConfigProperties#getProducerConfig(String)} contain
+     * the predefined entries, overriding any corresponding properties given in {@link MessagingKafkaProducerConfigProperties#setProducerConfig(Map)}.
+     */
+    @Test
+    public void testThatGetProducerConfigReturnsAdaptedConfig() {
+
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("key.serializer", "foo");
+        properties.put("value.serializer", "bar");
+        properties.put("enable.idempotence", "baz");
+
+        final MessagingKafkaProducerConfigProperties config = new MessagingKafkaProducerConfigProperties();
+        config.setProducerConfig(properties);
+
+        final Map<String, String> producerConfig = config.getProducerConfig("producerName");
+
+        assertThat(producerConfig.get("key.serializer"))
+                .isEqualTo("org.apache.kafka.common.serialization.StringSerializer");
+        assertThat(producerConfig.get("value.serializer"))
+                .isEqualTo("io.vertx.kafka.client.serialization.BufferSerializer");
+        assertThat(producerConfig.get("enable.idempotence")).isEqualTo("true");
+    }
+
+}

--- a/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/KafkaBasedNotificationSender.java
+++ b/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/KafkaBasedNotificationSender.java
@@ -17,8 +17,8 @@ import java.net.HttpURLConnection;
 import java.util.Objects;
 
 import org.eclipse.hono.client.ServerErrorException;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.notification.AbstractNotification;
 import org.eclipse.hono.notification.NotificationSender;
 import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
@@ -37,7 +37,7 @@ import io.vertx.kafka.client.producer.RecordMetadata;
 public class KafkaBasedNotificationSender implements NotificationSender {
 
     public static final String PRODUCER_NAME = "notification";
-    private final KafkaProducerConfigProperties config;
+    private final MessagingKafkaProducerConfigProperties config;
     private final KafkaProducerFactory<String, JsonObject> producerFactory;
     private boolean stopped = false;
 
@@ -49,7 +49,7 @@ public class KafkaBasedNotificationSender implements NotificationSender {
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     public KafkaBasedNotificationSender(final KafkaProducerFactory<String, JsonObject> producerFactory,
-            final KafkaProducerConfigProperties kafkaProducerConfig) {
+            final MessagingKafkaProducerConfigProperties kafkaProducerConfig) {
         Objects.requireNonNull(producerFactory);
         Objects.requireNonNull(kafkaProducerConfig);
 

--- a/clients/notification-kafka/src/test/java/org/eclipse/hono/client/notification/KafkaBasedNotificationSenderTest.java
+++ b/clients/notification-kafka/src/test/java/org/eclipse/hono/client/notification/KafkaBasedNotificationSenderTest.java
@@ -24,8 +24,8 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.kafka.test.KafkaClientUnitTestHelper;
 import org.eclipse.hono.notification.AbstractNotification;
 import org.eclipse.hono.notification.NotificationConstants;
@@ -54,7 +54,7 @@ public class KafkaBasedNotificationSenderTest {
     private static final String DEVICE_ID = "my-device";
     private static final boolean ENABLED = false;
 
-    private final KafkaProducerConfigProperties config = new KafkaProducerConfigProperties();
+    private final MessagingKafkaProducerConfigProperties config = new MessagingKafkaProducerConfigProperties();
 
     /**
      * Sets up the fixture.

--- a/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/AbstractKafkaBasedDownstreamSender.java
+++ b/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/AbstractKafkaBasedDownstreamSender.java
@@ -20,8 +20,8 @@ import java.util.Optional;
 
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.producer.AbstractKafkaBasedMessageSender;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.RegistrationAssertion;
@@ -54,7 +54,7 @@ public abstract class AbstractKafkaBasedDownstreamSender extends AbstractKafkaBa
     public AbstractKafkaBasedDownstreamSender(
             final KafkaProducerFactory<String, Buffer> producerFactory,
             final String producerName,
-            final KafkaProducerConfigProperties config,
+            final MessagingKafkaProducerConfigProperties config,
             final boolean includeDefaults,
             final Tracer tracer) {
         super(producerFactory, producerName, config, tracer);

--- a/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/KafkaBasedEventSender.java
+++ b/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/KafkaBasedEventSender.java
@@ -17,8 +17,8 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.eclipse.hono.client.kafka.HonoTopic;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.client.telemetry.EventSender;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.QoS;
@@ -46,7 +46,7 @@ public class KafkaBasedEventSender extends AbstractKafkaBasedDownstreamSender im
      */
     public KafkaBasedEventSender(
             final KafkaProducerFactory<String, Buffer> producerFactory,
-            final KafkaProducerConfigProperties kafkaProducerConfig,
+            final MessagingKafkaProducerConfigProperties kafkaProducerConfig,
             final boolean includeDefaults,
             final Tracer tracer) {
 

--- a/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/KafkaBasedTelemetrySender.java
+++ b/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/KafkaBasedTelemetrySender.java
@@ -17,8 +17,8 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.eclipse.hono.client.kafka.HonoTopic;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.client.telemetry.TelemetrySender;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.RegistrationAssertion;
@@ -46,7 +46,7 @@ public class KafkaBasedTelemetrySender extends AbstractKafkaBasedDownstreamSende
      */
     public KafkaBasedTelemetrySender(
             final KafkaProducerFactory<String, Buffer> producerFactory,
-            final KafkaProducerConfigProperties kafkaProducerConfig,
+            final MessagingKafkaProducerConfigProperties kafkaProducerConfig,
             final boolean includeDefaults,
             final Tracer tracer) {
 

--- a/clients/telemetry-kafka/src/test/java/org/eclipse/hono/client/telemetry/kafka/AbstractKafkaBasedDownstreamSenderTest.java
+++ b/clients/telemetry-kafka/src/test/java/org/eclipse/hono/client/telemetry/kafka/AbstractKafkaBasedDownstreamSenderTest.java
@@ -28,7 +28,7 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.kafka.test.KafkaClientUnitTestHelper;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.QoS;
@@ -62,7 +62,7 @@ public class AbstractKafkaBasedDownstreamSenderTest {
     private static final String PRODUCER_NAME = "test-producer";
 
     protected final Tracer tracer = NoopTracerFactory.create();
-    private final KafkaProducerConfigProperties config = new KafkaProducerConfigProperties();
+    private final MessagingKafkaProducerConfigProperties config = new MessagingKafkaProducerConfigProperties();
     private final HonoTopic topic = new HonoTopic(HonoTopic.Type.EVENT, TENANT_ID);
     private final TenantObject tenant = new TenantObject(TENANT_ID, true);
     private final RegistrationAssertion device = new RegistrationAssertion(DEVICE_ID);

--- a/clients/telemetry-kafka/src/test/java/org/eclipse/hono/client/telemetry/kafka/KafkaBasedEventSenderTest.java
+++ b/clients/telemetry-kafka/src/test/java/org/eclipse/hono/client/telemetry/kafka/KafkaBasedEventSenderTest.java
@@ -23,7 +23,7 @@ import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.kafka.test.KafkaClientUnitTestHelper;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.RegistrationAssertion;
@@ -48,7 +48,7 @@ public class KafkaBasedEventSenderTest {
     private final RegistrationAssertion device = new RegistrationAssertion("the-device");
     private final Tracer tracer = NoopTracerFactory.create();
 
-    private KafkaProducerConfigProperties kafkaProducerConfig;
+    private MessagingKafkaProducerConfigProperties kafkaProducerConfig;
 
     /**
      * Sets up the fixture.
@@ -56,7 +56,7 @@ public class KafkaBasedEventSenderTest {
     @BeforeEach
     public void setUp() {
 
-        kafkaProducerConfig = new KafkaProducerConfigProperties();
+        kafkaProducerConfig = new MessagingKafkaProducerConfigProperties();
         kafkaProducerConfig.setProducerConfig(new HashMap<>());
 
     }

--- a/clients/telemetry-kafka/src/test/java/org/eclipse/hono/client/telemetry/kafka/KafkaBasedTelemetrySenderTest.java
+++ b/clients/telemetry-kafka/src/test/java/org/eclipse/hono/client/telemetry/kafka/KafkaBasedTelemetrySenderTest.java
@@ -23,7 +23,7 @@ import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.kafka.test.KafkaClientUnitTestHelper;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.RegistrationAssertion;
@@ -49,7 +49,7 @@ public class KafkaBasedTelemetrySenderTest {
     private final RegistrationAssertion device = new RegistrationAssertion("the-device");
     private final Tracer tracer = NoopTracerFactory.create();
 
-    private KafkaProducerConfigProperties kafkaProducerConfig;
+    private MessagingKafkaProducerConfigProperties kafkaProducerConfig;
 
     /**
      * Sets up the fixture.
@@ -57,7 +57,7 @@ public class KafkaBasedTelemetrySenderTest {
     @BeforeEach
     public void setUp() {
 
-        kafkaProducerConfig = new KafkaProducerConfigProperties();
+        kafkaProducerConfig = new MessagingKafkaProducerConfigProperties();
         kafkaProducerConfig.setProducerConfig(new HashMap<>());
 
     }

--- a/examples/hono-client-examples/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleApplicationBase.java
+++ b/examples/hono-client-examples/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleApplicationBase.java
@@ -29,10 +29,10 @@ import org.eclipse.hono.application.client.amqp.ProtonBasedApplicationClient;
 import org.eclipse.hono.application.client.kafka.impl.KafkaApplicationClientImpl;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ServiceInvocationException;
-import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.MessagingKafkaConsumerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.util.TimeUntilDisconnectNotification;
 import org.slf4j.Logger;
@@ -136,12 +136,12 @@ public class HonoExampleApplicationBase {
         // properties.put("ssl.truststore.location", "/path/to/file");
         // properties.put("ssl.truststore.password", "secret");
 
-        final KafkaConsumerConfigProperties consumerConfig = new KafkaConsumerConfigProperties();
+        final MessagingKafkaConsumerConfigProperties consumerConfig = new MessagingKafkaConsumerConfigProperties();
         consumerConfig.setCommonClientConfig(properties);
         consumerConfig.setDefaultClientIdPrefix(clientIdPrefix);
         consumerConfig.setConsumerConfig(Map.of("group.id", consumerGroupId));
 
-        final KafkaProducerConfigProperties producerConfig = new KafkaProducerConfigProperties();
+        final MessagingKafkaProducerConfigProperties producerConfig = new MessagingKafkaProducerConfigProperties();
         producerConfig.setCommonClientConfig(properties);
         producerConfig.setDefaultClientIdPrefix(clientIdPrefix);
 

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -22,10 +22,10 @@ import org.eclipse.hono.client.command.kafka.KafkaBasedCommandResponseSender;
 import org.eclipse.hono.client.command.kafka.KafkaBasedInternalCommandSender;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.consumer.AsyncHandlingAutoCommitKafkaConsumer;
-import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.MessagingKafkaConsumerConfigProperties;
 import org.eclipse.hono.client.kafka.metrics.KafkaClientMetricsSupport;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.client.registry.TenantClient;
 import org.eclipse.hono.commandrouter.CommandConsumerFactory;
 import org.eclipse.hono.commandrouter.CommandRouterMetrics;
@@ -66,7 +66,7 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
     private final Vertx vertx;
     private final TenantClient tenantClient;
     private final CommandTargetMapper commandTargetMapper;
-    private final KafkaConsumerConfigProperties kafkaConsumerConfig;
+    private final MessagingKafkaConsumerConfigProperties kafkaConsumerConfig;
     private final Tracer tracer;
     private final CommandRouterMetrics metrics;
     private final KafkaBasedInternalCommandSender internalCommandSender;
@@ -98,8 +98,8 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
             final TenantClient tenantClient,
             final CommandTargetMapper commandTargetMapper,
             final KafkaProducerFactory<String, Buffer> kafkaProducerFactory,
-            final KafkaProducerConfigProperties kafkaProducerConfig,
-            final KafkaConsumerConfigProperties kafkaConsumerConfig,
+            final MessagingKafkaProducerConfigProperties kafkaProducerConfig,
+            final MessagingKafkaConsumerConfigProperties kafkaConsumerConfig,
             final CommandRouterMetrics metrics,
             final KafkaClientMetricsSupport kafkaClientMetricsSupport,
             final Tracer tracer) {

--- a/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/quarkus/Application.java
+++ b/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/quarkus/Application.java
@@ -22,14 +22,14 @@ import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.kafka.KafkaClientOptions;
-import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.MessagingKafkaConsumerConfigProperties;
 import org.eclipse.hono.client.kafka.metrics.KafkaClientMetricsSupport;
 import org.eclipse.hono.client.kafka.metrics.KafkaMetricsOptions;
 import org.eclipse.hono.client.kafka.metrics.MicrometerKafkaClientMetricsSupport;
 import org.eclipse.hono.client.kafka.metrics.NoopKafkaClientMetricsSupport;
 import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.client.registry.TenantClient;
 import org.eclipse.hono.client.registry.amqp.ProtonBasedDeviceRegistrationClient;
@@ -123,8 +123,8 @@ public class Application extends AbstractServiceApplication {
     private RequestResponseClientConfigProperties deviceRegistrationClientConfig;
     private RequestResponseClientConfigProperties tenantClientConfig;
     private KafkaClientMetricsSupport kafkaClientMetricsSupport;
-    private KafkaProducerConfigProperties kafkaProducerConfig;
-    private KafkaConsumerConfigProperties kafkaConsumerConfig;
+    private MessagingKafkaProducerConfigProperties kafkaProducerConfig;
+    private MessagingKafkaConsumerConfigProperties kafkaConsumerConfig;
 
     private Cache<Object, RegistrationResult> registrationResponseCache;
     private Cache<Object, TenantResult<TenantObject>> tenantResponseCache;
@@ -177,12 +177,12 @@ public class Application extends AbstractServiceApplication {
 
     @Inject
     void setKafkaClientOptions(final KafkaClientOptions options) {
-        this.kafkaProducerConfig = new KafkaProducerConfigProperties();
+        this.kafkaProducerConfig = new MessagingKafkaProducerConfigProperties();
         this.kafkaProducerConfig.setCommonClientConfig(options.commonClientConfig());
         this.kafkaProducerConfig.setProducerConfig(options.producerConfig());
         this.kafkaProducerConfig.setDefaultClientIdPrefix(DEFAULT_CLIENT_ID_PREFIX);
 
-        this.kafkaConsumerConfig = new KafkaConsumerConfigProperties();
+        this.kafkaConsumerConfig = new MessagingKafkaConsumerConfigProperties();
         this.kafkaConsumerConfig.setCommonClientConfig(options.commonClientConfig());
         this.kafkaConsumerConfig.setConsumerConfig(options.consumerConfig());
         this.kafkaConsumerConfig.setDefaultClientIdPrefix(DEFAULT_CLIENT_ID_PREFIX);

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/spring/ApplicationConfig.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/spring/ApplicationConfig.java
@@ -18,14 +18,14 @@ import java.util.Optional;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.SendMessageSampler;
-import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.MessagingKafkaConsumerConfigProperties;
 import org.eclipse.hono.client.kafka.metrics.KafkaClientMetricsSupport;
 import org.eclipse.hono.client.kafka.metrics.KafkaMetricsConfig;
 import org.eclipse.hono.client.kafka.metrics.MicrometerKafkaClientMetricsSupport;
 import org.eclipse.hono.client.kafka.metrics.NoopKafkaClientMetricsSupport;
 import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.client.registry.TenantClient;
 import org.eclipse.hono.client.registry.amqp.ProtonBasedDeviceRegistrationClient;
@@ -252,7 +252,7 @@ public class ApplicationConfig {
 
         final CommandTargetMapper commandTargetMapper = CommandTargetMapper.create(registrationClient, deviceConnectionInfo, getTracer());
         final MessagingClientProvider<CommandConsumerFactory> commandConsumerFactoryProvider = new MessagingClientProvider<>();
-        if (kafkaProducerConfig().isConfigured() && kafkaConsumerConfig().isConfigured()) {
+        if (messagingKafkaProducerConfig().isConfigured() && messagingKafkaConsumerConfig().isConfigured()) {
             final KafkaClientMetricsSupport kafkaClientMetricsSupport = kafkaClientMetricsSupport(meterRegistry, kafkaMetricsConfig());
             final KafkaProducerFactory<String, Buffer> kafkaProducerFactory = kafkaProducerFactory(kafkaClientMetricsSupport);
             commandConsumerFactoryProvider.setClient(new KafkaBasedCommandConsumerFactoryImpl(
@@ -260,8 +260,8 @@ public class ApplicationConfig {
                     tenantClient,
                     commandTargetMapper,
                     kafkaProducerFactory,
-                    kafkaProducerConfig(),
-                    kafkaConsumerConfig(),
+                    messagingKafkaProducerConfig(),
+                    messagingKafkaConsumerConfig(),
                     metrics,
                     kafkaClientMetricsSupport,
                     getTracer()));
@@ -431,8 +431,8 @@ public class ApplicationConfig {
      */
     @ConfigurationProperties(prefix = "hono.kafka")
     @Bean
-    public KafkaConsumerConfigProperties kafkaConsumerConfig() {
-        final KafkaConsumerConfigProperties kafkaConsumerConfigProperties = new KafkaConsumerConfigProperties();
+    public MessagingKafkaConsumerConfigProperties messagingKafkaConsumerConfig() {
+        final MessagingKafkaConsumerConfigProperties kafkaConsumerConfigProperties = new MessagingKafkaConsumerConfigProperties();
         kafkaConsumerConfigProperties.setDefaultClientIdPrefix("cmd-router");
         return kafkaConsumerConfigProperties;
     }
@@ -444,8 +444,8 @@ public class ApplicationConfig {
      */
     @ConfigurationProperties(prefix = "hono.kafka")
     @Bean
-    public KafkaProducerConfigProperties kafkaProducerConfig() {
-        final KafkaProducerConfigProperties configProperties = new KafkaProducerConfigProperties();
+    public MessagingKafkaProducerConfigProperties messagingKafkaProducerConfig() {
+        final MessagingKafkaProducerConfigProperties configProperties = new MessagingKafkaProducerConfigProperties();
         configProperties.setDefaultClientIdPrefix("cmd-router");
         return configProperties;
     }

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
@@ -19,8 +19,8 @@ import org.eclipse.hono.auth.SpringBasedHonoPasswordEncoder;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.client.telemetry.EventSender;
 import org.eclipse.hono.client.telemetry.amqp.ProtonBasedDownstreamSender;
 import org.eclipse.hono.client.telemetry.kafka.KafkaBasedEventSender;
@@ -185,9 +185,9 @@ public class FileBasedServiceConfig {
                     true));
         }
 
-        if (kafkaProducerConfig().isConfigured()) {
+        if (messagingKafkaProducerConfig().isConfigured()) {
             final KafkaProducerFactory<String, Buffer> factory = CachingKafkaProducerFactory.sharedFactory(vertx);
-            result.setClient(new KafkaBasedEventSender(factory, kafkaProducerConfig(), true, tracer));
+            result.setClient(new KafkaBasedEventSender(factory, messagingKafkaProducerConfig(), true, tracer));
         }
 
         healthCheckServer.registerHealthCheckResources(ServiceClientAdapter.forClient(result));
@@ -215,8 +215,8 @@ public class FileBasedServiceConfig {
      */
     @ConfigurationProperties(prefix = "hono.kafka")
     @Bean
-    public KafkaProducerConfigProperties kafkaProducerConfig() {
-        final KafkaProducerConfigProperties configProperties = new KafkaProducerConfigProperties();
+    public MessagingKafkaProducerConfigProperties messagingKafkaProducerConfig() {
+        final MessagingKafkaProducerConfigProperties configProperties = new MessagingKafkaProducerConfigProperties();
         configProperties.setDefaultClientIdPrefix("device-registry");
         return configProperties;
     }

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
@@ -21,8 +21,8 @@ import org.eclipse.hono.auth.SpringBasedHonoPasswordEncoder;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.client.telemetry.EventSender;
 import org.eclipse.hono.client.telemetry.amqp.ProtonBasedDownstreamSender;
 import org.eclipse.hono.client.telemetry.kafka.KafkaBasedEventSender;
@@ -386,9 +386,9 @@ public class ApplicationConfig {
                     true));
         }
 
-        if (kafkaProducerConfig().isConfigured()) {
+        if (messagingKafkaProducerConfig().isConfigured()) {
             final KafkaProducerFactory<String, Buffer> factory = CachingKafkaProducerFactory.sharedFactory(vertx());
-            result.setClient(new KafkaBasedEventSender(factory, kafkaProducerConfig(), true, tracer()));
+            result.setClient(new KafkaBasedEventSender(factory, messagingKafkaProducerConfig(), true, tracer()));
         }
 
         healthCheckServer().registerHealthCheckResources(ServiceClientAdapter.forClient(result));
@@ -416,8 +416,8 @@ public class ApplicationConfig {
      */
     @ConfigurationProperties(prefix = "hono.kafka")
     @Bean
-    public KafkaProducerConfigProperties kafkaProducerConfig() {
-        final KafkaProducerConfigProperties configProperties = new KafkaProducerConfigProperties();
+    public MessagingKafkaProducerConfigProperties messagingKafkaProducerConfig() {
+        final MessagingKafkaProducerConfigProperties configProperties = new MessagingKafkaProducerConfigProperties();
         configProperties.setDefaultClientIdPrefix("device-registry");
         return configProperties;
     }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
@@ -22,8 +22,8 @@ import org.eclipse.hono.auth.SpringBasedHonoPasswordEncoder;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.client.telemetry.EventSender;
 import org.eclipse.hono.client.telemetry.amqp.ProtonBasedDownstreamSender;
 import org.eclipse.hono.client.telemetry.kafka.KafkaBasedEventSender;
@@ -376,9 +376,9 @@ public class ApplicationConfig {
                     true));
         }
 
-        if (kafkaProducerConfig().isConfigured()) {
+        if (messagingKafkaProducerConfig().isConfigured()) {
             final KafkaProducerFactory<String, Buffer> factory = CachingKafkaProducerFactory.sharedFactory(vertx());
-            result.setClient(new KafkaBasedEventSender(factory, kafkaProducerConfig(), true, tracer()));
+            result.setClient(new KafkaBasedEventSender(factory, messagingKafkaProducerConfig(), true, tracer()));
         }
 
         healthCheckServer().registerHealthCheckResources(ServiceClientAdapter.forClient(result));
@@ -406,8 +406,8 @@ public class ApplicationConfig {
      */
     @ConfigurationProperties(prefix = "hono.kafka")
     @Bean
-    public KafkaProducerConfigProperties kafkaProducerConfig() {
-        final KafkaProducerConfigProperties configProperties = new KafkaProducerConfigProperties();
+    public MessagingKafkaProducerConfigProperties messagingKafkaProducerConfig() {
+        final MessagingKafkaProducerConfigProperties configProperties = new MessagingKafkaProducerConfigProperties();
         configProperties.setDefaultClientIdPrefix("device-registry");
         return configProperties;
     }

--- a/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
+++ b/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
@@ -37,7 +37,7 @@ to use another.
 
 The `org.eclipse.hono.client.kafka.CachingKafkaProducerFactory` factory can be used to create Kafka producers for Hono's
 Kafka based APIs. The producers created by the factory are configured with instances of the class
-`org.eclipse.hono.client.kafka.KafkaProducerConfigProperties` which can be used to programmatically configure a producer.
+`org.eclipse.hono.client.kafka.MessagingKafkaConsumerConfigProperties` which can be used to programmatically configure a producer.
 
 The configuration needs to be provided in the form `HONO_KAFKA_PRODUCERCONFIG_${PROPERTY}` as an environment variable or
 as a Java system property in the form `hono.kafka.producerConfig.${property}`, where `${PROPERTY}` respectively
@@ -72,7 +72,7 @@ The complete reference of available properties and the possible values is availa
 ## Consumer Configuration Properties
 
 Consumers for Hono's Kafka based APIs are configured with instances of the class
-`org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties` which can be used to programmatically configure a consumer.
+`org.eclipse.hono.client.kafka.consumer.MessagingKafkaConsumerConfigProperties` which can be used to programmatically configure a consumer.
 
 The configuration needs to be provided in the form `HONO_KAFKA_CONSUMERCONFIG_${PROPERTY}` as an environment variable or
 as a Java system property in the form `hono.kafka.consumerConfig.${property}`, where `${PROPERTY}` respectively

--- a/tests/src/test/java/org/eclipse/hono/tests/GenericKafkaSender.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/GenericKafkaSender.java
@@ -17,8 +17,8 @@ import java.util.Map;
 
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.kafka.producer.AbstractKafkaBasedMessageSender;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 
 import io.opentracing.SpanContext;
 import io.opentracing.noop.NoopTracerFactory;
@@ -39,7 +39,7 @@ public class GenericKafkaSender extends AbstractKafkaBasedMessageSender {
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     public GenericKafkaSender(final KafkaProducerFactory<String, Buffer> producerFactory,
-            final KafkaProducerConfigProperties producerConfig) {
+            final MessagingKafkaProducerConfigProperties producerConfig) {
         super(producerFactory, "generic-sender", producerConfig, NoopTracerFactory.create());
     }
 

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -62,10 +62,10 @@ import org.eclipse.hono.client.amqp.GenericSenderLink;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaAdminClientConfigProperties;
 import org.eclipse.hono.client.kafka.consumer.AsyncHandlingAutoCommitKafkaConsumer;
-import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.MessagingKafkaConsumerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
-import org.eclipse.hono.client.kafka.producer.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.service.management.credentials.Credentials;
 import org.eclipse.hono.service.management.credentials.PasswordCredential;
@@ -624,9 +624,9 @@ public final class IntegrationTestSupport {
      *
      * @return The properties.
      */
-    public static KafkaConsumerConfigProperties getKafkaConsumerConfig() {
+    public static MessagingKafkaConsumerConfigProperties getKafkaConsumerConfig() {
         LOGGER.info("Configured to connect to Kafka on {}", IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS);
-        final KafkaConsumerConfigProperties consumerConfig = new KafkaConsumerConfigProperties();
+        final MessagingKafkaConsumerConfigProperties consumerConfig = new MessagingKafkaConsumerConfigProperties();
         consumerConfig.setConsumerConfig(Map.of(
                 ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS,
                 ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
@@ -639,9 +639,9 @@ public final class IntegrationTestSupport {
      *
      * @return The properties.
      */
-    public static KafkaProducerConfigProperties getKafkaProducerConfig() {
+    public static MessagingKafkaProducerConfigProperties getKafkaProducerConfig() {
         LOGGER.info("Configured to connect to Kafka on {}", IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS);
-        final KafkaProducerConfigProperties consumerConfig = new KafkaProducerConfigProperties();
+        final MessagingKafkaProducerConfigProperties consumerConfig = new MessagingKafkaProducerConfigProperties();
         consumerConfig.setProducerConfig(Map.of(
                 ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS));
         return consumerConfig;
@@ -843,7 +843,7 @@ public final class IntegrationTestSupport {
      *
      * @return A future indicating the outcome of the operation.
      */
-    public Future<Void> init(final KafkaConsumerConfigProperties kafkaDownstreamProps) {
+    public Future<Void> init(final MessagingKafkaConsumerConfigProperties kafkaDownstreamProps) {
 
         initRegistryClient();
 

--- a/tests/src/test/java/org/eclipse/hono/tests/commandrouter/KafkaBasedCommandConsumerFactoryImplIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/commandrouter/KafkaBasedCommandConsumerFactoryImplIT.java
@@ -36,7 +36,7 @@ import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaRecordHelper;
 import org.eclipse.hono.client.kafka.consumer.AsyncHandlingAutoCommitKafkaConsumer;
 import org.eclipse.hono.client.kafka.consumer.HonoKafkaConsumer;
-import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.MessagingKafkaConsumerConfigProperties;
 import org.eclipse.hono.client.kafka.metrics.NoopKafkaClientMetricsSupport;
 import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
@@ -426,7 +426,7 @@ public class KafkaBasedCommandConsumerFactoryImplIT {
         final Span span = TracingMockSupport.mockSpan();
         final Tracer tracer = TracingMockSupport.mockTracer(span);
 
-        final KafkaConsumerConfigProperties kafkaConsumerConfig = new KafkaConsumerConfigProperties();
+        final MessagingKafkaConsumerConfigProperties kafkaConsumerConfig = new MessagingKafkaConsumerConfigProperties();
         kafkaConsumerConfig.setConsumerConfig(Map.of(
                 ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS));
         final CommandRouterMetrics metrics = mock(CommandRouterMetrics.class);


### PR DESCRIPTION
This is needed for [ #2924].
Extracted new superclasses for the Kafka producer and consumer configuration properties that do not have the serialization types hardcoded or assume any particular configuration values.

The first commit contains the actual change. The second one only renames the Kafka client config properties implementation classes that are specific for messaging.