### PR TITLE
Fix test-logging in modules that use quarkus-junit5

### DIFF
--- a/adapter-base-quarkus/pom.xml
+++ b/adapter-base-quarkus/pom.xml
@@ -118,6 +118,10 @@
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-ide-launcher</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jboss.slf4j</groupId>
+          <artifactId>slf4j-jboss-logmanager</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/adapter-base/pom.xml
+++ b/adapter-base/pom.xml
@@ -133,6 +133,10 @@
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-ide-launcher</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jboss.slf4j</groupId>
+          <artifactId>slf4j-jboss-logmanager</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/client-device-connection-infinispan/pom.xml
+++ b/client-device-connection-infinispan/pom.xml
@@ -167,6 +167,10 @@
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-ide-launcher</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jboss.slf4j</groupId>
+          <artifactId>slf4j-jboss-logmanager</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/clients/kafka-common/pom.xml
+++ b/clients/kafka-common/pom.xml
@@ -96,6 +96,10 @@
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-ide-launcher</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jboss.slf4j</groupId>
+          <artifactId>slf4j-jboss-logmanager</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/service-base-quarkus/pom.xml
+++ b/service-base-quarkus/pom.xml
@@ -96,6 +96,10 @@
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-ide-launcher</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jboss.slf4j</groupId>
+          <artifactId>slf4j-jboss-logmanager</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/services/auth-base/pom.xml
+++ b/services/auth-base/pom.xml
@@ -70,6 +70,10 @@
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-ide-launcher</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jboss.slf4j</groupId>
+          <artifactId>slf4j-jboss-logmanager</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
When running unit-tests in modules that use the `quarkus-junit5` module, there is this log output:
```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/home/user/.m2/repository/org/jboss/slf4j/slf4j-jboss-logmanager/1.1.0.Final/slf4j-jboss-logmanager-1.1.0.Final.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/user/.m2/repository/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Slf4jLoggerFactory]
```
Log levels defined in `logback-test.xml` don't get applied.