### PR TITLE
Enable setting SSL ciphers in HotRod config

### DIFF
--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/InfinispanRemoteConfigurationOptions.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/InfinispanRemoteConfigurationOptions.java
@@ -29,152 +29,167 @@ import io.smallrye.config.WithDefault;
 public interface InfinispanRemoteConfigurationOptions {
 
     /**
-     * Gets the options.
+     * Gets the connection pool options.
      *
      * @return The options.
      */
     Map<String, String> connectionPool();
 
     /**
-     * Gets the options.
+     * Gets the SASL properties.
      *
-     * @return The options.
+     * @return The properties.
      */
     Map<String, String> saslProperties();
 
     /**
-     * Gets the options.
+     * Gets the cluster options.
      *
      * @return The options.
      */
     Map<String, String> cluster();
 
     /**
-     * Gets the value.
+     * Gets the list of remote servers as a string of the form <em>host1[:port][;host2[:port]]</em>.
      *
-     * @return The value.
+     * @return The servers.
      */
     Optional<String> serverList();
 
     /**
-     * Gets the value.
+     * Gets the auth server name.
      *
-     * @return The value.
+     * @return The server name.
      */
     Optional<String> authServerName();
 
     /**
-     * Gets the value.
+     * Gets the user name to use for authentication.
      *
-     * @return The value.
+     * @return The user name.
      */
     Optional<String> authUsername();
 
     /**
-     * Gets the value.
+     * Gets the password to use for authentication.
      *
-     * @return The value.
+     * @return The password.
      */
     Optional<String> authPassword();
 
     /**
-     * Gets the value.
+     * Gets the auth realm (for DIGEST-MD5 authentication).
      *
-     * @return The value.
+     * @return The realm.
      */
     Optional<String> authRealm();
 
     /**
-     * Gets the value.
+     * Gets the SASL mechanism to use for authentication.
      *
-     * @return The value.
+     * @return The mechanism.
      */
     Optional<String> saslMechanism();
 
     /**
-     * Gets the value.
+     * Gets the socket timeout.
      *
-     * @return The value.
+     * @return The timeout.
      */
     @WithDefault("60000")
     int socketTimeout();
 
     /**
-     * Gets the value.
+     * Gets the connect timeout.
      *
-     * @return The value.
+     * @return The timeout.
      */
     @WithDefault("60000")
     int connectTimeout();
 
     /**
-     * Gets the value.
+     * Gets the path of the trust store.
      *
-     * @return The value.
+     * @return The path.
      */
     Optional<String> trustStorePath();
 
     /**
-     * Gets the value.
+     * Gets the trust store file name.
      *
-     * @return The value.
+     * @return The file name.
      */
     Optional<String> trustStoreFileName();
 
     /**
-     * Gets the value.
+     * Gets the type of the trust store (JKS, JCEKS, PCKS12 or PEM).
      *
-     * @return The value.
+     * @return The type.
      */
     Optional<String> trustStoreType();
 
     /**
-     * Gets the value.
+     * Gets the password of the trust store.
      *
-     * @return The value.
+     * @return The password.
      */
     Optional<String> trustStorePassword();
 
     /**
-     * Gets the value.
+     * Gets the file name of a keystore to use when using client certificate authentication.
      *
-     * @return The value.
+     * @return The file name.
      */
     Optional<String> keyStoreFileName();
 
     /**
-     * Gets the value.
+     * Gets the keystore type.
      *
-     * @return The value.
+     * @return The type.
      */
     Optional<String> keyStoreType();
 
     /**
-     * Gets the value.
+     * Gets the keystore password.
      *
-     * @return The value.
+     * @return The password.
      */
     Optional<String> keyStorePassword();
 
     /**
-     * Gets the value.
+     * Gets the key alias.
      *
-     * @return The value.
+     * @return The alias.
      */
     Optional<String> keyAlias();
 
     /**
-     * Gets the value.
+     * Gets the certificate password in the keystore.
      *
-     * @return The value.
+     * @return The password.
      */
     Optional<String> keyStoreCertificatePassword();
 
     /**
-     * Gets the value.
+     * Checks whether TLS is enabled.
      *
-     * @return The value.
+     * @return {@code true} if TLS is enabled.
      */
     @WithDefault("false")
     boolean useSsl();
+
+    /**
+     * Gets the list of ciphers, separated with spaces and in order of preference, that are used during the TLS
+     * handshake.
+     *
+     * @return The ciphers.
+     */
+    Optional<String> sslCiphers();
+
+    /**
+     * Gets the TLS protocol to use (e.g. TLSv1.2).
+     *
+     * @return The protocol.
+     */
+    Optional<String> sslProtocol();
 }

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/InfinispanRemoteConfigurationProperties.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/InfinispanRemoteConfigurationProperties.java
@@ -75,6 +75,9 @@ public class InfinispanRemoteConfigurationProperties extends ConfigurationProper
         options.trustStoreType().ifPresent(this::setTrustStoreType);
 
         setUseSSL(options.useSsl());
+
+        options.sslCiphers().ifPresent(this::setSSLCiphers);
+        options.sslProtocol().ifPresent(this::setSSLProtocol);
     }
 
     /**
@@ -123,9 +126,25 @@ public class InfinispanRemoteConfigurationProperties extends ConfigurationProper
        });
     }
 
+    // ------- Getters/setters missing in the parent ConfigurationProperties class -------
     /**
-    * {@inheritDoc}
-    */
+     * Gets the SSL ciphers.
+     *
+     * @return The ciphers.
+     */
+    public String getSSLCiphers() {
+        return getProperties().getProperty(SSL_CIPHERS);
+    }
+
+    /**
+     * Sets the SSL ciphers.
+     *
+     * @param ciphers The ciphers.
+     */
+    public void setSSLCiphers(final String ciphers) {
+        getProperties().put(SSL_CIPHERS, ciphers);
+    }
+
    @Override
    public String toString() {
        return MoreObjects

--- a/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/QuarkusPropertyBindingTest.java
+++ b/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/QuarkusPropertyBindingTest.java
@@ -18,10 +18,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import javax.inject.Inject;
 
-import org.eclipse.hono.deviceconnection.infinispan.client.CommonCacheConfig;
-import org.eclipse.hono.deviceconnection.infinispan.client.CommonCacheOptions;
-import org.eclipse.hono.deviceconnection.infinispan.client.InfinispanRemoteConfigurationOptions;
-import org.eclipse.hono.deviceconnection.infinispan.client.InfinispanRemoteConfigurationProperties;
 import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 import org.junit.jupiter.api.Test;
 
@@ -74,5 +70,6 @@ public class QuarkusPropertyBindingTest {
         assertThat(remoteCacheConfig.getTrustStoreType()).isEqualTo("PKCS12");
         assertThat(remoteCacheConfig.getTrustStorePassword()).isEqualTo("trust-store-secret");
         assertThat(remoteCacheConfig.getUseSSL()).isTrue();
+        assertThat(remoteCacheConfig.getSSLCiphers()).isEqualTo("TLS_AES_128_GCM_SHA256 TLS_AES_256_GCM_SHA384 TLS_CHACHA20_POLY1305_SHA256");
     }
 }

--- a/client-device-connection-infinispan/src/test/resources/application.yaml
+++ b/client-device-connection-infinispan/src/test/resources/application.yaml
@@ -23,3 +23,4 @@ hono:
       trustStoreType: "PKCS12"
       trustStorePassword: "trust-store-secret"
       useSsl: true
+      sslCiphers: "TLS_AES_128_GCM_SHA256 TLS_AES_256_GCM_SHA384 TLS_CHACHA20_POLY1305_SHA256"


### PR DESCRIPTION
The [Infinispan HotRod client config](https://docs.jboss.org/infinispan/12.1/apidocs/org/infinispan/client/hotrod/configuration/package-summary.html) allows setting the ciphers to be used in the SSL handshake via the property `infinispan.client.hotrod.ssl_ciphers`.
Unfortunately, there are no corresponding getter/setter methods on the `ConfigurationProperties` object, so that the property isn't adopted in the Spring-based Command Router component.
For the Quarkus-based component, the property can also not be set.

As for the motivation for setting this property:
When using the Boring SSL library, on each connection attempt the following warning is logged:
```
BoringSSL doesn't allow to enable or disable TLSv1.3 ciphers explicitly. 
```
This can be quite misleading. Explicitly setting the ciphers prevents this.