### PR TITLE
[#2925] Use "earliest" offset reset strategy for Kafka command consumer

### DIFF
--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumer.java
@@ -842,17 +842,18 @@ public class HonoKafkaConsumer implements Lifecycle {
      * Tries to ensure that the given topic is part of the list of topics this consumer is subscribed to.
      * <p>
      * The successful completion of the returned Future means that the topic exists and is among the subscribed topics.
-     * It also means that if partitions of this topic have been assigned to this consumer, the positions for these
-     * partitions have already been fetched and the consumer will receive records published thereafter.
+     * It also means that if partitions of this topic have been assigned to this consumer and if the offset reset config
+     * is set to "latest", the positions for these partitions have already been fetched and the consumer will receive
+     * records published thereafter.
      * If all topic partition are assigned to other consumers, a best-effort approach is taken to let the result
      * Future be completed after this assignment has been done.
      * <p>
      * Note that this method is only applicable if a topic pattern subscription is used, otherwise an
      * {@link IllegalStateException} is thrown.
      * <p>
-     * This is relevant if the topic either has just been created and this consumer doesn't know about it yet or
-     * the topic doesn't exist yet. In the latter case, this method will try to trigger creation of the topic,
-     * which may succeed if "auto.create.topics.enable" is true, and wait for the following rebalance to check
+     * This method is needed for scenarios where the given topic either has just been created and this consumer doesn't
+     * know about it yet or the topic doesn't exist yet. In the latter case, this method will try to trigger creation of
+     * the topic, which may succeed if topic auto-creation is enabled, and wait for the following rebalance to check
      * if the topic is part of the subscribed topics then.
      *
      * @param topic The topic to use.

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -156,6 +156,7 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
         final Map<String, String> consumerConfig = kafkaConsumerConfig.getConsumerConfig("consumer");
         consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         consumerConfig.putIfAbsent(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, CooperativeStickyAssignor.class.getName());
+        consumerConfig.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         kafkaConsumer = new AsyncHandlingAutoCommitKafkaConsumer(vertx, COMMANDS_TOPIC_PATTERN,
                 commandHandler::mapAndDelegateIncomingCommandMessage, consumerConfig);
         kafkaConsumer.setMetricsSupport(kafkaClientMetricsSupport);

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
@@ -666,7 +666,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
         kafkaSenderRef.get().sendAndWaitForOutcome(commandTopic, tenantId, deviceId, Buffer.buffer(), properties2)
                 .onComplete(ctx.succeeding(ok -> {}));
 
-        final long timeToWait = 500;
+        final long timeToWait = 1500;
         if (!expectedCommandResponses.await(timeToWait, TimeUnit.MILLISECONDS)) {
             log.info("Timeout of {} milliseconds reached, stop waiting for command response", timeToWait);
         }

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
@@ -520,7 +520,7 @@ public class CommandAndControlMqttIT extends MqttTestBase {
         kafkaSenderRef.get().sendAndWaitForOutcome(commandTopic, tenantId, deviceId, Buffer.buffer(), properties2)
                 .onComplete(ctx.succeeding(ok -> {}));
 
-        final long timeToWait = 500;
+        final long timeToWait = 1500;
         if (!expectedCommandResponses.await(timeToWait, TimeUnit.MILLISECONDS)) {
             LOGGER.info("Timeout of {} milliseconds reached, stop waiting for command response", timeToWait);
         }


### PR DESCRIPTION
This resolves #2925.

Along with this change, the `HonoKafkaConsumer#ensureTopicIsAmongSubscribedTopicPatternTopics` method could be changed so that the result Future is completed earlier (without waiting for the consumer rebalance). But this changes the timing in the integration tests (first command subscription finishes sooner, but first command takes longer to be received), so that adaptations are needed there. This will go in a separate PR then.
