### PR TITLE
Fix JavaDoc in NotificationTopicHelper

### DIFF
--- a/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/KafkaBasedNotificationReceiver.java
+++ b/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/KafkaBasedNotificationReceiver.java
@@ -93,7 +93,7 @@ public class KafkaBasedNotificationReceiver implements NotificationReceiver {
             final Handler<T> consumer) {
 
         if (started) {
-            throw new IllegalStateException("consumers cannot be added when consumer is already started.");
+            throw new IllegalStateException("consumers cannot be added when receiver is already started.");
         }
 
         topics.add(NotificationTopicHelper.getTopicName(notificationType));

--- a/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/NotificationTopicHelper.java
+++ b/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/NotificationTopicHelper.java
@@ -21,7 +21,7 @@ import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
 import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
 
 /**
- * Utility methods to determine the Kafka topic for a given type of notifications.
+ * Utility methods to determine the Kafka topic for a given type of notification.
  */
 public final class NotificationTopicHelper {
 
@@ -30,10 +30,10 @@ public final class NotificationTopicHelper {
     }
 
     /**
-     * Gets the topic name to consume notifications from.
+     * Gets the topic name for a notification type.
      *
-     * @param notificationType The class of the notifications to consume.
-     * @param <T> The type of notifications to consume.
+     * @param notificationType The class of the notification.
+     * @param <T> The type of notification.
      * @return The topic name.
      * @throws IllegalArgumentException If the given type is not a known subclass of {@link AbstractNotification}.
      */


### PR DESCRIPTION
The method `NotificationTopicHelper.getTopicName()` is used on the sender side as well.