### PR TITLE
Prep work for supporting ttl on all message types

### DIFF
--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedDownstreamMessage.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedDownstreamMessage.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.hono.application.client.amqp;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
@@ -152,6 +153,14 @@ public final class ProtonBasedDownstreamMessage implements DownstreamMessage<Amq
     @Override
     public Instant getCreationTime() {
         return message.getCreationTime() == 0L ? null : Instant.ofEpochMilli(message.getCreationTime());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Duration getTimeToLive() {
+        return message.getTtl() == 0L ? null : Duration.ofMillis(message.getTtl());
     }
 
     /**

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaDownstreamMessage.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaDownstreamMessage.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.application.client.kafka.impl;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
@@ -44,6 +45,7 @@ public class KafkaDownstreamMessage implements DownstreamMessage<KafkaMessageCon
     private final QoS qos;
     private final Buffer payload;
     private final Instant creationTime;
+    private final Duration timeToLive;
     private final Integer timeTillDisconnect;
 
     /**
@@ -64,6 +66,7 @@ public class KafkaDownstreamMessage implements DownstreamMessage<KafkaMessageCon
         qos = getQosHeaderValue(record.headers());
         payload = record.value();
         creationTime = getCreationTimeHeaderValue(record.headers());
+        timeToLive = getTimeToLiveHeaderValue(record.headers());
         timeTillDisconnect = getTimeTillDisconnectHeaderValue(record.headers());
     }
 
@@ -86,6 +89,12 @@ public class KafkaDownstreamMessage implements DownstreamMessage<KafkaMessageCon
     private Instant getCreationTimeHeaderValue(final List<KafkaHeader> headers) {
         return KafkaRecordHelper.getHeaderValue(headers, MessageHelper.SYS_PROPERTY_CREATION_TIME, Long.class)
                 .map(Instant::ofEpochMilli)
+                .orElse(null);
+    }
+
+    private Duration getTimeToLiveHeaderValue(final List<KafkaHeader> headers) {
+        return KafkaRecordHelper.getHeaderValue(headers, MessageHelper.SYS_HEADER_PROPERTY_TTL, Long.class)
+                .map(Duration::ofMillis)
                 .orElse(null);
     }
 
@@ -132,6 +141,14 @@ public class KafkaDownstreamMessage implements DownstreamMessage<KafkaMessageCon
     @Override
     public Instant getCreationTime() {
         return creationTime;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Duration getTimeToLive() {
+        return timeToLive;
     }
 
     @Override

--- a/clients/application/src/main/java/org/eclipse/hono/application/client/DownstreamMessage.java
+++ b/clients/application/src/main/java/org/eclipse/hono/application/client/DownstreamMessage.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.application.client;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 
@@ -76,6 +77,13 @@ public interface DownstreamMessage<T extends MessageContext> extends Message<T> 
      * @return The instant in time or {@code null} if unknown.
      */
     Instant getCreationTime();
+
+    /**
+     * Gets the period of time after which this message should be considered stale.
+     *
+     * @return The duration or {@code null} if the message has no time-to-live.
+     */
+    Duration getTimeToLive();
 
     /**
      * Gets the amount of time that the sender of this message will stay connected

--- a/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
@@ -337,6 +337,21 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      */
     public static final String FIELD_MAX_TTL = "max-ttl";
     /**
+     * The name of the property that contains the maximum <em>time to live</em> (seconds) for
+     * downstream QoS 0 telemetry messages that protocol adapters should use for a tenant.
+     */
+    public static final String FIELD_MAX_TTL_TELEMETRY_QOS0 = "max-ttl-telemetry-qos0";
+    /**
+     * The name of the property that contains the maximum <em>time to live</em> (seconds) for
+     * downstream QoS 1 telemetry messages that protocol adapters should use for a tenant.
+     */
+    public static final String FIELD_MAX_TTL_TELEMETRY_QOS1 = "max-ttl-telemetry-qos1";
+    /**
+     * The name of the property that contains the maximum <em>time to live</em> (seconds) for
+     * downstream command response messages that protocol adapters should use for a tenant.
+     */
+    public static final String FIELD_MAX_TTL_COMMAND_RESPONSE = "max-ttl-command-response";
+    /**
      * The name of the property that contains the minimum message size in bytes.
      */
     public static final String FIELD_MINIMUM_MESSAGE_SIZE = "minimum-message-size";

--- a/core/src/main/java/org/eclipse/hono/util/ResourceLimits.java
+++ b/core/src/main/java/org/eclipse/hono/util/ResourceLimits.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -31,6 +31,12 @@ public class ResourceLimits {
     private int maxConnections = TenantConstants.UNLIMITED_CONNECTIONS;
     @JsonProperty(TenantConstants.FIELD_MAX_TTL)
     private long maxTtl = TenantConstants.UNLIMITED_TTL;
+    @JsonProperty(TenantConstants.FIELD_MAX_TTL_TELEMETRY_QOS0)
+    private long maxTtlTelemetryQos0 = TenantConstants.UNLIMITED_TTL;
+    @JsonProperty(TenantConstants.FIELD_MAX_TTL_TELEMETRY_QOS1)
+    private long maxTtlTelemetryQoS1 = TenantConstants.UNLIMITED_TTL;
+    @JsonProperty(TenantConstants.FIELD_MAX_TTL_COMMAND_RESPONSE)
+    private long maxTtlCommandResponse = TenantConstants.UNLIMITED_TTL;
 
     @JsonProperty(TenantConstants.FIELD_DATA_VOLUME)
     private DataVolume dataVolume;
@@ -68,6 +74,35 @@ public class ResourceLimits {
     }
 
     /**
+     * Gets the maximum time-to-live to use for messages published by
+     * devices of a tenant to a given endpoint.
+     *
+     * @param endpointName The name of the endpoint.
+     * @param qos The quality of service being used for the messages.
+     * @return The time-to-live in seconds.
+     * @throws NullPointerException if the endpoint name indicates a telemetry endpoint and qos is {@code null}.
+     * @throws IllegalArgumentException if endpoint name is unknown.
+     */
+    public final long getMaxTtl(final String endpointName, final QoS qos) {
+        if (EventConstants.isEventEndpoint(endpointName)) {
+            return getMaxTtl();
+        } else if (TelemetryConstants.isTelemetryEndpoint(endpointName)) {
+            if (qos == null) {
+                throw new NullPointerException("QoS must not be null for telemetry endpoint");
+            }
+            switch (qos) {
+            case AT_MOST_ONCE: return getMaxTtlTelemetryQoS0();
+            case AT_LEAST_ONCE:
+            default: return getMaxTtlTelemetryQoS1();
+            }
+        } else if (CommandConstants.isNorthboundCommandResponseEndpoint(endpointName)) {
+            return getMaxTtlCommandResponse();
+        } else {
+            throw new IllegalArgumentException("unknown endpoint name");
+        }
+    }
+
+    /**
      * Sets the maximum time-to-live to use for events published by
      * devices of a tenant.
      *
@@ -75,7 +110,7 @@ public class ResourceLimits {
      * @return A reference to this for fluent use.
      * @throws IllegalArgumentException if the time-to-live is set to less than -1.
      */
-    public ResourceLimits setMaxTtl(final long maxTtl) {
+    public final ResourceLimits setMaxTtl(final long maxTtl) {
         if (maxTtl < -1) {
             throw new IllegalArgumentException("Maximum time-to-live property must be set to value >= -1");
         }
@@ -89,8 +124,86 @@ public class ResourceLimits {
      *
      * @return The time-to-live in seconds.
      */
-    public long getMaxTtl() {
+    public final long getMaxTtl() {
         return this.maxTtl;
+    }
+
+    /**
+     * Sets the maximum time-to-live to use for telemetry messages published by
+     * devices of a tenant with QoS 0.
+     *
+     * @param maxTtl The time-to-live in seconds.
+     * @return A reference to this for fluent use.
+     * @throws IllegalArgumentException if the time-to-live is set to less than -1.
+     */
+    public final ResourceLimits setMaxTtlTelemetryQoS0(final long maxTtl) {
+        if (maxTtl < -1) {
+            throw new IllegalArgumentException("Maximum time-to-live property must be set to value >= -1");
+        }
+        this.maxTtlTelemetryQos0 = maxTtl;
+        return this;
+    }
+
+    /**
+     * Gets the maximum time-to-live to use for telemetry messages published by
+     * devices of a tenant with QoS 0.
+     *
+     * @return The time-to-live in seconds.
+     */
+    public final long getMaxTtlTelemetryQoS0() {
+        return this.maxTtlTelemetryQos0;
+    }
+
+    /**
+     * Sets the maximum time-to-live to use for telemetry messages published by
+     * devices of a tenant with QoS 1.
+     *
+     * @param maxTtl The time-to-live in seconds.
+     * @return A reference to this for fluent use.
+     * @throws IllegalArgumentException if the time-to-live is set to less than -1.
+     */
+    public final ResourceLimits setMaxTtlTelemetryQoS1(final long maxTtl) {
+        if (maxTtl < -1) {
+            throw new IllegalArgumentException("Maximum time-to-live property must be set to value >= -1");
+        }
+        this.maxTtlTelemetryQoS1 = maxTtl;
+        return this;
+    }
+
+    /**
+     * Gets the maximum time-to-live to use for telemetry messages published by
+     * devices of a tenant with QoS 1.
+     *
+     * @return The time-to-live in seconds.
+     */
+    public final long getMaxTtlTelemetryQoS1() {
+        return this.maxTtlTelemetryQoS1;
+    }
+
+    /**
+     * Sets the maximum time-to-live to use for command responses published by
+     * devices of a tenant.
+     *
+     * @param maxTtl The time-to-live in seconds.
+     * @return A reference to this for fluent use.
+     * @throws IllegalArgumentException if the time-to-live is set to less than -1.
+     */
+    public final ResourceLimits setMaxTtlCommandResponse(final long maxTtl) {
+        if (maxTtl < -1) {
+            throw new IllegalArgumentException("Maximum time-to-live property must be set to value >= -1");
+        }
+        this.maxTtlCommandResponse = maxTtl;
+        return this;
+    }
+
+    /**
+     * Gets the maximum time-to-live to use for command responses published by
+     * devices of a tenant.
+     *
+     * @return The time-to-live in seconds.
+     */
+    public final long getMaxTtlCommandResponse() {
+        return this.maxTtlCommandResponse;
     }
 
     /**

--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -111,6 +111,21 @@ public final class TenantConstants extends RequestResponseApiConstants {
      */
     public static final String FIELD_MAX_TTL = "max-ttl";
     /**
+     * The name of the property that contains the maximum <em>time to live</em> (seconds) for
+     * downstream QoS 0 telemetry messages that protocol adapters should use for a tenant.
+     */
+    public static final String FIELD_MAX_TTL_TELEMETRY_QOS0 = "max-ttl-telemetry-qos0";
+    /**
+     * The name of the property that contains the maximum <em>time to live</em> (seconds) for
+     * downstream QoS 1 telemetry messages that protocol adapters should use for a tenant.
+     */
+    public static final String FIELD_MAX_TTL_TELEMETRY_QOS1 = "max-ttl-telemetry-qos1";
+    /**
+     * The name of the property that contains the maximum <em>time to live</em> (seconds) for
+     * downstream command response messages that protocol adapters should use for a tenant.
+     */
+    public static final String FIELD_MAX_TTL_COMMAND_RESPONSE = "max-ttl-command-response";
+    /**
      * The name of the property that contains the algorithm used for a public key.
      */
     public static final String FIELD_PAYLOAD_KEY_ALGORITHM = "algorithm";

--- a/core/src/test/java/org/eclipse/hono/util/TenantObjectTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/TenantObjectTest.java
@@ -358,6 +358,7 @@ public class TenantObjectTest {
     public void testGetResourceLimits() {
         final JsonObject limitsConfig = new JsonObject()
                 .put("max-connections", 2)
+                .put(TenantConstants.FIELD_MAX_TTL_COMMAND_RESPONSE, 30L)
                 .put("data-volume",
                         new JsonObject().put("max-bytes", 20_000_000)
                                 .put("effective-since", "2019-04-25T15:30:00+01:00")
@@ -368,6 +369,7 @@ public class TenantObjectTest {
         tenantObject.setResourceLimits(limitsConfig);
         assertThat(tenantObject.getResourceLimits()).isNotNull();
         assertThat(tenantObject.getResourceLimits().getMaxConnections()).isEqualTo(2);
+        assertThat(tenantObject.getResourceLimits().getMaxTtlCommandResponse()).isEqualTo(30L);
         assertThat(tenantObject.getResourceLimits().getDataVolume().getMaxBytes()).isEqualTo(20_000_000L);
         assertThat(tenantObject.getResourceLimits().getDataVolume().getEffectiveSince()).isEqualTo(Instant.parse("2019-04-25T14:30:00Z"));
         assertThat(tenantObject.getResourceLimits().getDataVolume().getPeriod().getMode()).isEqualTo(PeriodMode.days);

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/tenant/TenantTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/tenant/TenantTest.java
@@ -283,7 +283,10 @@ public class TenantTest {
         final JsonObject tenantSpec = new JsonObject()
                 .put(RegistryManagementConstants.FIELD_RESOURCE_LIMITS, new JsonObject()
                         .put(RegistryManagementConstants.FIELD_MAX_CONNECTIONS, 100)
-                        .put(RegistryManagementConstants.FIELD_MAX_TTL, 30)
+                        .put(RegistryManagementConstants.FIELD_MAX_TTL, 60)
+                        .put(RegistryManagementConstants.FIELD_MAX_TTL_COMMAND_RESPONSE, 40)
+                        .put(RegistryManagementConstants.FIELD_MAX_TTL_TELEMETRY_QOS0, 10)
+                        .put(RegistryManagementConstants.FIELD_MAX_TTL_TELEMETRY_QOS1, 30)
                         .put(RegistryManagementConstants.FIELD_DATA_VOLUME, new JsonObject()
                                 .put(RegistryManagementConstants.FIELD_MAX_BYTES, 20_000_000)
                                 .put(RegistryManagementConstants.FIELD_EFFECTIVE_SINCE, "2019-04-25T14:30:00+02:00")
@@ -303,7 +306,10 @@ public class TenantTest {
         final ResourceLimits limits = tenant.getResourceLimits();
         assertNotNull(limits);
         assertEquals(100, limits.getMaxConnections());
-        assertEquals(30, limits.getMaxTtl());
+        assertEquals(60, limits.getMaxTtl());
+        assertEquals(40, limits.getMaxTtlCommandResponse());
+        assertEquals(10, limits.getMaxTtlTelemetryQoS0());
+        assertEquals(30, limits.getMaxTtlTelemetryQoS1());
         assertNotNull(limits.getDataVolume());
         assertEquals(
                 DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse("2019-04-25T14:30:00+02:00", OffsetDateTime::from).toInstant(),

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -967,9 +967,45 @@ components:
                   devices of this tenant. Any default TTL value specified
                   at either the tenant or device level will be limited to
                   the max value specified here.
-                  If this property is set to a value greater than -1 and no
+                  If this property is set to a value greater than `-1` and no
                   default TTL is specified for a device, the max value will
                   be used for events published by the device.
+                  A value of `-1` (the default) indicates that no limit is set.
+                  Note that this property contains the TTL in seconds whereas
+                  the AMQP 1.0 specification defines a message's ttl header
+                  to use milliseconds.
+            "max-ttl-telemetry-qos0":
+               type: integer
+               default: -1
+               description: |
+                  The maximum time-to-live (in seconds) to use for telemetry messages that
+                  are published by devices of this tenant using QoS 0.
+                  If this property is set to a value greater than `-1` then this value will
+                  be used for all QoS 0 telemetry messages published by the tenant's devices.
+                  A value of `-1` (the default) indicates that no limit is set.
+                  Note that this property contains the TTL in seconds whereas
+                  the AMQP 1.0 specification defines a message's ttl header
+                  to use milliseconds.
+            "max-ttl-telemetry-qos1":
+               type: integer
+               default: -1
+               description: |
+                  The maximum time-to-live (in seconds) to use for telemetry messages that
+                  are published by devices of this tenant using QoS 1.
+                  If this property is set to a value greater than `-1` then this value will
+                  be used for all QoS 1 telemetry messages published by the tenant's devices.
+                  A value of `-1` (the default) indicates that no limit is set.
+                  Note that this property contains the TTL in seconds whereas
+                  the AMQP 1.0 specification defines a message's ttl header
+                  to use milliseconds.
+            "max-ttl-command-response":
+               type: integer
+               default: -1
+               description: |
+                  The maximum time-to-live (in seconds) to use for command response messages
+                  published by devices of this tenant.
+                  If this property is set to a value greater than `-1` then this value will
+                  be used for all command response messages published by the tenant's devices.
                   A value of `-1` (the default) indicates that no limit is set.
                   Note that this property contains the TTL in seconds whereas
                   the AMQP 1.0 specification defines a message's ttl header


### PR DESCRIPTION
This is preparatory work for adding support for setting a TTL on downstream telemetry and command response messages (#2702).