### PR TITLE
[#2945] Add tenant_id header for Kafka-based command response

### DIFF
--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSender.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSender.java
@@ -76,6 +76,7 @@ public class KafkaBasedCommandResponseSender extends AbstractKafkaBasedMessageSe
 
         final List<KafkaHeader> headers = new ArrayList<>(encodePropertiesAsKafkaHeaders(response.getAdditionalProperties(), span));
         headers.add(KafkaRecordHelper.createKafkaHeader(MessageHelper.SYS_PROPERTY_CORRELATION_ID, response.getCorrelationId()));
+        headers.add(KafkaRecordHelper.createKafkaHeader(MessageHelper.APP_PROPERTY_TENANT_ID, response.getTenantId()));
         headers.add(KafkaRecordHelper.createKafkaHeader(MessageHelper.APP_PROPERTY_DEVICE_ID, response.getDeviceId()));
         headers.add(KafkaRecordHelper.createKafkaHeader(MessageHelper.APP_PROPERTY_STATUS, response.getStatus()));
         headers.add(KafkaRecordHelper.createKafkaHeader(MessageHelper.SYS_PROPERTY_CONTENT_TYPE,

--- a/clients/command-kafka/src/test/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSenderTest.java
+++ b/clients/command-kafka/src/test/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSenderTest.java
@@ -103,6 +103,10 @@ public class KafkaBasedCommandResponseSenderTest {
 
                         //Verify if the record contains the necessary headers.
                         final Headers headers = record.headers();
+                        assertThat(headers.headers(MessageHelper.APP_PROPERTY_TENANT_ID)).hasSize(1);
+                        assertThat(headers).contains(
+                                new RecordHeader(MessageHelper.APP_PROPERTY_TENANT_ID, tenantId.getBytes()));
+
                         assertThat(headers.headers(MessageHelper.APP_PROPERTY_DEVICE_ID)).hasSize(1);
                         assertThat(headers).contains(
                                 new RecordHeader(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId.getBytes()));

--- a/site/documentation/content/api/command-and-control-kafka/index.md
+++ b/site/documentation/content/api/command-and-control-kafka/index.md
@@ -108,6 +108,7 @@ The following table provides an overview of the headers set on a message sent in
 | *creation-time*    | yes       | *long*    | The instant in time (milliseconds since the Unix epoch) when the message has been created. |
 | *device_id*        | yes       | *string*  | The identifier of the device that sent the response. |
 | *status*           | yes       | *integer* | MUST indicate the status of the execution. See table below for possible values. |
+| *tenant_id*        | yes       | *string*  | The identifier of the tenant that the device belongs to. |
 | *content-type*     | no        | *string*  | If present, MUST contain a *Media Type* as defined by [RFC 2046](https://tools.ietf.org/html/rfc2046) which describes the semantics and format of the command's input data contained in the message payload. However, not all protocol adapters will support this property as not all transport protocols provide means to convey this information, e.g. MQTT 3.1.1 has no notion of message headers.<br>If the response is an error message sent by the Hono protocol adapter or Command Router component, the content type MUST be *application/vnd.eclipse-hono-delivery-failure-notification+json*. |
 | *delivery-failure-notification-metadata[\*]* | no | *string* | MUST be adopted from the command message headers with the same names *if* the response is an error message sent by the Hono protocol adapter or Command Router component. |
 

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -39,6 +39,7 @@ description = "Information about changes in recent Hono releases. Includes new f
   This has been fixed.
 * The Quarkus based variants of the Hono components did not pick up the `hono.kafka.defaultClientIdPrefix` configuration
   property. This has been fixed.
+* Command response messages published via Kafka did not contain the `tenant_id` header. This has been fixed.
 
 ## 1.10.0
 


### PR DESCRIPTION
This fixes #2945.