### PR TITLE
[#2901] Let command_internal topics be deleted in the Command Router

### DIFF
--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/AdapterInstanceStatusProvider.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/AdapterInstanceStatusProvider.java
@@ -13,7 +13,12 @@
 
 package org.eclipse.hono.deviceconnection.infinispan.client;
 
+import java.util.Collection;
+import java.util.Set;
+
 import org.eclipse.hono.util.AdapterInstanceStatus;
+
+import io.vertx.core.Future;
 
 /**
  * Provides the status of an adapter instance.
@@ -25,11 +30,26 @@ public interface AdapterInstanceStatusProvider {
     /**
      * Gets the status of the adapter identified by the given identifier.
      *
-     * @param adapterInstanceId The identifier of the adapter.
+     * @param adapterInstanceId The identifier of the adapter instance.
      * @return The status of the adapter instance.
      * @throws NullPointerException if adapterInstanceId is {@code null}.
      */
     AdapterInstanceStatus getStatus(String adapterInstanceId);
+
+    /**
+     * Gets the identifiers of the adapter instances from the given collection
+     * that have the {@link AdapterInstanceStatus#DEAD} status.
+     * <p>
+     * Compared to {@link #getStatus(String)}, extra measures may be taken here
+     * to resolve the status of adapter instances otherwise classified as
+     * {@link AdapterInstanceStatus#SUSPECTED_DEAD} before completing the result future.
+     *
+     * @param adapterInstanceIds The identifiers of the adapter instances.
+     * @return A succeeded future containing the identifiers of the dead adapter instances or a failed future
+     *         indicating the reason why the operation failed.
+     * @throws NullPointerException if adapterInstanceIds is {@code null}.
+     */
+    Future<Set<String>> getDeadAdapterInstances(Collection<String> adapterInstanceIds);
 
     /**
      * Status provider that always returns the {@link AdapterInstanceStatus#UNKNOWN} status.
@@ -39,6 +59,12 @@ public interface AdapterInstanceStatusProvider {
         @Override
         public AdapterInstanceStatus getStatus(final String adapterInstanceId) {
             return AdapterInstanceStatus.UNKNOWN;
+        }
+
+        @Override
+        public Future<Set<String>> getDeadAdapterInstances(
+                final Collection<String> adapterInstanceIds) {
+            return Future.succeededFuture(Set.of());
         }
     }
 }

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/AdapterInstanceStatusService.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/AdapterInstanceStatusService.java
@@ -13,6 +13,9 @@
 
 package org.eclipse.hono.commandrouter;
 
+import java.util.Collection;
+import java.util.Set;
+
 import org.eclipse.hono.deviceconnection.infinispan.client.AdapterInstanceStatusProvider;
 import org.eclipse.hono.util.AdapterInstanceStatus;
 import org.eclipse.hono.util.Lifecycle;
@@ -34,6 +37,12 @@ public interface AdapterInstanceStatusService extends AdapterInstanceStatusProvi
         @Override
         public AdapterInstanceStatus getStatus(final String adapterInstanceId) {
             return AdapterInstanceStatus.UNKNOWN;
+        }
+
+        @Override
+        public Future<Set<String>> getDeadAdapterInstances(
+                final Collection<String> adapterInstanceIds) {
+            return Future.succeededFuture(Set.of());
         }
 
         @Override

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/InternalKafkaTopicCleanupService.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/InternalKafkaTopicCleanupService.java
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.commandrouter.impl.kafka;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.eclipse.hono.client.kafka.HonoTopic;
+import org.eclipse.hono.client.kafka.KafkaAdminClientConfigProperties;
+import org.eclipse.hono.commandrouter.AdapterInstanceStatusService;
+import org.eclipse.hono.util.Lifecycle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.kafka.admin.KafkaAdminClient;
+
+/**
+ * A service to delete obsolete {@link HonoTopic.Type#COMMAND_INTERNAL} topics.
+ */
+public class InternalKafkaTopicCleanupService implements Lifecycle {
+
+    private static final Logger LOG = LoggerFactory.getLogger(InternalKafkaTopicCleanupService.class);
+
+    private static final long CHECK_INTERVAL_MILLIS = TimeUnit.MINUTES.toMillis(10);
+
+    private static final String CLIENT_NAME = "internal-topic-cleanup";
+    private static final Pattern INTERNAL_COMMAND_TOPIC_PATTERN = Pattern
+            .compile(Pattern.quote(HonoTopic.Type.COMMAND_INTERNAL.prefix) + "(.+)");
+
+    private final Vertx vertx;
+    private final AdapterInstanceStatusService adapterInstanceStatusService;
+    private final Supplier<KafkaAdminClient> kafkaAdminClientCreator;
+    private final Set<String> topicsToDelete = new HashSet<>();
+    private final AtomicBoolean stopCalled = new AtomicBoolean();
+
+    private KafkaAdminClient adminClient;
+    private long timerId;
+
+    /**
+     * Creates an InternalKafkaTopicCleanupService.
+     *
+     * @param vertx The Vert.x instance to use.
+     * @param adapterInstanceStatusService The service providing info about the status of adapter instances.
+     * @param adminClientConfigProperties The Kafka admin client config properties.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public InternalKafkaTopicCleanupService(
+            final Vertx vertx,
+            final AdapterInstanceStatusService adapterInstanceStatusService,
+            final KafkaAdminClientConfigProperties adminClientConfigProperties) {
+        this.vertx = Objects.requireNonNull(vertx);
+        this.adapterInstanceStatusService = Objects.requireNonNull(adapterInstanceStatusService);
+        Objects.requireNonNull(adminClientConfigProperties);
+
+        this.kafkaAdminClientCreator = () -> KafkaAdminClient.create(vertx,
+                adminClientConfigProperties.getAdminClientConfig(CLIENT_NAME));
+    }
+
+    /**
+     * Creates an InternalKafkaTopicCleanupService.
+     * <p>
+     * To be used for unit tests.
+     *
+     * @param vertx The Vert.x instance to use.
+     * @param adapterInstanceStatusService The service providing info about the status of adapter instances.
+     * @param kafkaAdminClientCreator The supplier for the Kafka admin client to use.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    InternalKafkaTopicCleanupService(
+            final Vertx vertx,
+            final AdapterInstanceStatusService adapterInstanceStatusService,
+            final Supplier<KafkaAdminClient> kafkaAdminClientCreator) {
+        this.vertx = Objects.requireNonNull(vertx);
+        this.adapterInstanceStatusService = Objects.requireNonNull(adapterInstanceStatusService);
+        this.kafkaAdminClientCreator = Objects.requireNonNull(kafkaAdminClientCreator);
+    }
+
+    @Override
+    public Future<Void> start() {
+        if (adminClient == null) {
+            adminClient = kafkaAdminClientCreator.get();
+            timerId = vertx.setPeriodic(CHECK_INTERVAL_MILLIS, tid -> performCleanup());
+            LOG.info("started InternalKafkaTopicCleanupService");
+        }
+        return Future.succeededFuture();
+    }
+
+    /**
+     * Determine topics to be deleted and delete the set of such topics determined in a previous invocation.
+     */
+    protected final void performCleanup() {
+        if (!topicsToDelete.isEmpty()) {
+            adminClient.listTopics()
+                    .onFailure(thr -> LOG.warn("error listing topics", thr))
+                    .onSuccess(allTopics -> {
+                        final List<String> existingTopicsToDelete = topicsToDelete.stream().filter(allTopics::contains)
+                                .collect(Collectors.toList());
+                        if (existingTopicsToDelete.isEmpty()) {
+                            topicsToDelete.clear();
+                            determineToBeDeletedTopics(allTopics);
+                        } else {
+                            adminClient.deleteTopics(existingTopicsToDelete)
+                                    .onSuccess(v -> LOG.info("deleted topics {}", existingTopicsToDelete))
+                                    .onFailure(thr -> LOG.warn("error deleting topics {}", existingTopicsToDelete, thr))
+                                    .onComplete(ar -> {
+                                        topicsToDelete.clear();
+                                        determineToBeDeletedTopics();
+                                    });
+                        }
+                    });
+        } else {
+            // just determine topics to be deleted here, let them be deleted in the next cleanup invocation
+            // so that we don't delete topics too early (while producers may still publish messages to them)
+            determineToBeDeletedTopics();
+        }
+    }
+
+    private void determineToBeDeletedTopics() {
+        adminClient.listTopics()
+                .onSuccess(this::determineToBeDeletedTopics)
+                .onFailure(thr -> LOG.warn("error listing topics", thr));
+    }
+
+    private void determineToBeDeletedTopics(final Set<String> allTopics) {
+        final Map<String, String> adapterInstanceIdToTopicMap = new HashMap<>();
+        for (final String topic : allTopics) {
+            final Matcher matcher = INTERNAL_COMMAND_TOPIC_PATTERN.matcher(topic);
+            if (matcher.matches()) {
+                final String adapterInstanceId = matcher.group(1);
+                adapterInstanceIdToTopicMap.put(adapterInstanceId, topic);
+            }
+        }
+        adapterInstanceStatusService.getDeadAdapterInstances(adapterInstanceIdToTopicMap.keySet())
+                .onFailure(thr -> LOG.warn("error determining dead adapter instances", thr))
+                .onSuccess(deadAdapterInstances -> {
+                    deadAdapterInstances.forEach(id -> topicsToDelete.add(adapterInstanceIdToTopicMap.get(id)));
+                    if (topicsToDelete.isEmpty()) {
+                        LOG.debug("found no topics to be deleted; no. of checked topics: {}", adapterInstanceIdToTopicMap.size());
+                    } else {
+                        LOG.info("marking topics as to be deleted on next run {}", topicsToDelete);
+                    }
+                });
+    }
+
+    @Override
+    public Future<Void> stop() {
+        if (!stopCalled.compareAndSet(false, true) || adminClient == null) {
+            return Future.succeededFuture();
+        }
+        vertx.cancelTimer(timerId);
+        final Promise<Void> adminClientClosedPromise = Promise.promise();
+        adminClient.close(adminClientClosedPromise);
+        return adminClientClosedPromise.future()
+                .recover(thr -> {
+                    LOG.warn("error closing admin client", thr);
+                    return Future.succeededFuture();
+                });
+    }
+}

--- a/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/InternalKafkaTopicCleanupServiceTest.java
+++ b/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/InternalKafkaTopicCleanupServiceTest.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.commandrouter.impl.kafka;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import org.eclipse.hono.client.kafka.HonoTopic;
+import org.eclipse.hono.commandrouter.AdapterInstanceStatusService;
+import org.eclipse.hono.util.CommandConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Timeout;
+import io.vertx.kafka.admin.KafkaAdminClient;
+
+/**
+ * Verifies behavior of {@link InternalKafkaTopicCleanupService}.
+ */
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public class InternalKafkaTopicCleanupServiceTest {
+
+    private InternalKafkaTopicCleanupService internalKafkaTopicCleanupService;
+    private AdapterInstanceStatusService adapterInstanceStatusService;
+    private KafkaAdminClient kafkaAdminClient;
+
+    /**
+     * Sets up fixture.
+     */
+    @BeforeEach
+    public void setUp() {
+        final Vertx vertx = mock(Vertx.class);
+        adapterInstanceStatusService = mock(AdapterInstanceStatusService.class);
+        kafkaAdminClient = mock(KafkaAdminClient.class);
+        internalKafkaTopicCleanupService = new InternalKafkaTopicCleanupService(vertx, adapterInstanceStatusService,
+                () -> kafkaAdminClient);
+        internalKafkaTopicCleanupService.start();
+    }
+
+    /**
+     * Verifies that the service deletes topics identified as obsolete.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testPerformCleanup() {
+
+        final AtomicInteger counter = new AtomicInteger();
+        final String podName = "myAdapter";
+        final String aliveContainerId = "0ad9864b08bf";
+        final String deadContainerId = "000000000000";
+
+        final Set<String> toBeDeletedCmdInternalTopics = new HashSet<>();
+        toBeDeletedCmdInternalTopics.add(getCmdInternalTopic(podName, deadContainerId, counter.getAndIncrement()));
+        toBeDeletedCmdInternalTopics.add(getCmdInternalTopic(podName, deadContainerId, counter.getAndIncrement()));
+        toBeDeletedCmdInternalTopics.add(getCmdInternalTopic(podName, deadContainerId, counter.getAndIncrement()));
+
+        // GIVEN a number of topics
+        final Set<String> allTopics = new HashSet<>(toBeDeletedCmdInternalTopics);
+        allTopics.add("other");
+        allTopics.add(getCmdInternalTopic(podName, aliveContainerId, counter.getAndIncrement()));
+        allTopics.add(getCmdInternalTopic(podName, aliveContainerId, counter.getAndIncrement()));
+        allTopics.add(getCmdInternalTopic(podName, aliveContainerId, counter.getAndIncrement()));
+
+        // all adapter instances whose identifier contains the "deadContainerId" shall be identified as dead
+        when(adapterInstanceStatusService.getDeadAdapterInstances(any()))
+                .thenAnswer(invocation -> {
+                    final Collection<String> adapterInstanceIdsParam = invocation.getArgument(0);
+                    final Set<String> deadIds = adapterInstanceIdsParam.stream()
+                            .filter(id -> id.contains(deadContainerId)).collect(Collectors.toSet());
+                    return Future.succeededFuture(deadIds);
+                });
+        when(kafkaAdminClient.deleteTopics(any()))
+                .thenAnswer(invocation -> {
+                    // remove deleted from allTopics
+                    final List<String> topicsToDeleteParam = invocation.getArgument(0);
+                    topicsToDeleteParam.forEach(allTopics::remove);
+                    return Future.succeededFuture();
+                });
+        when(kafkaAdminClient.listTopics()).thenReturn(Future.succeededFuture(allTopics));
+
+        // WHEN the cleanup gets performed
+        internalKafkaTopicCleanupService.performCleanup();
+        verify(kafkaAdminClient, never()).deleteTopics(any());
+        // THEN the next invocation ...
+        internalKafkaTopicCleanupService.performCleanup();
+
+        // ... will cause the matching topics to be deleted
+        final var deletedTopicsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(kafkaAdminClient).deleteTopics(deletedTopicsCaptor.capture());
+        assertThat(deletedTopicsCaptor.getValue()).isEqualTo(new ArrayList<>(toBeDeletedCmdInternalTopics));
+    }
+
+    private String getCmdInternalTopic(final String podName, final String containerId, final int counter) {
+        final String adapterInstanceId = CommandConstants.getNewAdapterInstanceIdForK8sEnv(
+                podName, containerId, counter);
+        return new HonoTopic(HonoTopic.Type.COMMAND_INTERNAL, adapterInstanceId).toString();
+    }
+}

--- a/tests/src/test/java/org/eclipse/hono/tests/commandrouter/KafkaBasedCommandConsumerFactoryImplIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/commandrouter/KafkaBasedCommandConsumerFactoryImplIT.java
@@ -436,7 +436,7 @@ public class KafkaBasedCommandConsumerFactoryImplIT {
         final CommandRouterMetrics metrics = mock(CommandRouterMetrics.class);
         final var kafkaBasedCommandConsumerFactoryImpl = new KafkaBasedCommandConsumerFactoryImpl(vertx, tenantClient,
                 commandTargetMapper, producerFactory, IntegrationTestSupport.getKafkaProducerConfig(),
-                kafkaConsumerConfig, metrics, NoopKafkaClientMetricsSupport.INSTANCE, tracer);
+                kafkaConsumerConfig, metrics, NoopKafkaClientMetricsSupport.INSTANCE, tracer, null);
         kafkaBasedCommandConsumerFactoryImpl.setGroupId(commandRouterGroupId);
         componentsToStopAfterTest.add(kafkaBasedCommandConsumerFactoryImpl);
         return kafkaBasedCommandConsumerFactoryImpl;


### PR DESCRIPTION
This fixes #2901:
The `hono.command_internal.[adapterInstanceId]` Kafka topics associated with dead adapter instances are now deleted with some delay in the Command Router component.
This relies on the `KubernetesBasedAdapterInstanceStatusService` (as the only `AdapterInstanceStatusService` implementation right now) to recognize dead adapter instances.