### PR TITLE
[#2967] Remove support for Kafka client ID prefix configuration property

### DIFF
--- a/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
+++ b/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
@@ -222,22 +222,18 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
 
     @Inject
     void setKafkaClientOptions(final KafkaClientOptions options) {
-
-        final Optional<String> clientIdPrefix = Optional.ofNullable(
-                options.defaultClientIdPrefix().orElse(getComponentName()));
-
         this.kafkaProducerConfig = new MessagingKafkaProducerConfigProperties();
-        clientIdPrefix.ifPresent(this.kafkaProducerConfig::setDefaultClientIdPrefix);
+        Optional.ofNullable(getComponentName()).ifPresent(this.kafkaProducerConfig::setDefaultClientIdPrefix);
         this.kafkaProducerConfig.setCommonClientConfig(options.commonClientConfig());
         this.kafkaProducerConfig.setProducerConfig(options.producerConfig());
 
         this.kafkaConsumerConfig = new MessagingKafkaConsumerConfigProperties();
-        clientIdPrefix.ifPresent(this.kafkaConsumerConfig::setDefaultClientIdPrefix);
+        Optional.ofNullable(getComponentName()).ifPresent(this.kafkaConsumerConfig::setDefaultClientIdPrefix);
         this.kafkaConsumerConfig.setCommonClientConfig(options.commonClientConfig());
         this.kafkaConsumerConfig.setConsumerConfig(options.consumerConfig());
 
         this.kafkaAdminClientConfig = new KafkaAdminClientConfigProperties();
-        clientIdPrefix.ifPresent(this.kafkaAdminClientConfig::setDefaultClientIdPrefix);
+        Optional.ofNullable(getComponentName()).ifPresent(this.kafkaAdminClientConfig::setDefaultClientIdPrefix);
         this.kafkaAdminClientConfig.setCommonClientConfig(options.commonClientConfig());
         this.kafkaAdminClientConfig.setAdminClientConfig(options.adminClientConfig());
     }

--- a/clients/kafka-common/pom.xml
+++ b/clients/kafka-common/pom.xml
@@ -117,7 +117,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <properties>
-            <!-- 
+            <!--
               do not run unit test classes in parallel as this seems to have
               a negative effect on startup of Quarkus in tests annotated with
               @QuarkusTest

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaClientOptions.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaClientOptions.java
@@ -14,7 +14,6 @@
 package org.eclipse.hono.client.kafka;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -31,19 +30,6 @@ public class KafkaClientOptions {
 
     @Inject
     RawKafkaClientOptions rawKafkaClientOptions;
-
-    /**
-     * Gets the prefix for the client ID that is passed to the Kafka server to allow application
-     * specific server-side request logging.
-     * <p>
-     * If the common or specific client config already contains a value for key {@code client.id}, that one
-     * will be used and the parameter here will be ignored.
-     *
-     * @return The client ID prefix to use.
-     */
-    public Optional<String> defaultClientIdPrefix() {
-        return rawKafkaClientOptions.defaultClientIdPrefix();
-    }
 
     /**
      * The properties shared by all types of clients.
@@ -96,17 +82,6 @@ public class KafkaClientOptions {
      */
     @ConfigMapping(prefix = "hono.kafka", namingStrategy = ConfigMapping.NamingStrategy.VERBATIM)
     interface RawKafkaClientOptions {
-
-        /**
-         * Gets the prefix for the client ID that is passed to the Kafka server to allow application
-         * specific server-side request logging.
-         * <p>
-         * If the common or specific client config already contains a value for key {@code client.id}, that one
-         * will be used and the parameter here will be ignored.
-         *
-         * @return The client ID prefix to use.
-         */
-        Optional<String> defaultClientIdPrefix();
 
         /**
          * The properties shared by all types of clients.

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaClientOptionsTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaClientOptionsTest.java
@@ -39,15 +39,6 @@ public class KafkaClientOptionsTest {
     }
 
     /**
-     * Verifies that the configured default client ID prefix is picked up.
-     */
-    @Test
-    public void testThatDefaultClientIdPrefixIsSet() {
-        assertThat(kafkaClientOptions.defaultClientIdPrefix().isPresent()).isTrue();
-        assertThat(kafkaClientOptions.defaultClientIdPrefix().get()).isEqualTo("prefix");
-    }
-
-    /**
      * Asserts that common client properties are present.
      */
     @Test

--- a/clients/kafka-common/src/test/resources/application.yaml
+++ b/clients/kafka-common/src/test/resources/application.yaml
@@ -1,6 +1,5 @@
 hono:
   kafka:
-    defaultClientIdPrefix: "prefix"
     commonClientConfig:
       common.property: "present"
       number: 123

--- a/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/quarkus/Application.java
+++ b/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/quarkus/Application.java
@@ -184,20 +184,17 @@ public class Application extends AbstractServiceApplication {
         this.kafkaProducerConfig = new MessagingKafkaProducerConfigProperties();
         this.kafkaProducerConfig.setCommonClientConfig(options.commonClientConfig());
         this.kafkaProducerConfig.setProducerConfig(options.producerConfig());
-        this.kafkaProducerConfig.setDefaultClientIdPrefix(
-                options.defaultClientIdPrefix().orElse(DEFAULT_CLIENT_ID_PREFIX));
+        this.kafkaProducerConfig.setDefaultClientIdPrefix(DEFAULT_CLIENT_ID_PREFIX);
 
         this.kafkaConsumerConfig = new MessagingKafkaConsumerConfigProperties();
         this.kafkaConsumerConfig.setCommonClientConfig(options.commonClientConfig());
         this.kafkaConsumerConfig.setConsumerConfig(options.consumerConfig());
-        this.kafkaConsumerConfig.setDefaultClientIdPrefix(
-                options.defaultClientIdPrefix().orElse(DEFAULT_CLIENT_ID_PREFIX));
+        this.kafkaConsumerConfig.setDefaultClientIdPrefix(DEFAULT_CLIENT_ID_PREFIX);
 
         this.kafkaAdminClientConfig = new KafkaAdminClientConfigProperties();
         this.kafkaAdminClientConfig.setCommonClientConfig(options.commonClientConfig());
         this.kafkaAdminClientConfig.setAdminClientConfig(options.adminClientConfig());
-        this.kafkaAdminClientConfig.setDefaultClientIdPrefix(
-                options.defaultClientIdPrefix().orElse(DEFAULT_CLIENT_ID_PREFIX));
+        this.kafkaAdminClientConfig.setDefaultClientIdPrefix(DEFAULT_CLIENT_ID_PREFIX);
     }
 
     @Override

--- a/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
+++ b/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
@@ -149,11 +149,7 @@ Relevant properties are `bootstrap.servers` and the properties related to authen
 The properties must be prefixed with `HONO_KAFKA_COMMONCLIENTCONFIG_` and `hono.kafka.commonClientConfig.` respectively.
 
 A property with the same name defined in the configuration of one of the specific client types above will have precedence
-over the common property. In addition, the following properties can be set:
-
-| OS Environment Variable<br>Java System Property | Mandatory | Default | Description                                    |
-| :---------------------------------------------- | :-------: | :-----: | :----------------------------------------------|
-| `HONO_KAFKA_DEFAULTCLIENTIDPREFIX`<br>`hono.kafka.defaultClientIdPrefix` | no | - | A prefix for the client ID that is passed to the Kafka server to allow application specific server-side request logging.<br>If the common or specific client configuration already contains a value for key `client.id`, that one will be used and this property will be ignored. |
+over the common property.
 
 ## Kafka client metrics configuration
 

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -37,8 +37,6 @@ description = "Information about changes in recent Hono releases. Includes new f
 * The Hono container images released with tag 1.10.0 failed to start up when not running as user `root` because the
   Java process was lacking authority to create a temporary directory in the file system's root folder (`/`).
   This has been fixed.
-* The Quarkus based variants of the Hono components did not pick up the `hono.kafka.defaultClientIdPrefix` configuration
-  property. This has been fixed.
 * Command response messages published via Kafka did not contain the `tenant_id` header. This has been fixed.
 
 ## 1.10.0

--- a/tests/src/test/resources/amqp/application.yml
+++ b/tests/src/test/resources/amqp/application.yml
@@ -86,7 +86,6 @@ hono:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
     preferNative: true
   kafka:
-    defaultClientIdPrefix: "hono-amqp-adapter"
     commonClientConfig:
       bootstrap.servers: ${hono.kafka.bootstrap.servers}
 

--- a/tests/src/test/resources/coap/application.yml
+++ b/tests/src/test/resources/coap/application.yml
@@ -85,7 +85,6 @@ hono:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
     preferNative: true
   kafka:
-    defaultClientIdPrefix: "hono-coap-adapter"
     commonClientConfig:
       bootstrap.servers: ${hono.kafka.bootstrap.servers}
 

--- a/tests/src/test/resources/http/application.yml
+++ b/tests/src/test/resources/http/application.yml
@@ -79,7 +79,6 @@ hono:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
     preferNative: true
   kafka:
-    defaultClientIdPrefix: "hono-http-adapter"
     commonClientConfig:
       bootstrap.servers: ${hono.kafka.bootstrap.servers}
 

--- a/tests/src/test/resources/mqtt/application.yml
+++ b/tests/src/test/resources/mqtt/application.yml
@@ -77,7 +77,6 @@ hono:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
     preferNative: true
   kafka:
-    defaultClientIdPrefix: "hono-mqtt-adapter"
     commonClientConfig:
       bootstrap.servers: ${hono.kafka.bootstrap.servers}
 


### PR DESCRIPTION
This fixes #2967. 
It reverts some changes of PR #2962. Property defaultClientIdPrefix is not intended to be changed by configuration.