### PR TITLE
[#2906] Improve Kafka client ID creation

### DIFF
--- a/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
+++ b/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
@@ -235,19 +235,10 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
             @ConfigMapping(prefix = "hono.kafka.commandInternal") final KafkaAdminClientOptions commandInternalOptions) {
 
         kafkaTelemetryConfig = new MessagingKafkaProducerConfigProperties(commonOptions, telemetryOptions);
-        Optional.ofNullable(getComponentName()).ifPresent(kafkaTelemetryConfig::setDefaultClientIdPrefix);
-
         kafkaEventConfig = new MessagingKafkaProducerConfigProperties(commonOptions, eventOptions);
-        Optional.ofNullable(getComponentName()).ifPresent(kafkaEventConfig::setDefaultClientIdPrefix);
-
         kafkaCommandResponseConfig = new MessagingKafkaProducerConfigProperties(commonOptions, commandResponseOptions);
-        Optional.ofNullable(getComponentName()).ifPresent(kafkaCommandResponseConfig::setDefaultClientIdPrefix);
-
         kafkaCommandConfig = new MessagingKafkaConsumerConfigProperties(commonOptions, commandOptions);
-        Optional.ofNullable(getComponentName()).ifPresent(kafkaCommandConfig::setDefaultClientIdPrefix);
-
         kafkaCommandInternalConfig = new KafkaAdminClientConfigProperties(commonOptions, commandInternalOptions);
-        Optional.ofNullable(getComponentName()).ifPresent(kafkaCommandInternalConfig::setDefaultClientIdPrefix);
     }
 
     @Override

--- a/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractAdapterConfig.java
+++ b/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractAdapterConfig.java
@@ -258,9 +258,6 @@ public abstract class AbstractAdapterConfig extends AbstractMessagingClientConfi
     public KafkaAdminClientConfigProperties kafkaCommandInternalConfig() {
         final KafkaAdminClientConfigProperties configProperties = new KafkaAdminClientConfigProperties();
         configProperties.setCommonClientConfig(commonKafkaClientConfig());
-        if (getComponentName() != null) {
-            configProperties.setDefaultClientIdPrefix(getComponentName());
-        }
         return configProperties;
     }
 

--- a/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractMessagingClientConfig.java
+++ b/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractMessagingClientConfig.java
@@ -137,9 +137,6 @@ public abstract class AbstractMessagingClientConfig implements ComponentNameProv
     public MessagingKafkaProducerConfigProperties kafkaTelemetryConfig() {
         final MessagingKafkaProducerConfigProperties configProperties = new MessagingKafkaProducerConfigProperties();
         configProperties.setCommonClientConfig(commonKafkaClientConfig());
-        if (getComponentName() != null) {
-            configProperties.setDefaultClientIdPrefix(getComponentName());
-        }
         return configProperties;
     }
 
@@ -153,9 +150,6 @@ public abstract class AbstractMessagingClientConfig implements ComponentNameProv
     public MessagingKafkaProducerConfigProperties kafkaEventConfig() {
         final MessagingKafkaProducerConfigProperties configProperties = new MessagingKafkaProducerConfigProperties();
         configProperties.setCommonClientConfig(commonKafkaClientConfig());
-        if (getComponentName() != null) {
-            configProperties.setDefaultClientIdPrefix(getComponentName());
-        }
         return configProperties;
     }
 
@@ -169,9 +163,6 @@ public abstract class AbstractMessagingClientConfig implements ComponentNameProv
     public MessagingKafkaProducerConfigProperties kafkaCommandResponseConfig() {
         final MessagingKafkaProducerConfigProperties configProperties = new MessagingKafkaProducerConfigProperties();
         configProperties.setCommonClientConfig(commonKafkaClientConfig());
-        if (getComponentName() != null) {
-            configProperties.setDefaultClientIdPrefix(getComponentName());
-        }
         return configProperties;
     }
 
@@ -185,9 +176,6 @@ public abstract class AbstractMessagingClientConfig implements ComponentNameProv
     public MessagingKafkaConsumerConfigProperties kafkaCommandConfig() {
         final MessagingKafkaConsumerConfigProperties configProperties = new MessagingKafkaConsumerConfigProperties();
         configProperties.setCommonClientConfig(commonKafkaClientConfig());
-        if (getComponentName() != null) {
-            configProperties.setDefaultClientIdPrefix(getComponentName());
-        }
         return configProperties;
     }
 

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumer.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumer.java
@@ -70,7 +70,6 @@ public class KafkaBasedInternalCommandConsumer implements InternalCommandConsume
     private static final Logger LOG = LoggerFactory.getLogger(KafkaBasedInternalCommandConsumer.class);
 
     private static final int NUM_PARTITIONS = 1;
-    private static final String CLIENT_NAME = "internal-cmd";
     private static final long CREATE_TOPIC_RETRY_INTERVAL = 1000L;
 
     private final Supplier<Future<KafkaConsumer<String, Buffer>>> consumerCreator;
@@ -122,7 +121,7 @@ public class KafkaBasedInternalCommandConsumer implements InternalCommandConsume
         this.commandHandlers = Objects.requireNonNull(commandHandlers);
         this.tracer = Objects.requireNonNull(tracer);
 
-        final Map<String, String> adminClientConfig = adminClientConfigProperties.getAdminClientConfig(CLIENT_NAME);
+        final Map<String, String> adminClientConfig = adminClientConfigProperties.getAdminClientConfig("internal-cmd-admin");
         // Vert.x KafkaAdminClient doesn't support creating topics using the broker default replication factor,
         // therefore use Kafka Admin client directly here
         final String bootstrapServersConfig = adminClientConfig.get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG);
@@ -132,7 +131,7 @@ public class KafkaBasedInternalCommandConsumer implements InternalCommandConsume
                 bootstrapServersConfig,
                 KafkaClientFactory.UNLIMITED_RETRIES_DURATION);
 
-        final Map<String, String> consumerConfig = consumerConfigProperties.getConsumerConfig(CLIENT_NAME);
+        final Map<String, String> consumerConfig = consumerConfigProperties.getConsumerConfig("internal-cmd");
         consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, adapterInstanceId);
         // no commits of partition offsets needed - topic only used during lifetime of this consumer
         consumerConfig.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaAdminClientConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaAdminClientConfigProperties.java
@@ -61,9 +61,11 @@ public class KafkaAdminClientConfigProperties extends AbstractKafkaConfigPropert
 
     /**
      * Gets the Kafka admin client configuration. This is the result of applying the admin client configuration on the
-     * common configuration. The returned map will contain a property {@code client.id} which will be set to a unique
-     * value containing the already set client id or alternatively the value set via
-     * {@link #setDefaultClientIdPrefix(String)}, the given adminClientName and a newly created UUID.
+     * common configuration.
+     * <p>
+     * It is ensured that the returned map contains a unique {@code client.id}. The client ID will be created from the
+     * given client name, followed by a unique ID (containing component identifiers if running in Kubernetes).
+     * An already set {@code client.id} property value will be used as prefix for the client ID.
      *
      * Note: This method should be called for each new admin client, ensuring that a unique client id is used.
      *

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/KafkaConsumerConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/KafkaConsumerConfigProperties.java
@@ -91,10 +91,11 @@ public class KafkaConsumerConfigProperties extends AbstractKafkaConfigProperties
 
     /**
      * Gets the Kafka consumer configuration. This is the result of applying the consumer configuration on the common
-     * configuration. It includes changes made in {@link #adaptConfiguration(Map)}. The returned map will contain a
-     * property {@code client.id} which will be set to a unique value containing the already set client id or
-     * alternatively the value set via {@link #setDefaultClientIdPrefix(String)}, the given consumerName and a newly
-     * created UUID.
+     * configuration. It includes changes made in {@link #adaptConfiguration(Map)}.
+     * <p>
+     * It is ensured that the returned map contains a unique {@code client.id}. The client ID will be created from the
+     * given client name, followed by a unique ID (containing component identifiers if running in Kubernetes).
+     * An already set {@code client.id} property value will be used as prefix for the client ID.
      *
      * Note: This method should be called for each new consumer, ensuring that a unique client id is used.
      *

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/KafkaProducerConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/KafkaProducerConfigProperties.java
@@ -83,10 +83,11 @@ public class KafkaProducerConfigProperties extends AbstractKafkaConfigProperties
 
     /**
      * Gets the Kafka producer configuration. This is the result of applying the producer configuration on the common
-     * configuration. It includes changes made in {@link #adaptConfiguration(Map)}. The returned map will contain a
-     * property {@code client.id} which will be set to a unique value containing the already set client id or
-     * alternatively the value set via {@link #setDefaultClientIdPrefix(String)}, the given producerName and a newly
-     * created UUID.
+     * configuration. It includes changes made in {@link #adaptConfiguration(Map)}.
+     * <p>
+     * It is ensured that the returned map contains a unique {@code client.id}. The client ID will be created from the
+     * given client name, followed by a unique ID (containing component identifiers if running in Kubernetes).
+     * An already set {@code client.id} property value will be used as prefix for the client ID.
      *
      * Note: This method should be called for each new producer, ensuring that a unique client id is used.
      *

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaAdminClientConfigPropertiesTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaAdminClientConfigPropertiesTest.java
@@ -35,14 +35,6 @@ public class KafkaAdminClientConfigPropertiesTest {
     }
 
     /**
-     * Verifies that trying to set a {@code null} client ID throws a {@link NullPointerException}.
-     */
-    @Test
-    public void testThatClientIdCanNotBeSetToNull() {
-        assertThrows(NullPointerException.class, () -> new KafkaAdminClientConfigProperties().setDefaultClientIdPrefix(null));
-    }
-
-    /**
      * Verifies that properties provided with {@link KafkaAdminClientConfigProperties#setAdminClientConfig(Map)} are returned
      * in {@link KafkaAdminClientConfigProperties#getAdminClientConfig(String)}.
      */
@@ -90,35 +82,18 @@ public class KafkaAdminClientConfigPropertiesTest {
     }
 
     /**
-     * Verifies that the client ID set with {@link KafkaAdminClientConfigProperties#setDefaultClientIdPrefix(String)} is applied when it
-     * is NOT present in the configuration.
+     * Verifies that the client ID set in the {@link KafkaAdminClientConfigProperties#getAdminClientConfig(String)} map
+     * conforms to the expected format.
      */
     @Test
-    public void testThatClientIdIsApplied() {
-        final String clientId = "the-client";
+    public void testThatCreatedClientIdConformsToExpectedFormat() {
+        final String componentUid = "hono-adapter-amqp-vertx-7548cc6c66-4qhqh_ed7c6ab9cc27";
 
         final KafkaAdminClientConfigProperties config = new KafkaAdminClientConfigProperties();
-        config.setAdminClientConfig(Map.of());
-        config.setDefaultClientIdPrefix(clientId);
+        config.setAdminClientConfig(Map.of("client.id", "configuredId"));
+        config.overrideComponentUidUsedForClientId(componentUid);
 
         final Map<String, String> adminClientConfig = config.getAdminClientConfig("adminClientName");
-        assertThat(adminClientConfig.get("client.id")).startsWith(clientId + "-adminClientName-");
+        assertThat(adminClientConfig.get("client.id")).matches("configuredId-adminClientName-" + componentUid + "_\\d+");
     }
-
-    /**
-     * Verifies that the client ID set with {@link KafkaAdminClientConfigProperties#setDefaultClientIdPrefix(String)} is NOT applied
-     * when it is present in the configuration.
-     */
-    @Test
-    public void testThatClientIdIsNotAppliedIfAlreadyPresent() {
-        final String userProvidedClientId = "custom-client";
-
-        final KafkaAdminClientConfigProperties config = new KafkaAdminClientConfigProperties();
-        config.setAdminClientConfig(Map.of("client.id", userProvidedClientId));
-        config.setDefaultClientIdPrefix("other-client");
-
-        final Map<String, String> adminClientConfig = config.getAdminClientConfig("adminClientName");
-        assertThat(adminClientConfig.get("client.id")).startsWith(userProvidedClientId + "-adminClientName-");
-    }
-
 }

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/KafkaConsumerConfigPropertiesTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/KafkaConsumerConfigPropertiesTest.java
@@ -47,15 +47,6 @@ public class KafkaConsumerConfigPropertiesTest {
     }
 
     /**
-     * Verifies that trying to set a {@code null} client ID throws a {@link NullPointerException}.
-     */
-    @Test
-    public void testThatClientIdCanNotBeSetToNull() {
-        assertThrows(NullPointerException.class,
-                () -> config.setDefaultClientIdPrefix(null));
-    }
-
-    /**
      * Verifies that trying to set a negative poll timeout throws an {@link IllegalArgumentException}.
      */
     @Test
@@ -108,33 +99,18 @@ public class KafkaConsumerConfigPropertiesTest {
     }
 
     /**
-     * Verifies that the client ID set with {@link KafkaConsumerConfigProperties#setDefaultClientIdPrefix(String)} is
-     * applied when it is NOT present in the configuration.
+     * Verifies that the client ID set in the {@link KafkaConsumerConfigProperties#getConsumerConfig(String)} map
+     * conforms to the expected format.
      */
     @Test
-    public void testThatClientIdIsApplied() {
-        final String clientId = "the-client";
+    public void testThatCreatedClientIdConformsToExpectedFormat() {
+        final String componentUid = "hono-adapter-amqp-vertx-7548cc6c66-4qhqh_ed7c6ab9cc27";
 
-        config.setConsumerConfig(Map.of());
-        config.setDefaultClientIdPrefix(clientId);
-
-        final Map<String, String> consumerConfig = config.getConsumerConfig("consumerName");
-        assertThat(consumerConfig.get("client.id")).startsWith(clientId + "-consumerName-");
-    }
-
-    /**
-     * Verifies that the client ID set with {@link KafkaConsumerConfigProperties#setDefaultClientIdPrefix(String)} is
-     * NOT applied when it is present in the configuration.
-     */
-    @Test
-    public void testThatClientIdIsNotAppliedIfAlreadyPresent() {
-        final String userProvidedClientId = "custom-client";
-
-        config.setConsumerConfig(Map.of("client.id", userProvidedClientId));
-        config.setDefaultClientIdPrefix("other-client");
+        config.setConsumerConfig(Map.of("client.id", "configuredId"));
+        config.overrideComponentUidUsedForClientId(componentUid);
 
         final Map<String, String> consumerConfig = config.getConsumerConfig("consumerName");
-        assertThat(consumerConfig.get("client.id")).startsWith(userProvidedClientId + "-consumerName-");
+        assertThat(consumerConfig.get("client.id")).matches("configuredId-consumerName-" + componentUid + "_\\d+");
     }
 
 }

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/producer/KafkaProducerConfigPropertiesTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/producer/KafkaProducerConfigPropertiesTest.java
@@ -46,14 +46,6 @@ public class KafkaProducerConfigPropertiesTest {
     }
 
     /**
-     * Verifies that trying to set a {@code null} client ID throws a {@link NullPointerException}.
-     */
-    @Test
-    public void testThatClientIdCanNotBeSetToNull() {
-        assertThrows(NullPointerException.class, () -> config.setDefaultClientIdPrefix(null));
-    }
-
-    /**
      * Verifies that properties provided with {@link KafkaProducerConfigProperties#setProducerConfig(Map)} are returned
      * in {@link KafkaProducerConfigProperties#getProducerConfig(String)}.
      */
@@ -97,33 +89,17 @@ public class KafkaProducerConfigPropertiesTest {
     }
 
     /**
-     * Verifies that the client ID set with {@link KafkaProducerConfigProperties#setDefaultClientIdPrefix(String)} is
-     * applied when it is NOT present in the configuration.
+     * Verifies that the client ID set in the {@link KafkaProducerConfigProperties#getProducerConfig(String)}
+     * map conforms to the expected format.
      */
     @Test
-    public void testThatClientIdIsApplied() {
-        final String clientId = "the-client";
+    public void testThatCreatedClientIdConformsToExpectedFormat() {
+        final String componentUid = "hono-adapter-amqp-vertx-7548cc6c66-4qhqh_ed7c6ab9cc27";
 
-        config.setProducerConfig(Map.of());
-        config.setDefaultClientIdPrefix(clientId);
-
-        final Map<String, String> producerConfig = config.getProducerConfig("producerName");
-        assertThat(producerConfig.get("client.id")).startsWith(clientId + "-producerName-");
-    }
-
-    /**
-     * Verifies that the client ID set with {@link KafkaProducerConfigProperties#setDefaultClientIdPrefix(String)} is
-     * NOT applied when it is present in the configuration.
-     */
-    @Test
-    public void testThatClientIdIsNotAppliedIfAlreadyPresent() {
-        final String userProvidedClientId = "custom-client";
-
-        config.setProducerConfig(Map.of("client.id", userProvidedClientId));
-        config.setDefaultClientIdPrefix("other-client");
+        config.setProducerConfig(Map.of("client.id", "configuredId"));
+        config.overrideComponentUidUsedForClientId(componentUid);
 
         final Map<String, String> producerConfig = config.getProducerConfig("producerName");
-        assertThat(producerConfig.get("client.id")).startsWith(userProvidedClientId + "-producerName-");
+        assertThat(producerConfig.get("client.id")).matches("configuredId-producerName-" + componentUid + "_\\d+");
     }
-
 }

--- a/clients/notification-kafka/src/test/java/org/eclipse/hono/client/notification/kafka/NotificationKafkaConsumerConfigPropertiesTest.java
+++ b/clients/notification-kafka/src/test/java/org/eclipse/hono/client/notification/kafka/NotificationKafkaConsumerConfigPropertiesTest.java
@@ -38,14 +38,6 @@ public class NotificationKafkaConsumerConfigPropertiesTest {
     }
 
     /**
-     * Verifies that trying to set a {@code null} client ID throws a {@link NullPointerException}.
-     */
-    @Test
-    public void testThatClientIdCanNotBeSetToNull() {
-        assertThrows(NullPointerException.class, () -> new NotificationKafkaConsumerConfigProperties().setDefaultClientIdPrefix(null));
-    }
-
-    /**
      * Verifies that trying to set a negative poll timeout throws an {@link IllegalArgumentException}.
      */
     @Test
@@ -125,37 +117,18 @@ public class NotificationKafkaConsumerConfigPropertiesTest {
     }
 
     /**
-     * Verifies that the client ID set with
-     * {@link NotificationKafkaConsumerConfigProperties#setDefaultClientIdPrefix(String)} is applied when it is NOT
-     * present in the configuration.
+     * Verifies that the client ID set in the {@link NotificationKafkaConsumerConfigProperties#getConsumerConfig(String)}
+     * map conforms to the expected format.
      */
     @Test
-    public void testThatClientIdIsApplied() {
-        final String clientId = "the-client";
+    public void testThatCreatedClientIdConformsToExpectedFormat() {
+        final String componentUid = "hono-adapter-amqp-vertx-7548cc6c66-4qhqh_ed7c6ab9cc27";
 
         final NotificationKafkaConsumerConfigProperties config = new NotificationKafkaConsumerConfigProperties();
-        config.setConsumerConfig(Map.of());
-        config.setDefaultClientIdPrefix(clientId);
+        config.setConsumerConfig(Map.of("client.id", "configuredId"));
+        config.overrideComponentUidUsedForClientId(componentUid);
 
         final Map<String, String> consumerConfig = config.getConsumerConfig("consumerName");
-        assertThat(consumerConfig.get("client.id")).startsWith(clientId + "-consumerName-");
+        assertThat(consumerConfig.get("client.id")).matches("configuredId-consumerName-" + componentUid + "_\\d+");
     }
-
-    /**
-     * Verifies that the client ID set with
-     * {@link NotificationKafkaConsumerConfigProperties#setDefaultClientIdPrefix(String)} is NOT applied when it is
-     * present in the configuration.
-     */
-    @Test
-    public void testThatClientIdIsNotAppliedIfAlreadyPresent() {
-        final String userProvidedClientId = "custom-client";
-
-        final NotificationKafkaConsumerConfigProperties config = new NotificationKafkaConsumerConfigProperties();
-        config.setConsumerConfig(Map.of("client.id", userProvidedClientId));
-        config.setDefaultClientIdPrefix("other-client");
-
-        final Map<String, String> consumerConfig = config.getConsumerConfig("consumerName");
-        assertThat(consumerConfig.get("client.id")).startsWith(userProvidedClientId + "-consumerName-");
-    }
-
 }

--- a/clients/notification-kafka/src/test/java/org/eclipse/hono/client/notification/kafka/NotificationKafkaProducerConfigPropertiesTest.java
+++ b/clients/notification-kafka/src/test/java/org/eclipse/hono/client/notification/kafka/NotificationKafkaProducerConfigPropertiesTest.java
@@ -39,15 +39,6 @@ public class NotificationKafkaProducerConfigPropertiesTest {
     }
 
     /**
-     * Verifies that trying to set a {@code null} client ID throws a {@link NullPointerException}.
-     */
-    @Test
-    public void testThatClientIdCanNotBeSetToNull() {
-        assertThrows(NullPointerException.class,
-                () -> new NotificationKafkaProducerConfigProperties().setDefaultClientIdPrefix(null));
-    }
-
-    /**
      * Verifies that properties provided with {@link NotificationKafkaProducerConfigProperties#setProducerConfig(Map)}
      * are returned in {@link NotificationKafkaProducerConfigProperties#getProducerConfig(String)}.
      */
@@ -120,37 +111,18 @@ public class NotificationKafkaProducerConfigPropertiesTest {
     }
 
     /**
-     * Verifies that the client ID set with
-     * {@link NotificationKafkaProducerConfigProperties#setDefaultClientIdPrefix(String)} is applied when it is NOT
-     * present in the configuration.
+     * Verifies that the client ID set in the {@link NotificationKafkaProducerConfigProperties#getProducerConfig(String)}
+     * map conforms to the expected format.
      */
     @Test
-    public void testThatClientIdIsApplied() {
-        final String clientId = "the-client";
+    public void testThatCreatedClientIdConformsToExpectedFormat() {
+        final String componentUid = "hono-adapter-amqp-vertx-7548cc6c66-4qhqh_ed7c6ab9cc27";
 
         final NotificationKafkaProducerConfigProperties config = new NotificationKafkaProducerConfigProperties();
-        config.setProducerConfig(Map.of());
-        config.setDefaultClientIdPrefix(clientId);
+        config.setProducerConfig(Map.of("client.id", "configuredId"));
+        config.overrideComponentUidUsedForClientId(componentUid);
 
         final Map<String, String> producerConfig = config.getProducerConfig("producerName");
-        assertThat(producerConfig.get("client.id")).startsWith(clientId + "-producerName-");
+        assertThat(producerConfig.get("client.id")).matches("^configuredId-producerName-" + componentUid + "_\\d+");
     }
-
-    /**
-     * Verifies that the client ID set with
-     * {@link NotificationKafkaProducerConfigProperties#setDefaultClientIdPrefix(String)} is NOT applied when it is
-     * present in the configuration.
-     */
-    @Test
-    public void testThatClientIdIsNotAppliedIfAlreadyPresent() {
-        final String userProvidedClientId = "custom-client";
-
-        final NotificationKafkaProducerConfigProperties config = new NotificationKafkaProducerConfigProperties();
-        config.setProducerConfig(Map.of("client.id", userProvidedClientId));
-        config.setDefaultClientIdPrefix("other-client");
-
-        final Map<String, String> producerConfig = config.getProducerConfig("producerName");
-        assertThat(producerConfig.get("client.id")).startsWith(userProvidedClientId + "-producerName-");
-    }
-
 }

--- a/examples/hono-client-examples/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleApplicationBase.java
+++ b/examples/hono-client-examples/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleApplicationBase.java
@@ -69,8 +69,6 @@ public class HonoExampleApplicationBase {
     public static final Boolean USE_KAFKA = Boolean.valueOf(System.getProperty("kafka", "false"));
 
     private static final Logger LOG = LoggerFactory.getLogger(HonoExampleApplicationBase.class);
-    // used by Kafka for request logging
-    private static final String KAFKA_CLIENT_ID_PREFIX = "example.application";
     private static final String KAFKA_CONSUMER_GROUP_ID = "hono-example-application";
     private static final String COMMAND_SEND_LIFECYCLE_INFO = "sendLifecycleInfo";
     private static final Random RAND = new Random();
@@ -153,12 +151,10 @@ public class HonoExampleApplicationBase {
         commonClientConfig.setCommonClientConfig(properties);
         final MessagingKafkaConsumerConfigProperties consumerConfig = new MessagingKafkaConsumerConfigProperties();
         consumerConfig.setCommonClientConfig(commonClientConfig);
-        consumerConfig.setDefaultClientIdPrefix(KAFKA_CLIENT_ID_PREFIX);
         consumerConfig.setConsumerConfig(Map.of("group.id", KAFKA_CONSUMER_GROUP_ID));
 
         final MessagingKafkaProducerConfigProperties producerConfig = new MessagingKafkaProducerConfigProperties();
         producerConfig.setCommonClientConfig(commonClientConfig);
-        producerConfig.setDefaultClientIdPrefix(KAFKA_CLIENT_ID_PREFIX);
 
         final KafkaProducerFactory<String, Buffer> producerFactory = CachingKafkaProducerFactory.sharedFactory(vertx);
         return new KafkaApplicationClientImpl(vertx, consumerConfig, producerFactory, producerConfig);

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -163,7 +163,7 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
         commandHandler = new KafkaBasedMappingAndDelegatingCommandHandler(vertx, tenantClient, commandQueue,
                 commandTargetMapper, internalCommandSender, kafkaBasedCommandResponseSender, metrics, tracer);
 
-        final Map<String, String> consumerConfig = kafkaConsumerConfig.getConsumerConfig("consumer");
+        final Map<String, String> consumerConfig = kafkaConsumerConfig.getConsumerConfig("command");
         consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         consumerConfig.putIfAbsent(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, CooperativeStickyAssignor.class.getName());
         consumerConfig.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");

--- a/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/quarkus/Application.java
+++ b/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/quarkus/Application.java
@@ -88,8 +88,6 @@ import io.vertx.proton.sasl.ProtonSaslAuthenticatorFactory;
 @ApplicationScoped
 public class Application extends AbstractServiceApplication {
 
-    private static final String DEFAULT_CLIENT_ID_PREFIX = "cmd-router";
-
     // workaround so that the Quarkus KubernetesClientProcessor finds a Pod watcher and registers corresponding model classes
     static {
         new Watcher<Pod>() {
@@ -196,16 +194,9 @@ public class Application extends AbstractServiceApplication {
             @ConfigMapping(prefix = "hono.kafka.cleanup") final KafkaAdminClientOptions adminClientOptions) {
 
         this.commandInternalKafkaProducerConfig = new MessagingKafkaProducerConfigProperties(commonOptions, commandInternalProducerOptions);
-        this.commandInternalKafkaProducerConfig.setDefaultClientIdPrefix(DEFAULT_CLIENT_ID_PREFIX);
-
         this.commandResponseKafkaProducerConfig = new MessagingKafkaProducerConfigProperties(commonOptions, commandResponseProducerOptions);
-        this.commandResponseKafkaProducerConfig.setDefaultClientIdPrefix(DEFAULT_CLIENT_ID_PREFIX);
-
         this.kafkaConsumerConfig = new MessagingKafkaConsumerConfigProperties(commonOptions, consumerOptions);
-        this.kafkaConsumerConfig.setDefaultClientIdPrefix(DEFAULT_CLIENT_ID_PREFIX);
-
         this.kafkaAdminClientConfig = new KafkaAdminClientConfigProperties(commonOptions, adminClientOptions);
-        this.kafkaAdminClientConfig.setDefaultClientIdPrefix(DEFAULT_CLIENT_ID_PREFIX);
     }
 
     @Override

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/spring/ApplicationConfig.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/spring/ApplicationConfig.java
@@ -107,7 +107,7 @@ public class ApplicationConfig {
     public static final String PROFILE_ENABLE_DEVICE_CONNECTION_ENDPOINT = "enable-device-connection-endpoint";
 
     private static final String BEAN_NAME_AMQP_SERVER = "amqpServer";
-    private static final String COMPONENT_NAME = "Command Router";
+    private static final String COMPONENT_NAME = "Hono Command Router";
 
     /**
      * Exposes an OpenTracing {@code Tracer} as a Spring Bean.
@@ -467,7 +467,6 @@ public class ApplicationConfig {
     public MessagingKafkaConsumerConfigProperties messagingKafkaConsumerConfig() {
         final MessagingKafkaConsumerConfigProperties configProperties = new MessagingKafkaConsumerConfigProperties();
         configProperties.setCommonClientConfig(commonKafkaClientConfig());
-        configProperties.setDefaultClientIdPrefix("cmd-router");
         return configProperties;
     }
 
@@ -482,7 +481,6 @@ public class ApplicationConfig {
     public MessagingKafkaProducerConfigProperties messagingCommandInternalKafkaProducerConfig() {
         final MessagingKafkaProducerConfigProperties configProperties = new MessagingKafkaProducerConfigProperties();
         configProperties.setCommonClientConfig(commonKafkaClientConfig());
-        configProperties.setDefaultClientIdPrefix("cmd-router");
         return configProperties;
     }
 
@@ -496,7 +494,6 @@ public class ApplicationConfig {
     public MessagingKafkaProducerConfigProperties messagingCommandResponseKafkaProducerConfig() {
         final MessagingKafkaProducerConfigProperties configProperties = new MessagingKafkaProducerConfigProperties();
         configProperties.setCommonClientConfig(commonKafkaClientConfig());
-        configProperties.setDefaultClientIdPrefix("cmd-router");
         return configProperties;
     }
 
@@ -523,7 +520,6 @@ public class ApplicationConfig {
     public KafkaAdminClientConfigProperties kafkaAdminClientConfig() {
         final KafkaAdminClientConfigProperties configProperties = new KafkaAdminClientConfigProperties();
         configProperties.setCommonClientConfig(commonKafkaClientConfig());
-        configProperties.setDefaultClientIdPrefix("cmd-router");
         return configProperties;
     }
 

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
@@ -230,7 +230,6 @@ public class FileBasedServiceConfig {
     public MessagingKafkaProducerConfigProperties kafkaEventConfig() {
         final MessagingKafkaProducerConfigProperties configProperties = new MessagingKafkaProducerConfigProperties();
         configProperties.setCommonClientConfig(commonKafkaClientConfig());
-        configProperties.setDefaultClientIdPrefix("device-registry");
         return configProperties;
     }
 

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
@@ -436,7 +436,6 @@ public class ApplicationConfig {
     public MessagingKafkaProducerConfigProperties kafkaEventConfig() {
         final MessagingKafkaProducerConfigProperties configProperties = new MessagingKafkaProducerConfigProperties();
         configProperties.setCommonClientConfig(commonKafkaClientConfig());
-        configProperties.setDefaultClientIdPrefix("device-registry");
         return configProperties;
     }
 
@@ -777,7 +776,6 @@ public class ApplicationConfig {
     public NotificationKafkaProducerConfigProperties notificationKafkaProducerConfig() {
         final var configProperties = new NotificationKafkaProducerConfigProperties();
         configProperties.setCommonClientConfig(commonKafkaClientConfig());
-        configProperties.setDefaultClientIdPrefix("device-registry");
         return configProperties;
     }
 

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
@@ -426,7 +426,6 @@ public class ApplicationConfig {
     public MessagingKafkaProducerConfigProperties kafkaEventConfig() {
         final MessagingKafkaProducerConfigProperties configProperties = new MessagingKafkaProducerConfigProperties();
         configProperties.setCommonClientConfig(commonKafkaClientConfig());
-        configProperties.setDefaultClientIdPrefix("device-registry");
         return configProperties;
     }
 
@@ -772,7 +771,6 @@ public class ApplicationConfig {
     public NotificationKafkaProducerConfigProperties notificationKafkaProducerConfig() {
         final var configProperties = new NotificationKafkaProducerConfigProperties();
         configProperties.setCommonClientConfig(commonKafkaClientConfig());
-        configProperties.setDefaultClientIdPrefix("device-registry");
         return configProperties;
     }
 

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -47,6 +47,12 @@ description = "Information about changes in recent Hono releases. Includes new f
   For the Command Router component [remote data grid configuration]({{% doclink "/admin-guide/command-router-config/#remote-cache" %}})
   this can be done by setting the `hono.commandRouter.cache.remote.sslCiphers` property.
 
+## API Changes
+
+* The `hono.kafka.defaultClientIdPrefix` configuration property needs to be removed from existing configurations.
+  Configuring parts of the created Kafka client identifiers should usually not be needed any more. To still set a custom
+  part, the `client.id` property value may be used instead. It is adopted as prefix for created client identifiers.
+
 ## 1.10.0
 
 ### New Features


### PR DESCRIPTION
This fixed #2906.
Default client ID contains the Kubernetes Pod name and container ID now.