### PR TITLE
[#2825] Make use of auth-id template to get credentials

### DIFF
--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/credentials/AbstractCredentialsService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/credentials/AbstractCredentialsService.java
@@ -19,10 +19,10 @@ import java.util.Optional;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.deviceregistry.service.tenant.NoopTenantInformationService;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
-import org.eclipse.hono.deviceregistry.service.tenant.TenantKey;
 import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
 import org.eclipse.hono.service.credentials.CredentialsService;
 import org.eclipse.hono.service.management.device.DeviceAndGatewayAutoProvisioner;
+import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.Constants;
@@ -98,7 +98,7 @@ public abstract class AbstractCredentialsService implements CredentialsService, 
     /**
      * Get credentials for a device.
      *
-     * @param tenant The tenant key object.
+     * @param tenant The tenant information.
      * @param key The credentials key object.
      * @param clientContext Optional bag of properties that can be used to identify the device.
      * @param span The active OpenTracing span for this operation.
@@ -106,7 +106,7 @@ public abstract class AbstractCredentialsService implements CredentialsService, 
      * @throws NullPointerException if any of the parameters other than client context are {@code null}.
      */
     protected abstract Future<CredentialsResult<JsonObject>> processGet(
-            TenantKey tenant,
+            Tenant tenant,
             CredentialKey key,
             JsonObject clientContext,
             Span span);
@@ -153,7 +153,7 @@ public abstract class AbstractCredentialsService implements CredentialsService, 
                 .compose(tenant -> {
                     LOG.trace("retrieving credentials by auth-id");
                     return processGet(
-                            TenantKey.from(tenantId),
+                            tenant,
                             CredentialKey.from(tenantId, authId, type),
                             clientContext,
                             span)

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/credentials/AbstractCredentialsServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/credentials/AbstractCredentialsServiceTest.java
@@ -21,10 +21,10 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.hono.client.util.MessagingClientProvider;
-import org.eclipse.hono.deviceregistry.service.tenant.TenantKey;
 import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
 import org.eclipse.hono.service.management.device.DeviceAndGatewayAutoProvisioner;
 import org.eclipse.hono.service.management.device.DeviceManagementService;
+import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.CredentialsResult;
@@ -59,7 +59,7 @@ public class AbstractCredentialsServiceTest {
 
         final AbstractCredentialsService credentialsService = new AbstractCredentialsService() {
             @Override
-            protected Future<CredentialsResult<JsonObject>> processGet(final TenantKey tenant, final CredentialKey key,
+            protected Future<CredentialsResult<JsonObject>> processGet(final Tenant tenant, final CredentialKey key,
                     final JsonObject clientContext, final Span span) {
                 return Future.succeededFuture(CredentialsResult.from(HttpURLConnection.HTTP_BAD_GATEWAY));
             }

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/CredentialsServiceImpl.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/CredentialsServiceImpl.java
@@ -77,7 +77,7 @@ public class CredentialsServiceImpl extends AbstractCredentialsService {
                     final var secrets = result.getCredentials()
                             .stream()
                             .map(JsonObject::mapFrom)
-                            .map(c -> DeviceRegistryUtils.applyAuthIdTemplate(c, tenant))
+                            .map(c -> DeviceRegistryUtils.applyAuthIdTemplate(c, tenant, clientContext))
                             .filter(filter(key.getType(), key.getAuthId()))
                             .filter(credential -> DeviceRegistryUtils.matchesWithClientContext(credential, clientContext))
                             .flatMap(c -> c.getJsonArray(CredentialsConstants.FIELD_SECRETS)

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/CredentialsServiceImpl.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/CredentialsServiceImpl.java
@@ -26,9 +26,9 @@ import java.util.stream.Collectors;
 import org.eclipse.hono.deviceregistry.jdbc.config.DeviceServiceProperties;
 import org.eclipse.hono.deviceregistry.service.credentials.AbstractCredentialsService;
 import org.eclipse.hono.deviceregistry.service.credentials.CredentialKey;
-import org.eclipse.hono.deviceregistry.service.tenant.TenantKey;
 import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
 import org.eclipse.hono.service.base.jdbc.store.device.TableAdapterStore;
+import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.CredentialsResult;
@@ -60,7 +60,7 @@ public class CredentialsServiceImpl extends AbstractCredentialsService {
 
     @Override
     protected Future<CredentialsResult<JsonObject>> processGet(
-            final TenantKey tenant,
+            final Tenant tenant,
             final CredentialKey key,
             final JsonObject clientContext,
             final Span span) {
@@ -77,6 +77,7 @@ public class CredentialsServiceImpl extends AbstractCredentialsService {
                     final var secrets = result.getCredentials()
                             .stream()
                             .map(JsonObject::mapFrom)
+                            .map(c -> DeviceRegistryUtils.applyAuthIdTemplate(c, tenant))
                             .filter(filter(key.getType(), key.getAuthId()))
                             .filter(credential -> DeviceRegistryUtils.matchesWithClientContext(credential, clientContext))
                             .flatMap(c -> c.getJsonArray(CredentialsConstants.FIELD_SECRETS)


### PR DESCRIPTION
While working on extending Credentials Management implementations to generate _auth-id_ (if _auth-id template_ is available) from _subject DN_ and store it, I came across a severe drawback in that approach. What if the _auth-id template_ has been changed after device/credentials registration or removed? In that case, with the current approach,  we won't get any credentials as no _auth-id_ will match.  To overcome this, I believe that we should **always** store the _subject DN_ as the _auth-id_ as we did before. During _get credentials_ operation, we can apply the _auth-id template_ to the _subject DN_ and then filter based on the template.  This approach is resilient to such _auth-id template_ modifications.

 @sophokles73 WDYT?