### PR TITLE
Fix NPE when cache.stop() called more than once

### DIFF
--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/EmbeddedCache.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/EmbeddedCache.java
@@ -70,7 +70,7 @@ public class EmbeddedCache<K, V> extends BasicCache<K, V> {
 
             vertx.executeBlocking(r -> {
                 try {
-                    LOG.debug("trying to start cache manager, current state");
+                    LOG.debug("trying to start cache manager");
                     cacheManager.start();
                     LOG.info("started cache manager");
                     LOG.debug("trying to get cache");


### PR DESCRIPTION
This prevents the following NPE:
```
INFO org.eclipse.hono.deviceconnection.infinispan.client.BasicCache  error trying to stop connection(s) to cache
java.lang.NullPointerException: null
	at org.infinispan.commons.util.concurrent.NonReentrantLock.unlock(NonReentrantLock.java:83)
	at org.infinispan.client.hotrod.counter.impl.NotificationManager.stop(NotificationManager.java:185)
	at org.infinispan.client.hotrod.counter.impl.RemoteCounterManager.stop(RemoteCounterManager.java:89)
	at org.infinispan.client.hotrod.RemoteCacheManager.stop(RemoteCacheManager.java:473)
	at org.eclipse.hono.deviceconnection.infinispan.client.BasicCache.lambda$stop$0(BasicCache.java:90)
	at io.vertx.core.impl.ContextImpl.lambda$null$0(ContextImpl.java:159)
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:100)
	at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$1(ContextImpl.java:157)
	at io.vertx.core.impl.TaskQueue.run(TaskQueue.java:76)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Unknown Source)
```
thrown when the device connection cache gets stopped more than once.

Background:
There is actually only one device connection cache object being used from vert.x verticles. Since from every verticle the cache.stop() method gets called, the above exception did occur.

Note: I've considered letting the `cache.stop()` result Future, returned when the cache is already (getting) stopped, be completed along with the initial `cache.stop()` Future. To get this right, the completion needs to be done in the correct vert.x context. While this isn't a problem, I think that it is a bit of overkill, since the `start()` method currently isn't implemented in such a way either.