### PR TITLE
Pick up Kafka client ID prefix configuration property

### DIFF
--- a/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
+++ b/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
@@ -232,7 +232,6 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
         this.kafkaProducerConfig.setProducerConfig(options.producerConfig());
 
         this.kafkaConsumerConfig = new MessagingKafkaConsumerConfigProperties();
-        this.kafkaConsumerConfig.setDefaultClientIdPrefix(options.defaultClientIdPrefix().orElse(getComponentName()));
         clientIdPrefix.ifPresent(this.kafkaConsumerConfig::setDefaultClientIdPrefix);
         this.kafkaConsumerConfig.setCommonClientConfig(options.commonClientConfig());
         this.kafkaConsumerConfig.setConsumerConfig(options.consumerConfig());

--- a/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
+++ b/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
@@ -222,15 +222,23 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
 
     @Inject
     void setKafkaClientOptions(final KafkaClientOptions options) {
+
+        final Optional<String> clientIdPrefix = Optional.ofNullable(
+                options.defaultClientIdPrefix().orElse(getComponentName()));
+
         this.kafkaProducerConfig = new MessagingKafkaProducerConfigProperties();
+        clientIdPrefix.ifPresent(this.kafkaProducerConfig::setDefaultClientIdPrefix);
         this.kafkaProducerConfig.setCommonClientConfig(options.commonClientConfig());
         this.kafkaProducerConfig.setProducerConfig(options.producerConfig());
 
         this.kafkaConsumerConfig = new MessagingKafkaConsumerConfigProperties();
+        this.kafkaConsumerConfig.setDefaultClientIdPrefix(options.defaultClientIdPrefix().orElse(getComponentName()));
+        clientIdPrefix.ifPresent(this.kafkaConsumerConfig::setDefaultClientIdPrefix);
         this.kafkaConsumerConfig.setCommonClientConfig(options.commonClientConfig());
         this.kafkaConsumerConfig.setConsumerConfig(options.consumerConfig());
 
         this.kafkaAdminClientConfig = new KafkaAdminClientConfigProperties();
+        clientIdPrefix.ifPresent(this.kafkaAdminClientConfig::setDefaultClientIdPrefix);
         this.kafkaAdminClientConfig.setCommonClientConfig(options.commonClientConfig());
         this.kafkaAdminClientConfig.setAdminClientConfig(options.adminClientConfig());
     }
@@ -548,9 +556,13 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
      * @return The Kafka metrics support.
      */
     public KafkaClientMetricsSupport kafkaClientMetricsSupport(final KafkaMetricsOptions options) {
-        return options.enabled()
-                ? new MicrometerKafkaClientMetricsSupport(meterRegistry, options.useDefaultMetrics(),
-                        options.metricsPrefixes().orElse(List.of()))
-                : NoopKafkaClientMetricsSupport.INSTANCE;
+        if (options.enabled()) {
+            return new MicrometerKafkaClientMetricsSupport(
+                    meterRegistry,
+                    options.useDefaultMetrics(),
+                    options.metricsPrefixes().orElse(List.of()));
+        } else {
+            return NoopKafkaClientMetricsSupport.INSTANCE;
+        }
     }
 }

--- a/adapter-base-quarkus/src/test/java/org/eclipse/hono/adapter/quarkus/QuarkusPropertyBindingTest.java
+++ b/adapter-base-quarkus/src/test/java/org/eclipse/hono/adapter/quarkus/QuarkusPropertyBindingTest.java
@@ -17,7 +17,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import javax.inject.Inject;
 
-import org.eclipse.hono.client.kafka.KafkaClientOptions;
 import org.eclipse.hono.config.MapperEndpoint;
 import org.eclipse.hono.config.ProtocolAdapterOptions;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
@@ -32,67 +31,7 @@ import io.quarkus.test.junit.QuarkusTest;
 public class QuarkusPropertyBindingTest {
 
     @Inject
-    KafkaClientOptions kafkaClientOptions;
-
-    @Inject
     ProtocolAdapterOptions protocolAdapterOptions;
-
-    /**
-     * Asserts that the Kafka configuration is exposed as a beans.
-     */
-    @Test
-    public void testThatClientOptionsExist() {
-        assertThat(kafkaClientOptions).isNotNull();
-    }
-
-    /**
-     * Asserts that common client properties are present.
-     */
-    @Test
-    public void testThatCommonConfigIsPresent() {
-        assertThat(kafkaClientOptions.commonClientConfig().get("common.property")).isEqualTo("present");
-        assertThat(kafkaClientOptions.commonClientConfig().get("empty")).isEqualTo("");
-    }
-
-    /**
-     * Asserts that consumer properties are present.
-     */
-    @Test
-    public void testThatConsumerConfigIsPresent() {
-        assertThat(kafkaClientOptions.consumerConfig().get("consumer.property")).isEqualTo("consumer");
-    }
-
-    /**
-     * Asserts that admin client properties are present.
-     */
-    @Test
-    public void testThatAdminClientConfigIsPresent() {
-        assertThat(kafkaClientOptions.adminClientConfig().get("admin.property")).isEqualTo("admin");
-    }
-
-    /**
-     * Asserts that producer properties are present.
-     */
-    @Test
-    public void testThatProducerConfigIsPresent() {
-        assertThat(kafkaClientOptions.producerConfig().get("producer.property")).isEqualTo("producer");
-    }
-
-    /**
-     * Asserts that compound keys that contain dots are added and not changed.
-     */
-    @Test
-    public void testThatKeysWithDotsAreAllowed() {
-        assertThat(kafkaClientOptions.commonClientConfig().get("bootstrap.servers")).isEqualTo("example.com:9999");
-    }
-
-    /**
-     * Asserts that properties with a numeric value added as strings.
-     */
-    @Test
-    public void testThatNumbersArePresentAsStrings() {
-        assertThat(kafkaClientOptions.commonClientConfig().get("number")).isEqualTo("123");
-    }
 
     /**
      * Verifies that Quarkus correctly binds properties from a yaml file to a

--- a/adapter-base-quarkus/src/test/resources/application.yaml
+++ b/adapter-base-quarkus/src/test/resources/application.yaml
@@ -3,18 +3,3 @@ hono:
     mapperEndpoints:
       telemetry:
         uri: "https://mapper.eclipseprojects.io/telemetry"
-  kafka:
-    commonClientConfig:
-      common.property: "present"
-      number: 123
-      empty: ""
-      bootstrap.servers: "example.com:9999"
-      admin.property: "common"
-      consumer.property: "common"
-      producer.property: "common"
-    adminClientConfig:
-      admin.property: "admin"
-    consumerConfig:
-      consumer.property: "consumer"
-    producerConfig:
-      producer.property: "producer"

--- a/clients/kafka-common/pom.xml
+++ b/clients/kafka-common/pom.xml
@@ -87,6 +87,27 @@
       <artifactId>kafka-test-utils</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-ide-launcher</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-config-yaml</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-vertx</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/clients/kafka-common/pom.xml
+++ b/clients/kafka-common/pom.xml
@@ -110,4 +110,25 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <properties>
+            <!-- 
+              do not run unit test classes in parallel as this seems to have
+              a negative effect on startup of Quarkus in tests annotated with
+              @QuarkusTest
+             -->
+            <configurationParameters>
+              junit.jupiter.execution.parallel.enabled = false
+            </configurationParameters>
+          </properties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaClientOptions.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaClientOptions.java
@@ -14,6 +14,7 @@
 package org.eclipse.hono.client.kafka;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -30,6 +31,19 @@ public class KafkaClientOptions {
 
     @Inject
     RawKafkaClientOptions rawKafkaClientOptions;
+
+    /**
+     * Gets the prefix for the client ID that is passed to the Kafka server to allow application
+     * specific server-side request logging.
+     * <p>
+     * If the common or specific client config already contains a value for key {@code client.id}, that one
+     * will be used and the parameter here will be ignored.
+     *
+     * @return The client ID prefix to use.
+     */
+    public Optional<String> defaultClientIdPrefix() {
+        return rawKafkaClientOptions.defaultClientIdPrefix();
+    }
 
     /**
      * The properties shared by all types of clients.
@@ -84,25 +98,40 @@ public class KafkaClientOptions {
     interface RawKafkaClientOptions {
 
         /**
+         * Gets the prefix for the client ID that is passed to the Kafka server to allow application
+         * specific server-side request logging.
+         * <p>
+         * If the common or specific client config already contains a value for key {@code client.id}, that one
+         * will be used and the parameter here will be ignored.
+         *
+         * @return The client ID prefix to use.
+         */
+        Optional<String> defaultClientIdPrefix();
+
+        /**
          * The properties shared by all types of clients.
+         *
          * @return The properties.
          */
         Map<String, ConfigValue> commonClientConfig();
 
         /**
          * The properties to use for admin clients.
+         *
          * @return The properties.
          */
         Map<String, ConfigValue> adminClientConfig();
 
         /**
          * The properties to use for consumers.
+         *
          * @return The properties.
          */
         Map<String, ConfigValue> consumerConfig();
 
         /**
          * The properties to use for producers.
+         *
          * @return The properties.
          */
         Map<String, ConfigValue> producerConfig();

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaClientOptionsTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaClientOptionsTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Verifies that Quarkus binds properties from yaml files to configuration objects.
+ */
+@QuarkusTest
+public class KafkaClientOptionsTest {
+
+    @Inject
+    KafkaClientOptions kafkaClientOptions;
+
+    /**
+     * Asserts that the Kafka configuration is exposed as a beans.
+     */
+    @Test
+    public void testThatClientOptionsExist() {
+        assertThat(kafkaClientOptions).isNotNull();
+    }
+
+    /**
+     * Verifies that the configured default client ID prefix is picked up.
+     */
+    @Test
+    public void testThatDefaultClientIdPrefixIsSet() {
+        assertThat(kafkaClientOptions.defaultClientIdPrefix().isPresent()).isTrue();
+        assertThat(kafkaClientOptions.defaultClientIdPrefix().get()).isEqualTo("prefix");
+    }
+
+    /**
+     * Asserts that common client properties are present.
+     */
+    @Test
+    public void testThatCommonConfigIsPresent() {
+        assertThat(kafkaClientOptions.commonClientConfig().get("common.property")).isEqualTo("present");
+        assertThat(kafkaClientOptions.commonClientConfig().get("empty")).isEqualTo("");
+    }
+
+    /**
+     * Asserts that consumer properties are present.
+     */
+    @Test
+    public void testThatConsumerConfigIsPresent() {
+        assertThat(kafkaClientOptions.consumerConfig().get("consumer.property")).isEqualTo("consumer");
+    }
+
+    /**
+     * Asserts that admin client properties are present.
+     */
+    @Test
+    public void testThatAdminClientConfigIsPresent() {
+        assertThat(kafkaClientOptions.adminClientConfig().get("admin.property")).isEqualTo("admin");
+    }
+
+    /**
+     * Asserts that producer properties are present.
+     */
+    @Test
+    public void testThatProducerConfigIsPresent() {
+        assertThat(kafkaClientOptions.producerConfig().get("producer.property")).isEqualTo("producer");
+    }
+
+    /**
+     * Asserts that compound keys that contain dots are added and not changed.
+     */
+    @Test
+    public void testThatKeysWithDotsAreAllowed() {
+        assertThat(kafkaClientOptions.commonClientConfig().get("bootstrap.servers")).isEqualTo("example.com:9999");
+    }
+
+    /**
+     * Asserts that properties with a numeric value added as strings.
+     */
+    @Test
+    public void testThatNumbersArePresentAsStrings() {
+        assertThat(kafkaClientOptions.commonClientConfig().get("number")).isEqualTo("123");
+    }
+}

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/metrics/KafkaMetricsOptionsTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/metrics/KafkaMetricsOptionsTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Verifies that Quarkus binds properties from yaml files to configuration objects.
+ */
+@QuarkusTest
+public class KafkaMetricsOptionsTest {
+
+    @Inject
+    KafkaMetricsOptions kafkaMetricsOptions;
+
+    /**
+     * Verifies that the metrics properties are bound correctly.
+     */
+    @Test
+    public void testPropertyBinding() {
+        assertThat(kafkaMetricsOptions).isNotNull();
+        assertThat(kafkaMetricsOptions.enabled()).isFalse();
+        assertThat(kafkaMetricsOptions.metricsPrefixes().isPresent()).isTrue();
+        assertThat(kafkaMetricsOptions.metricsPrefixes().get()).containsExactly("metrics.one", "metrics.two");
+    }
+}

--- a/clients/kafka-common/src/test/resources/application.yaml
+++ b/clients/kafka-common/src/test/resources/application.yaml
@@ -1,0 +1,22 @@
+hono:
+  kafka:
+    defaultClientIdPrefix: "prefix"
+    commonClientConfig:
+      common.property: "present"
+      number: 123
+      empty: ""
+      bootstrap.servers: "example.com:9999"
+      admin.property: "common"
+      consumer.property: "common"
+      producer.property: "common"
+    adminClientConfig:
+      admin.property: "admin"
+    consumerConfig:
+      consumer.property: "consumer"
+    producerConfig:
+      producer.property: "producer"
+    metrics:
+      enabled: false
+      metricsPrefixes:
+      - "metrics.one"
+      - "metrics.two"

--- a/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/quarkus/Application.java
+++ b/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/quarkus/Application.java
@@ -180,12 +180,14 @@ public class Application extends AbstractServiceApplication {
         this.kafkaProducerConfig = new MessagingKafkaProducerConfigProperties();
         this.kafkaProducerConfig.setCommonClientConfig(options.commonClientConfig());
         this.kafkaProducerConfig.setProducerConfig(options.producerConfig());
-        this.kafkaProducerConfig.setDefaultClientIdPrefix(DEFAULT_CLIENT_ID_PREFIX);
+        this.kafkaProducerConfig.setDefaultClientIdPrefix(
+                options.defaultClientIdPrefix().orElse(DEFAULT_CLIENT_ID_PREFIX));
 
         this.kafkaConsumerConfig = new MessagingKafkaConsumerConfigProperties();
         this.kafkaConsumerConfig.setCommonClientConfig(options.commonClientConfig());
         this.kafkaConsumerConfig.setConsumerConfig(options.consumerConfig());
-        this.kafkaConsumerConfig.setDefaultClientIdPrefix(DEFAULT_CLIENT_ID_PREFIX);
+        this.kafkaConsumerConfig.setDefaultClientIdPrefix(
+                options.defaultClientIdPrefix().orElse(DEFAULT_CLIENT_ID_PREFIX));
     }
 
     @Override

--- a/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
+++ b/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
@@ -13,15 +13,17 @@ The implementation as well as its APIs may change with the next version.
 
 ## Configuring Tenants to use Kafka based Messaging
 
-Hono's components by default support using AQMP 1.0 based messaging infrastructure to transmit messages hence and forth
+Hono's components by default support using AMQP 1.0 based messaging infrastructure to transmit messages hence and forth
 between devices and applications. Hono also supports using Kafka as the messaging infrastructure either as a replacement
 for or as an alternative in addition to the AMQP 1.0 based infrastructure.
 
-All tenants configured in Hono use the AMQP 1.0 based infrastructure by default. A tenant can also be configured
-to use Kafka instead of AMQP 1.0 by means of adding the property `ext/messaging-type` with value `kafka` to the
-[tenant's configuration]({{< relref "/api/tenant#tenant-information-format" >}}) in the registry.
+In most cases Hono's components will be configured to use either AMQP 1.0 or Kafka based messaging infrastructure.
+However, in cases where both types of infrastructure are being used, Hono's components need to be able to determine,
+which infrastructure should be used for messages of a given tenant. For this purpose, the [configuration properties
+registered for a tenant]({{< relref "/api/tenant#tenant-information-format" >}}) support the `ext/messaging-type` property
+which can have a value of either `amqp` or `kafka`.
 
-The following example shows a tenant that is configured to use Kafka for messaging:
+The following example shows a tenant that is configured to use the Kafka messaging infrastructure:
 
 ~~~json
 {
@@ -37,9 +39,8 @@ If not explicitly set, the `ext/messaging-type` property's value is `amqp` which
 for the tenant.
 
 {{% notice info %}}
-Protocol adapters need to be configured with connection information for both AMQP 1.0 and Kafka based messaging
-infrastructure in order to be able to do this kind of configuration at the tenant level. If an adapter is configured
-to connect to only one type of messaging infrastructure, the tenant specific messaging type configuration is ignored.
+If an adapter is configured to connect to only one type of messaging infrastructure, the tenant specific messaging
+type configuration is ignored.
 {{% /notice %}}
 
 ## Producer Configuration Properties

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -37,6 +37,8 @@ description = "Information about changes in recent Hono releases. Includes new f
 * The Hono container images released with tag 1.10.0 failed to start up when not running as user `root` because the
   Java process was lacking authority to create a temporary directory in the file system's root folder (`/`).
   This has been fixed.
+* The Quarkus based variants of the Hono components did not pick up the `hono.kafka.defaultClientIdPrefix` configuration
+  property. This has been fixed.
 
 ## 1.10.0
 

--- a/tests/src/test/resources/amqp/application.yml
+++ b/tests/src/test/resources/amqp/application.yml
@@ -86,6 +86,7 @@ hono:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
     preferNative: true
   kafka:
+    defaultClientIdPrefix: "hono-amqp-adapter"
     commonClientConfig:
       bootstrap.servers: ${hono.kafka.bootstrap.servers}
 

--- a/tests/src/test/resources/coap/application.yml
+++ b/tests/src/test/resources/coap/application.yml
@@ -85,6 +85,7 @@ hono:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
     preferNative: true
   kafka:
+    defaultClientIdPrefix: "hono-coap-adapter"
     commonClientConfig:
       bootstrap.servers: ${hono.kafka.bootstrap.servers}
 

--- a/tests/src/test/resources/http/application.yml
+++ b/tests/src/test/resources/http/application.yml
@@ -79,6 +79,7 @@ hono:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
     preferNative: true
   kafka:
+    defaultClientIdPrefix: "hono-http-adapter"
     commonClientConfig:
       bootstrap.servers: ${hono.kafka.bootstrap.servers}
 

--- a/tests/src/test/resources/mqtt/application.yml
+++ b/tests/src/test/resources/mqtt/application.yml
@@ -77,6 +77,7 @@ hono:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
     preferNative: true
   kafka:
+    defaultClientIdPrefix: "hono-mqtt-adapter"
     commonClientConfig:
       bootstrap.servers: ${hono.kafka.bootstrap.servers}
 


### PR DESCRIPTION
The Quarkus based components did not support the "defaultClientIdPrefix"
configuration property of the Kafka client.

Fixes #2960