### PR TITLE
[#2702] Improve Kafka client class hierarchy

### DIFF
--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
@@ -267,9 +267,16 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
         final HonoTopic topic = new HonoTopic(HonoTopic.Type.COMMAND, tenantId);
         final Map<String, Object> headerProperties = getHeaderProperties(deviceId, command, contentType, correlationId,
                 responseRequired, properties);
-
-        return sendAndWaitForOutcome(topic.toString(), tenantId, deviceId, data, headerProperties, spanOperationName,
-                context);
+        final String topicName = topic.toString();
+        final Span currentSpan = startChildSpan(spanOperationName, topicName, tenantId, deviceId, context);
+        return sendAndWaitForOutcome(
+                topicName,
+                tenantId,
+                deviceId,
+                data,
+                headerProperties,
+                currentSpan)
+            .onComplete(ar -> currentSpan.finish());
     }
 
     private Map<String, Object> getHeaderProperties(final String deviceId, final String subject,

--- a/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/AbstractKafkaBasedDownstreamSender.java
+++ b/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/AbstractKafkaBasedDownstreamSender.java
@@ -15,10 +15,8 @@ package org.eclipse.hono.client.telemetry.kafka;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
-import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.producer.AbstractKafkaBasedMessageSender;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
 import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
@@ -29,9 +27,7 @@ import org.eclipse.hono.util.ResourceLimits;
 import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.TenantObject;
 
-import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 
 /**
@@ -62,11 +58,8 @@ public abstract class AbstractKafkaBasedDownstreamSender extends AbstractKafkaBa
     }
 
     /**
-     * Sends a message downstream.
-     * <p>
-     * Default properties defined either at the device or tenant level are added to the message headers.
+     * Adds default properties defined either at the device or tenant level are added to the message headers.
      *
-     * @param topic The topic to send the message to.
      * @param tenant The tenant that the device belongs to.
      * @param device The registration assertion for the device that the data originates from.
      * @param qos The delivery semantics to use for sending the data.
@@ -81,53 +74,15 @@ public abstract class AbstractKafkaBasedDownstreamSender extends AbstractKafkaBa
      *            <li>the {@linkplain org.eclipse.hono.util.MessageHelper#CONTENT_TYPE_OCTET_STREAM default content
      *            type}</li>
      *            </ol>
-     * @param payload The data to send.
      * @param properties Additional meta data that should be included in the downstream message.
-     * @param spanOperationName The operation name to set for the span created in this method.
-     *                          If {@code null}, "send message" will be used.
-     * @param context The currently active OpenTracing span (may be {@code null}). An implementation should use this as
-     *            the parent for any span it creates for tracing the execution of this operation.
-     * @return A future indicating the outcome of the operation.
-     *         <p>
-     *         The future will be succeeded if the message has been sent downstream.
-     *         <p>
-     *         The future will be failed with a {@link org.eclipse.hono.client.ServerErrorException} if the data could
-     *         not be sent. The error code contained in the exception indicates the cause of the failure.
-     * @throws NullPointerException if topic, tenant, device, or qos are {@code null}.
+     * @return The augmented properties.
      */
-    protected Future<Void> send(
-            final HonoTopic topic,
+    protected final Map<String, Object> addDefaults(
             final TenantObject tenant,
             final RegistrationAssertion device,
             final QoS qos,
             final String contentType,
-            final Buffer payload,
-            final Map<String, Object> properties,
-            final String spanOperationName,
-            final SpanContext context) {
-
-        Objects.requireNonNull(topic);
-        Objects.requireNonNull(tenant);
-        Objects.requireNonNull(device);
-        Objects.requireNonNull(qos);
-
-        final String tenantId = tenant.getTenantId();
-        final String deviceId = device.getDeviceId();
-        log.trace("sending to Kafka [topic: {}, tenantId: {}, deviceId: {}, qos: {}, contentType: {}, properties: {}]",
-                topic, tenantId, deviceId, qos, contentType, properties);
-        final Map<String, Object> propsWithDefaults = addDefaults(tenant, device, qos, contentType, properties);
-
-        if (QoS.AT_LEAST_ONCE.equals(qos)) {
-            return sendAndWaitForOutcome(topic.toString(), tenantId, deviceId, payload, propsWithDefaults,
-                    spanOperationName, context);
-        } else {
-            send(topic.toString(), tenantId, deviceId, payload, propsWithDefaults, spanOperationName, context);
-            return Future.succeededFuture();
-        }
-    }
-
-    private Map<String, Object> addDefaults(final TenantObject tenant, final RegistrationAssertion device,
-            final QoS qos, final String contentType, final Map<String, Object> properties) {
+            final Map<String, Object> properties) {
 
         final Map<String, Object> headerProperties = new HashMap<>();
         if (isDefaultsEnabled) {

--- a/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/AbstractKafkaBasedDownstreamSender.java
+++ b/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/AbstractKafkaBasedDownstreamSender.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.client.telemetry.kafka;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.hono.client.kafka.producer.AbstractKafkaBasedMessageSender;
@@ -76,6 +77,7 @@ public abstract class AbstractKafkaBasedDownstreamSender extends AbstractKafkaBa
      *            </ol>
      * @param properties Additional meta data that should be included in the downstream message.
      * @return The augmented properties.
+     * @throws NullPointerException if tenant, device or qos are {@code null}.
      */
     protected final Map<String, Object> addDefaults(
             final TenantObject tenant,
@@ -83,6 +85,10 @@ public abstract class AbstractKafkaBasedDownstreamSender extends AbstractKafkaBa
             final QoS qos,
             final String contentType,
             final Map<String, Object> properties) {
+
+        Objects.requireNonNull(tenant);
+        Objects.requireNonNull(device);
+        Objects.requireNonNull(qos);
 
         final Map<String, Object> headerProperties = new HashMap<>();
         if (isDefaultsEnabled) {

--- a/tests/src/test/java/org/eclipse/hono/tests/GenericKafkaSender.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/GenericKafkaSender.java
@@ -15,12 +15,11 @@ package org.eclipse.hono.tests;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.kafka.producer.AbstractKafkaBasedMessageSender;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
 import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 
-import io.opentracing.SpanContext;
+import io.opentracing.noop.NoopSpan;
 import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
@@ -38,42 +37,14 @@ public class GenericKafkaSender extends AbstractKafkaBasedMessageSender {
      * @param producerConfig The Kafka producer configuration.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
-    public GenericKafkaSender(final KafkaProducerFactory<String, Buffer> producerFactory,
+    public GenericKafkaSender(
+            final KafkaProducerFactory<String, Buffer> producerFactory,
             final MessagingKafkaProducerConfigProperties producerConfig) {
+
         super(producerFactory, "generic-sender", producerConfig, NoopTracerFactory.create());
     }
 
     /**
-     * Sends a message to a kafka cluster and doesn't wait for an outcome.
-     *
-     * @param topic      The topic to send the message to.
-     * @param tenantId   The tenant that the device belongs to.
-     * @param deviceId   The device identifier.
-     * @param payload    The data to send.
-     * @param properties Additional meta data that should be included in the message.
-     * @throws NullPointerException if topic, tenantId, deviceId or properties are {@code null}.
-     */
-    public void send(final String topic, final String tenantId, final String deviceId, final Buffer payload,
-            final Map<String, Object> properties) {
-        super.send(topic, tenantId, deviceId, payload, properties, null, (SpanContext) null);
-    }
-
-    /**
-     * Sends a message to a kafka cluster and doesn't wait for an outcome.
-     *
-     * @param topic    The topic to send the message to.
-     * @param tenantId The tenant that the device belongs to.
-     * @param deviceId The device identifier.
-     * @param payload  The data to send.
-     * @param headers  Additional meta data that should be included in the message.
-     * @throws NullPointerException if topic, tenantId, deviceId or headers are {@code null}.
-     */
-    public void send(final String topic, final String tenantId, final String deviceId, final Buffer payload,
-            final List<KafkaHeader> headers) {
-        super.send(topic, tenantId, deviceId, payload, headers, null, (SpanContext) null);
-    }
-
-    /**
      * Sends a message to a kafka cluster and waits for the outcome.
      *
      * @param topic      The topic to send the message to.
@@ -89,9 +60,13 @@ public class GenericKafkaSender extends AbstractKafkaBasedMessageSender {
      * not be sent. The error code contained in the exception indicates the cause of the failure.
      * @throws NullPointerException if topic, tenantId, deviceId or properties are {@code null}.
      */
-    public Future<Void> sendAndWaitForOutcome(final String topic, final String tenantId, final String deviceId,
+    public Future<Void> sendAndWaitForOutcome(
+            final String topic,
+            final String tenantId,
+            final String deviceId,
             final Buffer payload, final Map<String, Object> properties) {
-        return super.sendAndWaitForOutcome(topic, tenantId, deviceId, payload, properties, null, (SpanContext) null);
+
+        return super.sendAndWaitForOutcome(topic, tenantId, deviceId, payload, properties, NoopSpan.INSTANCE);
     }
 
     /**
@@ -110,9 +85,13 @@ public class GenericKafkaSender extends AbstractKafkaBasedMessageSender {
      * not be sent. The error code contained in the exception indicates the cause of the failure.
      * @throws NullPointerException if topic, tenantId, deviceId or headers are {@code null}.
      */
-    public Future<Void> sendAndWaitForOutcome(final String topic, final String tenantId, final String deviceId,
+    public Future<Void> sendAndWaitForOutcome(
+            final String topic,
+            final String tenantId,
+            final String deviceId,
             final Buffer payload, final List<KafkaHeader> headers) {
-        return super.sendAndWaitForOutcome(topic, tenantId, deviceId, payload, headers, null, (SpanContext) null);
+
+        return super.sendAndWaitForOutcome(topic, tenantId, deviceId, payload, headers, NoopSpan.INSTANCE);
     }
 
 }


### PR DESCRIPTION
This is preparatory work for #2702

The AbstractKafkaBasedMessageSender's send* methods have been changed to
require an OpenTracing Span to be passed in which will not be finished
by the send method anymore. The subclasses and test cases have been
adapted accordingly. With this change the classes are better in line
with the approach used in Hono in gerneral, i.e. the component creating
a Span should also be responsible for finishing it.

Some (now) obsolete send* methods have been removed as well.
