### PR TITLE
Don't let stop() fail if cache already stopped

### DIFF
--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/BasicCache.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/BasicCache.java
@@ -86,7 +86,7 @@ public abstract class BasicCache<K, V> implements Cache<K, V>, Lifecycle {
     @Override
     public Future<Void> stop() {
         if (!stopCalled.compareAndSet(false, true)) {
-            return Future.failedFuture("stop already called");
+            return Future.succeededFuture();
         }
         LOG.info("stopping cache");
         setCache(null);


### PR DESCRIPTION
Correction regarding #2947:
If `stop()` was already called (e.g. from another verticle), the result Future shouldn't be failed.
Otherwise the whole verticle undeployment would be logged as failed:
```
ERROR  io.vertx.core.impl.DeploymentManager  Undeploy failed
io.vertx.core.impl.NoStackTraceThrowable: stop already called
```
