### PR TITLE
Use default vert.x cache directory

### DIFF
--- a/adapters/base-quarkus/pom.xml
+++ b/adapters/base-quarkus/pom.xml
@@ -157,7 +157,7 @@
                         <JAVA_APP_NAME>${project.artifactId}</JAVA_APP_NAME>
                         <JAVA_LIB_DIR>/opt/hono/lib/*:/opt/hono/extensions/*</JAVA_LIB_DIR>
                         <!-- use Base64 encoder/decoder that is compatible with vert.x 3 -->
-                        <JAVA_OPTIONS>-Dvertx.cacheDirBase=/tmp -Dvertx.json.base64=legacy -Djava.util.logging.manager=org.jboss.logmanager.LogManager</JAVA_OPTIONS>
+                        <JAVA_OPTIONS>-Dvertx.json.base64=legacy -Djava.util.logging.manager=org.jboss.logmanager.LogManager</JAVA_OPTIONS>
                         <JAVA_APP_JAR>quarkus-run.jar</JAVA_APP_JAR>
                       </env>
                       <entryPoint>
@@ -242,7 +242,6 @@
                       <entryPoint>
                         <arg>/opt/hono/${project.artifactId}-${project.version}-runner</arg>
                         <!-- use Base64 encoder/decoder that is compatible with vert.x 3 -->
-                        <arg>-Dvertx.cacheDirBase=/tmp</arg>
                         <arg>-Dvertx.json.base64=legacy</arg>
                         <arg>-Djava.util.logging.manager=org.jboss.logmanager.LogManager</arg>
                       </entryPoint>

--- a/adapters/base-spring/pom.xml
+++ b/adapters/base-spring/pom.xml
@@ -100,7 +100,7 @@
                         <JAVA_APP_NAME>${project.artifactId}</JAVA_APP_NAME>
                         <JAVA_LIB_DIR>/opt/hono/extensions/*</JAVA_LIB_DIR>
                         <!-- use Base64 encoder/decoder that is compatible with vert.x 3 -->
-                        <JAVA_OPTIONS>-Dvertx.cacheDirBase=/tmp -Dvertx.json.base64=legacy</JAVA_OPTIONS>
+                        <JAVA_OPTIONS>-Dvertx.json.base64=legacy</JAVA_OPTIONS>
                       </env>
                       <entryPoint>
                         <arg>/opt/hono/run-java.sh</arg>

--- a/services/base-quarkus/pom.xml
+++ b/services/base-quarkus/pom.xml
@@ -148,7 +148,7 @@
                         <JAVA_APP_NAME>${project.artifactId}</JAVA_APP_NAME>
                         <JAVA_LIB_DIR>/opt/hono/lib/*:/opt/hono/extensions/*</JAVA_LIB_DIR>
                         <!-- use Base64 encoder/decoder that is compatible with vert.x 3 -->
-                        <JAVA_OPTIONS>-Dvertx.cacheDirBase=/tmp -Dvertx.json.base64=legacy -Djava.util.logging.manager=org.jboss.logmanager.LogManager</JAVA_OPTIONS>
+                        <JAVA_OPTIONS>-Dvertx.json.base64=legacy -Djava.util.logging.manager=org.jboss.logmanager.LogManager</JAVA_OPTIONS>
                         <JAVA_APP_JAR>quarkus-run.jar</JAVA_APP_JAR>
                       </env>
                       <entryPoint>
@@ -233,7 +233,6 @@
                       <entryPoint>
                         <arg>/opt/hono/${project.artifactId}-${project.version}-runner</arg>
                         <!-- use Base64 encoder/decoder that is compatible with vert.x 3 -->
-                        <arg>-Dvertx.cacheDirBase=/tmp</arg>
                         <arg>-Dvertx.json.base64=legacy</arg>
                         <arg>-Djava.util.logging.manager=org.jboss.logmanager.LogManager</arg>
                       </entryPoint>

--- a/services/base-spring/pom.xml
+++ b/services/base-spring/pom.xml
@@ -101,7 +101,7 @@
                         <JAVA_APP_NAME>${project.artifactId}</JAVA_APP_NAME>
                         <JAVA_LIB_DIR>/opt/hono/extensions/*</JAVA_LIB_DIR>
                         <!-- use Base64 encoder/decoder that is compatible with vert.x 3 -->
-                        <JAVA_OPTIONS>-Dvertx.cacheDirBase=/tmp -Dvertx.json.base64=legacy</JAVA_OPTIONS>
+                        <JAVA_OPTIONS>-Dvertx.json.base64=legacy</JAVA_OPTIONS>
                       </env>
                       <entryPoint>
                         <arg>/opt/hono/run-java.sh</arg>

--- a/services/command-router/pom.xml
+++ b/services/command-router/pom.xml
@@ -53,7 +53,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                       <port>${vertx.health.port}</port>
                     </ports>
                     <env>
-                      <JAVA_OPTIONS>-Dvertx.cacheDirBase=/tmp -Dorg.jboss.logging.provider=slf4j</JAVA_OPTIONS>
+                      <JAVA_OPTIONS>-Dorg.jboss.logging.provider=slf4j</JAVA_OPTIONS>
                       <JAVA_MAIN_CLASS>org.eclipse.hono.commandrouter.spring.Application</JAVA_MAIN_CLASS>
                     </env>
                   </build>

--- a/services/device-connection/pom.xml
+++ b/services/device-connection/pom.xml
@@ -63,7 +63,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                       <port>${vertx.health.port}</port>
                     </ports>
                     <env>
-                      <JAVA_OPTIONS>-Dvertx.cacheDirBase=/tmp -Dorg.jboss.logging.provider=slf4j</JAVA_OPTIONS>
+                      <JAVA_OPTIONS>-Dorg.jboss.logging.provider=slf4j</JAVA_OPTIONS>
                       <JAVA_MAIN_CLASS>org.eclipse.hono.deviceconnection.infinispan.Application</JAVA_MAIN_CLASS>
                     </env>
                   </build>


### PR DESCRIPTION
Hono's components have been using the "vertx.cacheDirBase" system
property to set the directory where vert.x should store files resolved
via the class path.

With vert.x 4 the semantics of this property's value has changed which
might lead to incompatibilities (see
https://github.com/eclipse-vertx/vert.x/issues/4168).

The system property is no longer set for Hono components because the
default behavior is to create a subfolder in the JVM's tmpdir to which
the running process will (usually) have write access.

Fixes #2946