### PR TITLE
[#2953] Use retries when trying to create Kafka consumer

### DIFF
--- a/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/KafkaBasedNotificationReceiver.java
+++ b/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/KafkaBasedNotificationReceiver.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import org.apache.kafka.clients.consumer.Consumer;
+import org.eclipse.hono.client.kafka.KafkaClientFactory;
 import org.eclipse.hono.client.kafka.consumer.HonoKafkaConsumer;
 import org.eclipse.hono.notification.AbstractNotification;
 import org.eclipse.hono.notification.NotificationReceiver;
@@ -82,6 +83,7 @@ public class KafkaBasedNotificationReceiver implements NotificationReceiver {
     @Override
     public Future<Void> start() {
         honoKafkaConsumer = new HonoKafkaConsumer(vertx, topics, getRecordHandler(), consumerConfig.getConsumerConfig(NAME));
+        honoKafkaConsumer.setConsumerCreationRetriesTimeout(KafkaClientFactory.UNLIMITED_RETRIES_DURATION);
         Optional.ofNullable(kafkaConsumerSupplier).ifPresent(honoKafkaConsumer::setKafkaConsumerSupplier);
         return honoKafkaConsumer
                 .start()

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/InternalKafkaTopicCleanupService.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/InternalKafkaTopicCleanupService.java
@@ -83,7 +83,8 @@ public class InternalKafkaTopicCleanupService implements Lifecycle {
 
         final Map<String, String> adminClientConfig = adminClientConfigProperties.getAdminClientConfig(CLIENT_NAME);
         final KafkaClientFactory kafkaClientFactory = new KafkaClientFactory(vertx);
-        this.kafkaAdminClientCreator = () -> kafkaClientFactory.createKafkaAdminClientWithRetries(adminClientConfig, null);
+        this.kafkaAdminClientCreator = () -> kafkaClientFactory.createKafkaAdminClientWithRetries(adminClientConfig,
+                KafkaClientFactory.UNLIMITED_RETRIES_DURATION);
     }
 
     /**

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.CooperativeStickyAssignor;
 import org.eclipse.hono.client.command.kafka.KafkaBasedCommandResponseSender;
 import org.eclipse.hono.client.command.kafka.KafkaBasedInternalCommandSender;
 import org.eclipse.hono.client.kafka.HonoTopic;
+import org.eclipse.hono.client.kafka.KafkaClientFactory;
 import org.eclipse.hono.client.kafka.consumer.AsyncHandlingAutoCommitKafkaConsumer;
 import org.eclipse.hono.client.kafka.consumer.MessagingKafkaConsumerConfigProperties;
 import org.eclipse.hono.client.kafka.metrics.KafkaClientMetricsSupport;
@@ -164,6 +165,7 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
         consumerConfig.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         kafkaConsumer = new AsyncHandlingAutoCommitKafkaConsumer(vertx, COMMANDS_TOPIC_PATTERN,
                 commandHandler::mapAndDelegateIncomingCommandMessage, consumerConfig);
+        kafkaConsumer.setConsumerCreationRetriesTimeout(KafkaClientFactory.UNLIMITED_RETRIES_DURATION);
         kafkaConsumer.setMetricsSupport(kafkaClientMetricsSupport);
         kafkaConsumer.setOnRebalanceDoneHandler(
                 partitions -> commandQueue.setCurrentlyHandledPartitions(Helper.to(partitions)));


### PR DESCRIPTION
The second part of the fix for #2953.