### PR TITLE
[#2953] Use retries when trying to create Kafka admin client

### DIFF
--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaClientFactoryTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaClientFactoryTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka;
+
+import static org.mockito.Mockito.mock;
+import static com.google.common.truth.Truth.assertThat;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.common.config.ConfigException;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.Vertx;
+
+/**
+ * Verifies the behavior of {@link KafkaClientFactory}.
+ */
+public class KafkaClientFactoryTest {
+
+    private final Vertx vertx = mock(Vertx.class);
+
+    /**
+     * Verifies that retries are performed if client creation fails because of an unresolvable URL.
+     */
+    @Test
+    public void testClientCreationIsDoneWithRetries() {
+        VertxMockSupport.runTimersImmediately(vertx);
+        final KafkaClientFactory kafkaClientFactory = new KafkaClientFactory(vertx);
+
+        final String bootstrapServers = "some.invalid.hostname.local:9094";
+        final Map<String, String> clientConfig = Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+        final AtomicInteger creationAttempts = new AtomicInteger();
+        final int expectedCreationAttempts = 3;
+        final Object client = new Object();
+        final Supplier<Object> clientSupplier = () -> {
+            if (creationAttempts.incrementAndGet() < expectedCreationAttempts) {
+                Admin.create(new HashMap<>(clientConfig));
+                throw new AssertionError("admin client creation should have thrown exception");
+            }
+            // let the 3rd attempt succeed (regardless of the config)
+            return client;
+        };
+        kafkaClientFactory.createClientWithRetries(clientSupplier, bootstrapServers, Duration.ofSeconds(1))
+                .onComplete(ar -> {
+                    assertThat(ar.succeeded()).isTrue();
+                    assertThat(ar.result()).isEqualTo(client);
+                    assertThat(creationAttempts.get()).isEqualTo(expectedCreationAttempts);
+                });
+    }
+
+    /**
+     * Verifies that client creation fails if the <em>bootstrap.servers</em> config entry is invalid.
+     */
+    @Test
+    public void testClientCreationFailsForInvalidServersEntry() {
+        VertxMockSupport.runTimersImmediately(vertx);
+        final KafkaClientFactory kafkaClientFactory = new KafkaClientFactory(vertx);
+
+        // contains entry with missing port
+        final String invalidBootstrapServers = "some.invalid.hostname.local, some.invalid.hostname.local:9094";
+        final Map<String, String> clientConfig = Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, invalidBootstrapServers);
+
+        final AtomicInteger creationAttempts = new AtomicInteger();
+        final Supplier<Object> clientSupplier = () -> {
+            creationAttempts.incrementAndGet();
+            Admin.create(new HashMap<>(clientConfig));
+            throw new AssertionError("admin client creation should have thrown exception");
+        };
+        kafkaClientFactory.createClientWithRetries(clientSupplier, invalidBootstrapServers, Duration.ofSeconds(1))
+                .onComplete(ar -> {
+                    assertThat(ar.succeeded()).isFalse();
+                    assertThat(ar.cause().getCause()).isInstanceOf(ConfigException.class);
+                    assertThat(ar.cause().getCause().getMessage()).contains(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG);
+                    // no retries should have been done here
+                    assertThat(creationAttempts.get()).isEqualTo(1);
+                });
+    }
+
+    /**
+     * Verifies that trying to create a client with an unresolvable URL fails after the retry-timeout has been reached.
+     */
+    @Test
+    public void testClientCreationFailsAfterTimeoutReached() {
+        VertxMockSupport.runTimersImmediately(vertx);
+        final KafkaClientFactory kafkaClientFactory = new KafkaClientFactory(vertx);
+
+        final String bootstrapServers = "some.invalid.hostname.local:9094";
+        final Map<String, String> clientConfig = Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+        final AtomicInteger creationAttempts = new AtomicInteger();
+        final int expectedCreationAttempts = 3;
+        final Supplier<Object> clientSupplier = () -> {
+            if (creationAttempts.incrementAndGet() == expectedCreationAttempts) {
+                // let following retries be skipped by letting the retry-timeout be reached
+                kafkaClientFactory.setClock(Clock.offset(Clock.systemUTC(), Duration.ofSeconds(10)));
+            }
+            Admin.create(new HashMap<>(clientConfig));
+            throw new AssertionError("admin client creation should have thrown exception");
+        };
+        kafkaClientFactory.createClientWithRetries(clientSupplier, bootstrapServers, Duration.ofSeconds(1))
+                .onComplete(ar -> {
+                    assertThat(ar.succeeded()).isFalse();
+                    assertThat(ar.cause().getCause()).isInstanceOf(ConfigException.class);
+                    assertThat(ar.cause().getCause().getMessage()).contains(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG);
+                    // no retries should have been done here
+                    assertThat(creationAttempts.get()).isEqualTo(expectedCreationAttempts);
+                });
+    }
+}

--- a/core/src/main/java/org/eclipse/hono/util/Futures.java
+++ b/core/src/main/java/org/eclipse/hono/util/Futures.java
@@ -133,4 +133,23 @@ public final class Futures {
         }
     }
 
+    /**
+     * Gets a handler that completes the given handler on the current Vert.x context (if set).
+     *
+     * @param handlerToComplete The handler to apply the result of the returned handler on.
+     * @param <T> The type of the result.
+     * @return The handler that will wrap the given handler so that it is handled on the original context.
+     * @throws NullPointerException if handlerToComplete is {@code null}.
+     */
+    public static <T> Handler<AsyncResult<T>> onCurrentContextCompletionHandler(
+            final Handler<AsyncResult<T>> handlerToComplete) {
+        Objects.requireNonNull(handlerToComplete);
+        final Context context = Vertx.currentContext();
+        if (context == null) {
+            return handlerToComplete;
+        } else {
+            return ar -> context.runOnContext(v -> handlerToComplete.handle(ar));
+        }
+    }
+
 }

--- a/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/InternalKafkaTopicCleanupServiceTest.java
+++ b/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/InternalKafkaTopicCleanupServiceTest.java
@@ -59,7 +59,7 @@ public class InternalKafkaTopicCleanupServiceTest {
         adapterInstanceStatusService = mock(AdapterInstanceStatusService.class);
         kafkaAdminClient = mock(KafkaAdminClient.class);
         internalKafkaTopicCleanupService = new InternalKafkaTopicCleanupService(vertx, adapterInstanceStatusService,
-                () -> kafkaAdminClient);
+                kafkaAdminClient);
         internalKafkaTopicCleanupService.start();
     }
 


### PR DESCRIPTION
This is the first part of the fix for #2953, using retries when trying to create Kafka admin clients in the protocol adapters and the command router.
