### PR TITLE
Upgrade to Qpid Dispatch Router 1.17.1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -32,7 +32,7 @@
     <assertj-core.version>3.20.2</assertj-core.version>
     <californium.version>2.6.5</californium.version>
     <cryptvault.version>1.0.2</cryptvault.version>
-    <dispatch-router.image.name>quay.io/interconnectedcloud/qdrouterd:1.14.0</dispatch-router.image.name>
+    <dispatch-router.image.name>quay.io/interconnectedcloud/qdrouterd:1.17.1</dispatch-router.image.name>
     <guava.version>30.1-jre</guava.version>
     <gson.version>2.8.6</gson.version>
     <hamcrest-core.version>2.2</hamcrest-core.version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -895,16 +895,8 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <LOGGING_CONFIG>file:///etc/hono/logback-spring.xml</LOGGING_CONFIG>
                       <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
                       <SPRING_PROFILES_ACTIVE>authentication-impl,${logging.profile}</SPRING_PROFILES_ACTIVE>
-                      <!--
-                        We disable the consumption of the "server_name" TLS extension which clients use to
-                        indicate the name of the host they want to connect to. The Qpid Dispatch Router sets
-                        a value which includes the port that the client wants to connect to. This is clearly not
-                        allowed by RFC 6066 and OpenJDK 17 will fail the TLS handshake with the Dispatch Router if
-                        the "server_name" extension is not disabled altogether.
-                        See https://docs.oracle.com/en/java/javase/17/security/java-secure-socket-extension-jsse-reference-guide.html#GUID-527BAE97-3B78-4390-A479-623BD998C4EE
-                       -->
                       <JDK_JAVA_OPTIONS>
-                        ${default.java.options} -Djdk.tls.server.disableExtensions=server_name
+                        ${default.java.options}
                       </JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
                     </env>


### PR DESCRIPTION
Addresses #2949 

This release contains the fix for
https://issues.apache.org/jira/browse/DISPATCH-2259 and thus allows us
to re-enable SNI in the Auth Server.

I have created [CQ23833](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23833) for tracking the dependency.