### PR TITLE
[#2837] Publish notification if all devices of a tenant are deleted.

### DIFF
--- a/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/NotificationTopicHelper.java
+++ b/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/NotificationTopicHelper.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.client.notification;
 
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.notification.AbstractNotification;
+import org.eclipse.hono.notification.deviceregistry.AllDevicesOfTenantDeletedNotification;
 import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
 import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
 import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
@@ -44,6 +45,8 @@ public final class NotificationTopicHelper {
             address = DeviceChangeNotification.ADDRESS;
         } else if (CredentialsChangeNotification.class.equals(notificationType)) {
             address = CredentialsChangeNotification.ADDRESS;
+        } else if (AllDevicesOfTenantDeletedNotification.class.equals(notificationType)) {
+            address = AllDevicesOfTenantDeletedNotification.ADDRESS;
         } else {
             throw new IllegalArgumentException("Unknown notification type " + notificationType.getName());
         }

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationTypeResolver.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationTypeResolver.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.notification;
 
+import org.eclipse.hono.notification.deviceregistry.AllDevicesOfTenantDeletedNotification;
 import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
 import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
 import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
@@ -65,6 +66,8 @@ public final class NotificationTypeResolver extends TypeIdResolverBase {
             return context.constructSpecializedType(this.baseType, DeviceChangeNotification.class);
         case CredentialsChangeNotification.TYPE:
             return context.constructSpecializedType(this.baseType, CredentialsChangeNotification.class);
+        case AllDevicesOfTenantDeletedNotification.TYPE:
+            return context.constructSpecializedType(this.baseType, AllDevicesOfTenantDeletedNotification.class);
         default:
             return null;
         }

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/AllDevicesOfTenantDeletedNotification.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/AllDevicesOfTenantDeletedNotification.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import org.eclipse.hono.annotation.HonoTimestamp;
+import org.eclipse.hono.notification.AbstractNotification;
+import org.eclipse.hono.notification.NotificationConstants;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Notification that informs that all devices of a tenant have been deleted.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AllDevicesOfTenantDeletedNotification extends AbstractNotification {
+
+    public static final String TYPE = "all-devices-of-tenant-deleted-v1";
+    public static final String ADDRESS = DeviceChangeNotification.ADDRESS;
+
+    @JsonProperty(value = NotificationConstants.JSON_FIELD_TENANT_ID, required = true)
+    private final String tenantId;
+
+    @JsonCreator
+    AllDevicesOfTenantDeletedNotification(
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_SOURCE, required = true) final String source,
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_CREATION_TIME, required = true) @HonoTimestamp final Instant creationTime,
+            @JsonProperty(value = NotificationConstants.JSON_FIELD_TENANT_ID, required = true) final String tenantId) {
+
+        super(source, creationTime);
+
+        this.tenantId = Objects.requireNonNull(tenantId);
+    }
+
+    /**
+     * Creates an instance.
+     *
+     * @param tenantId The ID of the tenant.
+     * @param creationTime The creation time of the event.
+     * @throws NullPointerException If any of the parameters are {@code null}.
+     */
+    public AllDevicesOfTenantDeletedNotification(final String tenantId, final Instant creationTime) {
+        this(NotificationConstants.SOURCE_DEVICE_REGISTRY, creationTime, tenantId);
+    }
+
+    /**
+     * Gets the ID of the tenant which devices have been deleted.
+     *
+     * @return The tenant ID.
+     */
+    public final String getTenantId() {
+        return tenantId;
+    }
+
+    @Override
+    public final String getType() {
+        return TYPE;
+    }
+
+}

--- a/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/AllDevicesOfTenantDeletedNotificationTest.java
+++ b/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/AllDevicesOfTenantDeletedNotificationTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification.deviceregistry;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.time.Instant;
+
+import org.eclipse.hono.notification.AbstractNotification;
+import org.eclipse.hono.notification.NotificationConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Tests verifying the behavior of {@link AllDevicesOfTenantDeletedNotification}.
+ *
+ */
+public class AllDevicesOfTenantDeletedNotificationTest {
+
+    private static final String CREATION_TIME = "2007-12-03T10:15:30Z";
+    private static final String TENANT_ID = "my-tenant";
+
+    private AbstractNotification notification;
+
+    /**
+     * Sets up the notification.
+     */
+    @BeforeEach
+    public void setUp() {
+        notification = new AllDevicesOfTenantDeletedNotification(TENANT_ID, Instant.parse(CREATION_TIME));
+    }
+
+    /**
+     * Verifies that the expected properties are contained in the JSON.
+     */
+    @Test
+    public void testThatValuesAreContainedInJson() {
+
+        final JsonObject json = JsonObject.mapFrom(notification);
+
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_SOURCE))
+                .isEqualTo(NotificationConstants.SOURCE_DEVICE_REGISTRY);
+        assertThat(json.getInstant(NotificationConstants.JSON_FIELD_CREATION_TIME).toString()).isEqualTo(CREATION_TIME);
+
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_TYPE))
+                .isEqualTo(AllDevicesOfTenantDeletedNotification.TYPE);
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_TENANT_ID)).isEqualTo(TENANT_ID);
+    }
+
+    /**
+     * Verifies that the serialization did not change: the JSON contains the static values and only the expected keys.
+     */
+    @Test
+    public void testThatSerializationIsStable() {
+
+        final JsonObject json = JsonObject.mapFrom(notification);
+        assertThat(json).isNotNull();
+
+        // When adding new properties to the data object, make sure not to break the existing API because messages might
+        // be persisted. For breaking changes add a new object mapper class instead.
+        final int expectedPropertiesCount = 4;
+        assertWithMessage("JSON contains unknown fields").that(json.size()).isEqualTo(expectedPropertiesCount);
+
+        assertThat(json.getString("type")).isEqualTo("all-devices-of-tenant-deleted-v1");
+        assertThat(json.getString("source")).isEqualTo("device-registry");
+        assertThat(json.getString("creation-time")).isEqualTo(CREATION_TIME);
+
+        assertThat(json.getString("tenant-id")).isNotNull();
+
+    }
+
+    /**
+     * Verifies that a serialized notification is deserialized correctly.
+     */
+    @Test
+    public void testDeserialization() {
+
+        final AbstractNotification abstractNotification = Json
+                .decodeValue(JsonObject.mapFrom(notification).toBuffer(), AbstractNotification.class);
+
+        assertThat(abstractNotification).isNotNull();
+        assertThat(abstractNotification).isInstanceOf(AllDevicesOfTenantDeletedNotification.class);
+        final AllDevicesOfTenantDeletedNotification newNotification = (AllDevicesOfTenantDeletedNotification) abstractNotification;
+
+        assertThat(newNotification.getSource()).isEqualTo(NotificationConstants.SOURCE_DEVICE_REGISTRY);
+        assertThat(newNotification.getCreationTime()).isEqualTo(Instant.parse(CREATION_TIME));
+
+        assertThat(newNotification.getTenantId()).isEqualTo(TENANT_ID);
+    }
+
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AbstractDeviceManagementService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AbstractDeviceManagementService.java
@@ -27,6 +27,7 @@ import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
 import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
 import org.eclipse.hono.notification.NoOpNotificationSender;
 import org.eclipse.hono.notification.NotificationSender;
+import org.eclipse.hono.notification.deviceregistry.AllDevicesOfTenantDeletedNotification;
 import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
 import org.eclipse.hono.notification.deviceregistry.LifecycleChange;
 import org.eclipse.hono.service.management.Filter;
@@ -406,7 +407,8 @@ public abstract class AbstractDeviceManagementService implements DeviceManagemen
                     }
                     return processDeleteDevicesOfTenant(tenantId, span);
                 })
-                // TODO send notification
+                .onSuccess(result -> notificationSender
+                        .publish(new AllDevicesOfTenantDeletedNotification(tenantId, Instant.now())))
                 .recover(t -> DeviceRegistryUtils.mapError(t, tenantId));
     }
 


### PR DESCRIPTION
When deleting all devices of a tenant at once, the device registry implementations do not report which devices have been deleted. It is therefore impossible to send out individual change notifications for each device. 
This PR adds a new notification type `DevicesOfTenantDeletedNotification` to inform about this event as suggested by https://github.com/eclipse/hono/pull/2924#discussion_r754078670.