### PR TITLE
Run ITs with preferred profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,24 +26,24 @@ jobs:
       matrix:
         device-registry: [file,jdbc,mongodb]
         include:
-          # Use quarkus-jvm images: file registry, kafka messaging, spring-boot-command-router with embedded cache
-          - device-registry: file
-            commandrouting-mode: spring-boot-command-router
-            commandrouting-cache: embedded
-            component-type: quarkus-jvm
-            messaging-type: kafka
-          # Use spring-boot images: jdbc registry, amqp messaging, dev-con-service with embedded cache
-          - device-registry: jdbc
-            commandrouting-mode: dev-con-service
-            commandrouting-cache: embedded
-            component-type: spring-boot
-            messaging-type: amqp
-          # Use quarkus-jvm images: mongodb registry, amqp messaging, command-router with server cache
-          - device-registry: mongodb
-            commandrouting-mode: command-router
-            commandrouting-cache: server
-            component-type: quarkus-jvm
-            messaging-type: amqp
+        # Use Quarkus JVM images: file registry, AMQP messaging, Command Router with embedded cache
+        - device-registry: file
+          commandrouting-mode: command-router
+          commandrouting-cache: embedded
+          component-type: quarkus-jvm
+          messaging-type: amqp
+        # Use Spring Boot images: jdbc registry, Kafka messaging, Command Router with embedded cache
+        - device-registry: jdbc
+          commandrouting-mode: command-router
+          commandrouting-cache: embedded
+          component-type: spring-boot
+          messaging-type: kafka
+        # Use Quarkus JVM images: mongodb registry, Kafka messaging, Command Router with data grid
+        - device-registry: mongodb
+          commandrouting-mode: command-router
+          commandrouting-cache: server
+          component-type: quarkus-jvm
+          messaging-type: kafka
 
     name: "Use ${{ matrix.component-type }} images: ${{ matrix.device-registry }} registry, ${{ matrix.messaging-type }} messaging, ${{ matrix.commandrouting-mode }} with ${{ matrix.commandrouting-cache }} cache"
     steps:

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -577,20 +577,6 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
       </properties>
     </profile>
     <profile>
-      <!-- overriding the above "components-quarkus-jvm"/"components-quarkus-native" profiles in terms of the command-router properties -->
-      <id>command-router-spring-boot</id>
-      <activation>
-        <property>
-          <name>hono.commandrouting.mode</name>
-          <value>spring-boot-command-router</value>
-        </property>
-      </activation>
-      <properties>
-        <hono.command-router.config-dir>etc/hono</hono.command-router.config-dir>
-        <hono.command-router.image>hono-service-command-router</hono.command-router.image>
-      </properties>
-    </profile>
-    <profile>
       <id>run-tests</id>
       <build>
         <plugins>


### PR DESCRIPTION
The integration test profiles to be run on GitHub Actions have been
modified to better reflect the preferred setup. The deprecated Device
Connection service has been removed from the three profiles altogether
in order to reuse the slot for an additional setup with the Command
Router.