### PR TITLE
[#2702] Allow inclusion of defaults in command response messages

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
@@ -697,8 +697,9 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * This method opens a new link for sending the response, tries to send the
      * response message and then closes the link again.
      *
-     * @param response The response message.
      * @param tenant The tenant to send the response for.
+     * @param device The registration assertion for the device that the data originates from.
+     * @param response The response message.
      * @param context The currently active OpenTracing span. An implementation
      *         should use this as the parent for any span it creates for tracing
      *         the execution of this operation.
@@ -707,16 +708,17 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * @throws NullPointerException if any of the parameters other than context are {@code null}.
      */
     protected final Future<Void> sendCommandResponse(
-            final CommandResponse response,
             final TenantObject tenant,
+            final RegistrationAssertion device,
+            final CommandResponse response,
             final SpanContext context) {
 
         Objects.requireNonNull(response);
         Objects.requireNonNull(tenant);
+        Objects.requireNonNull(device);
 
-        final CommandResponseSender sender = messagingClientProviders
-                .getCommandResponseSender(response.getMessagingType(), tenant);
-        return sender.sendCommandResponse(response, context);
+        return messagingClientProviders.getCommandResponseSender(response.getMessagingType(), tenant)
+                .sendCommandResponse(tenant, device, response, context);
     }
 
     @Override

--- a/adapter-base/src/test/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBaseTest.java
+++ b/adapter-base/src/test/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBaseTest.java
@@ -748,12 +748,21 @@ public class AbstractProtocolAdapterBaseTest {
                 null,
                 HttpURLConnection.HTTP_OK);
         final TenantObject tenant = new TenantObject("tenant", true);
+        final var device = new RegistrationAssertion("4711");
 
         tenant.setProperty(TenantConstants.FIELD_EXT,
                 Map.of(TenantConstants.FIELD_EXT_MESSAGING_TYPE, MessagingType.amqp.name()));
-        adapter.sendCommandResponse(kafkaResponse, tenant, null);
-        verify(kafkaCommandResponseSender).sendCommandResponse(any(), any());
-        verify(amqpCommandResponseSender, never()).sendCommandResponse(any(), any());
+        adapter.sendCommandResponse(tenant, device, kafkaResponse, null);
+        verify(kafkaCommandResponseSender).sendCommandResponse(
+                eq(tenant),
+                eq(device),
+                eq(kafkaResponse),
+                any());
+        verify(amqpCommandResponseSender, never()).sendCommandResponse(
+                any(TenantObject.class),
+                any(RegistrationAssertion.class),
+                any(CommandResponse.class),
+                any());
 
         final CommandResponse amqpResponse = CommandResponse.fromRequestId(
                 Commands.encodeRequestIdParameters("", "replyTo", "4711", MessagingType.amqp),
@@ -765,8 +774,12 @@ public class AbstractProtocolAdapterBaseTest {
 
         tenant.setProperty(TenantConstants.FIELD_EXT,
                 Map.of(TenantConstants.FIELD_EXT_MESSAGING_TYPE, MessagingType.kafka.name()));
-        adapter.sendCommandResponse(amqpResponse, tenant, null);
-        verify(amqpCommandResponseSender).sendCommandResponse(any(), any());
+        adapter.sendCommandResponse(tenant, device, amqpResponse, null);
+        verify(amqpCommandResponseSender).sendCommandResponse(
+                eq(tenant),
+                eq(device),
+                eq(amqpResponse),
+                any());
     }
 
     /**
@@ -785,7 +798,7 @@ public class AbstractProtocolAdapterBaseTest {
         adapter = newProtocolAdapter(properties, ADAPTER_NAME);
         setCollaborators(adapter);
 
-        final CommandResponse kafkaResponse = CommandResponse.fromRequestId(
+        final CommandResponse response = CommandResponse.fromRequestId(
                 Commands.encodeRequestIdParameters("", "replyTo", "4711", MessagingType.kafka),
                 Constants.DEFAULT_TENANT,
                 "4711",
@@ -793,11 +806,16 @@ public class AbstractProtocolAdapterBaseTest {
                 null,
                 HttpURLConnection.HTTP_OK);
         final TenantObject tenant = new TenantObject("tenant", true);
+        final var device = new RegistrationAssertion("4711");
 
         tenant.setProperty(TenantConstants.FIELD_EXT,
                 Map.of(TenantConstants.FIELD_EXT_MESSAGING_TYPE, MessagingType.amqp.name()));
-        adapter.sendCommandResponse(kafkaResponse, tenant, null);
-        verify(amqpCommandResponseSender).sendCommandResponse(any(), any());
+        adapter.sendCommandResponse(tenant, device, response, null);
+        verify(amqpCommandResponseSender).sendCommandResponse(
+                eq(tenant),
+                eq(device),
+                eq(response),
+                any());
     }
 
     private AbstractProtocolAdapterBase<ProtocolAdapterProperties> newProtocolAdapter(

--- a/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
@@ -1288,7 +1288,10 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                             .map(success -> tenantTracker.result());
 
                     return CompositeFuture.all(tenantValidationTracker, tokenFuture)
-                            .compose(success -> sendCommandResponse(commandResponse, tenantTracker.result(),
+                            .compose(success -> sendCommandResponse(
+                                    tenantTracker.result(),
+                                    tokenFuture.result(),
+                                    commandResponse,
                                     currentSpan.context()));
                 }).map(delivery -> {
 

--- a/adapters/amqp-vertx-base/src/test/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx-base/src/test/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapterTest.java
@@ -76,6 +76,7 @@ import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistrationAssertion;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.TelemetryConstants;
 import org.eclipse.hono.util.TenantObject;
@@ -665,7 +666,12 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
         // GIVEN an AMQP adapter
         givenAnAdapter(properties);
         final CommandResponseSender responseSender = givenACommandResponseSenderForAnyTenant();
-        when(responseSender.sendCommandResponse(any(CommandResponse.class), (SpanContext) any())).thenReturn(Future.succeededFuture());
+        when(responseSender.sendCommandResponse(
+                any(TenantObject.class),
+                any(RegistrationAssertion.class),
+                any(CommandResponse.class),
+                (SpanContext) any()))
+            .thenReturn(Future.succeededFuture());
         // which is enabled for the test tenant
         final TenantObject tenantObject = givenAConfiguredTenant(TEST_TENANT_ID, true);
 
@@ -685,7 +691,11 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
         adapter.onMessageReceived(AmqpContext.fromMessage(delivery, message, span, null)).onComplete(ctx.succeeding(ok -> {
             ctx.verify(() -> {
                 // THEN the adapter forwards the command response message downstream
-                verify(responseSender).sendCommandResponse((CommandResponse) any(), (SpanContext) any());
+                verify(responseSender).sendCommandResponse(
+                        eq(tenantObject),
+                        any(RegistrationAssertion.class),
+                        any(CommandResponse.class),
+                        (SpanContext) any());
                 // and reports the forwarded message
                 verify(metrics).reportCommand(
                     eq(Direction.RESPONSE),
@@ -710,8 +720,12 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
         // GIVEN an AMQP adapter
         givenAnAdapter(properties);
         final CommandResponseSender responseSender = givenACommandResponseSenderForAnyTenant();
-        when(responseSender.sendCommandResponse(any(CommandResponse.class), (SpanContext) any()))
-                .thenReturn(Future.succeededFuture());
+        when(responseSender.sendCommandResponse(
+                any(TenantObject.class),
+                any(RegistrationAssertion.class),
+                any(CommandResponse.class),
+                (SpanContext) any()))
+            .thenReturn(Future.succeededFuture());
         // which is enabled for the test tenant
         final TenantObject tenantObject = givenAConfiguredTenant(TEST_TENANT_ID, true);
 
@@ -730,7 +744,11 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
         adapter.onMessageReceived(AmqpContext.fromMessage(delivery, message, span, null)).onComplete(ctx.succeeding(ok -> {
             ctx.verify(() -> {
                 // THEN the adapter forwards the command response message downstream
-                verify(responseSender).sendCommandResponse((CommandResponse) any(), (SpanContext) any());
+                verify(responseSender).sendCommandResponse(
+                        eq(tenantObject),
+                        any(RegistrationAssertion.class),
+                        any(CommandResponse.class),
+                        (SpanContext) any());
                 // and reports the forwarded message
                 verify(metrics).reportCommand(
                         eq(Direction.RESPONSE),

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/CommandResponseResourceTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/CommandResponseResourceTest.java
@@ -43,6 +43,7 @@ import org.eclipse.hono.service.metric.MetricsTags.ProcessingOutcome;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessagingType;
+import org.eclipse.hono.util.RegistrationAssertion;
 import org.eclipse.hono.util.TenantObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -104,7 +105,11 @@ public class CommandResponseResourceTest extends ResourceTestBase {
             .onComplete(ctx.failing(t -> {
                 ctx.verify(() -> {
                     // THEN the command response has not been forwarded downstream
-                    verify(sender, never()).sendCommandResponse(any(CommandResponse.class), any(SpanContext.class));
+                    verify(sender, never()).sendCommandResponse(
+                            any(TenantObject.class),
+                            any(RegistrationAssertion.class),
+                            any(CommandResponse.class),
+                            any(SpanContext.class));
                     // and the device gets a 4.03 response
                     assertThat(t).isInstanceOf(ClientErrorException.class);
                     assertThat(((ClientErrorException) t).getErrorCode())
@@ -156,7 +161,11 @@ public class CommandResponseResourceTest extends ResourceTestBase {
         result.onComplete(ctx.failing(t -> {
             ctx.verify(() -> {
                 // THEN the command response is being forwarded downstream
-                verify(sender).sendCommandResponse(any(CommandResponse.class), any(SpanContext.class));
+                verify(sender).sendCommandResponse(
+                        any(TenantObject.class),
+                        any(RegistrationAssertion.class),
+                        any(CommandResponse.class),
+                        any(SpanContext.class));
                 // and the device gets a 4.00 response
                 assertThat(t).isInstanceOf(ClientErrorException.class);
                 assertThat(((ClientErrorException) t).getErrorCode())
@@ -204,7 +213,11 @@ public class CommandResponseResourceTest extends ResourceTestBase {
         final Future<Void> result = resource.uploadCommandResponseMessage(context);
 
         // THEN the command response is being forwarded downstream
-        verify(sender).sendCommandResponse(any(CommandResponse.class), any(SpanContext.class));
+        verify(sender).sendCommandResponse(
+                any(TenantObject.class),
+                any(RegistrationAssertion.class),
+                any(CommandResponse.class),
+                any(SpanContext.class));
         // but the device does not get a response
         verify(coapExchange, never()).respond(any(Response.class));
         // and the response has not been reported as forwarded

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -1256,7 +1256,10 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                             .map(ok -> null);
 
                     return CompositeFuture.all(tenantValidationTracker, deviceRegistrationTracker)
-                            .compose(ok -> sendCommandResponse(commandResponseTracker.result(), tenantTracker.result(),
+                            .compose(ok -> sendCommandResponse(
+                                    tenantTracker.result(),
+                                    deviceRegistrationTracker.result(),
+                                    commandResponseTracker.result(),
                                     currentSpan.context()))
                             .map(delivery -> {
                                 log.trace("delivered command response [command-request-id: {}] to application",

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -811,10 +811,13 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                             isAdapterEnabled(tenantTracker.result()),
                             checkMessageLimit(tenantTracker.result(), payloadSize, currentSpan.context()))
                             .mapEmpty();
-                    return CompositeFuture.all(deviceRegistrationTracker, tenantValidationTracker);
+                    return CompositeFuture.all(deviceRegistrationTracker, tenantValidationTracker)
+                            .compose(ok -> sendCommandResponse(
+                                    tenantTracker.result(),
+                                    deviceRegistrationTracker.result(),
+                                    commandResponseTracker.result(),
+                                    currentSpan.context()));
                 })
-                .compose(ok -> sendCommandResponse(commandResponseTracker.result(), tenantTracker.result(),
-                        currentSpan.context()))
                 .compose(delivery -> {
                     log.trace("successfully forwarded command response from device [tenant-id: {}, device-id: {}]",
                             targetAddress.getTenantId(), targetAddress.getResourceId());

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -59,6 +59,7 @@ import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistrationAssertion;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.TenantObject;
 import org.junit.jupiter.api.AfterAll;
@@ -745,7 +746,11 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
         adapter.uploadCommandResponseMessage(newMqttContext(messageFromDevice, endpoint, span), address)
                 .onComplete(ctx.succeeding(result -> {
                     ctx.verify(() -> {
-                        verify(sender).sendCommandResponse(any(CommandResponse.class), any());
+                        verify(sender).sendCommandResponse(
+                                any(TenantObject.class),
+                                any(RegistrationAssertion.class),
+                                any(CommandResponse.class),
+                                any());
                         // then it is forwarded successfully
                         verify(metrics).reportCommand(
                                 eq(MetricsTags.Direction.RESPONSE),
@@ -1309,7 +1314,11 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
                         assertThat(((ClientErrorException) t).getErrorCode())
                                 .isEqualTo(HttpUtils.HTTP_TOO_MANY_REQUESTS);
                         // AND the response is not being forwarded
-                        verify(sender, never()).sendCommandResponse(any(CommandResponse.class), (SpanContext) any());
+                        verify(sender, never()).sendCommandResponse(
+                                any(TenantObject.class),
+                                any(RegistrationAssertion.class),
+                                any(CommandResponse.class),
+                                (SpanContext) any());
                         // AND has reported the message as unprocessable
                         verify(metrics).reportCommand(
                                 eq(MetricsTags.Direction.RESPONSE),

--- a/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommandResponseSender.java
+++ b/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommandResponseSender.java
@@ -28,6 +28,8 @@ import org.eclipse.hono.client.command.CommandResponseSender;
 import org.eclipse.hono.util.AddressHelper;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
@@ -93,7 +95,11 @@ public class ProtonBasedCommandResponseSender extends AbstractServiceClient impl
     }
 
     @Override
-    public Future<Void> sendCommandResponse(final CommandResponse response, final SpanContext context) {
+    public Future<Void> sendCommandResponse(
+            final TenantObject tenant,
+            final RegistrationAssertion device,
+            final CommandResponse response,
+            final SpanContext context) {
 
         Objects.requireNonNull(response);
 

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSender.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSender.java
@@ -25,6 +25,8 @@ import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
 import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
@@ -56,9 +58,13 @@ public class KafkaBasedCommandResponseSender extends AbstractKafkaBasedMessageSe
 
     @Override
     public Future<Void> sendCommandResponse(
+            final TenantObject tenant,
+            final RegistrationAssertion device,
             final CommandResponse response,
             final SpanContext context) {
 
+        Objects.requireNonNull(tenant);
+        Objects.requireNonNull(device);
         Objects.requireNonNull(response);
 
         if (log.isTraceEnabled()) {

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumer.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumer.java
@@ -386,7 +386,7 @@ public class KafkaBasedInternalCommandConsumer implements InternalCommandConsume
         final Span currentSpan = CommandContext.createSpan(tracer, command, spanContext, followsFromSpanContext);
         currentSpan.setTag(MessageHelper.APP_PROPERTY_ADAPTER_INSTANCE_ID, adapterInstanceId);
 
-        final CommandContext commandContext = new KafkaBasedCommandContext(command, currentSpan, commandResponseSender);
+        final CommandContext commandContext = new KafkaBasedCommandContext(command, commandResponseSender, currentSpan);
 
         if (commandHandler != null) {
             // partition index and offset here are related to the *tenant-based* topic the command was originally received in

--- a/clients/command-kafka/src/test/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandContextTest.java
+++ b/clients/command-kafka/src/test/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandContextTest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.client.command.kafka;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.net.HttpURLConnection;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.command.CommandResponse;
+import org.eclipse.hono.client.command.CommandResponseSender;
+import org.eclipse.hono.client.kafka.HonoTopic.Type;
+import org.eclipse.hono.client.kafka.KafkaRecordHelper;
+import org.eclipse.hono.kafka.test.KafkaClientUnitTestHelper;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import io.opentracing.noop.NoopSpan;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.producer.KafkaHeader;
+
+
+/**
+ * Tests verifying behavior of {@link KafkaBasedCommandContext}.
+ *
+ */
+class KafkaBasedCommandContextTest {
+
+    private CommandResponseSender responseSender;
+
+    @BeforeEach
+    void setUp() {
+        responseSender = mock(CommandResponseSender.class);
+        when(responseSender.sendCommandResponse(
+                any(TenantObject.class),
+                any(RegistrationAssertion.class),
+                any(CommandResponse.class),
+                any()))
+            .thenReturn(Future.succeededFuture());
+    }
+
+    private KafkaBasedCommand getRequestResponseCommand(final String tenantId, final String deviceId) {
+
+        final KafkaConsumerRecord<String, Buffer> record = KafkaClientUnitTestHelper.newMockConsumerRecord(
+                Type.COMMAND.prefix + tenantId,
+                deviceId,
+                List.of(
+                        KafkaHeader.header(MessageHelper.SYS_PROPERTY_CORRELATION_ID, "corrId"),
+                        KafkaHeader.header(KafkaRecordHelper.HEADER_RESPONSE_REQUIRED, Boolean.TRUE.toString()),
+                        KafkaHeader.header(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId),
+                        KafkaHeader.header(MessageHelper.SYS_PROPERTY_SUBJECT, "go")));
+        return KafkaBasedCommand.from(record);
+    }
+
+    @Test
+    void testErrorIsSentOnCommandResponseTopicWhenContextGetsRejected() {
+
+        testErrorIsSentOnCommandResponseTopic(
+                context -> context.reject(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST)),
+                commandResponse -> {
+                    assertThat(commandResponse.getStatus()).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
+                });
+    }
+
+    @Test
+    void testErrorIsSentOnCommandResponseTopicWhenContextGetsReleased() {
+
+        testErrorIsSentOnCommandResponseTopic(
+                context -> context.release(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST)),
+                commandResponse -> {
+                    assertThat(commandResponse.getStatus()).isEqualTo(HttpURLConnection.HTTP_UNAVAILABLE);
+                });
+    }
+
+    private void testErrorIsSentOnCommandResponseTopic(
+            final Consumer<KafkaBasedCommandContext> contextHandler,
+            final Consumer<CommandResponse> responseAssertions) {
+
+        final String deviceId = "device-id";
+        final var command = getRequestResponseCommand(Constants.DEFAULT_TENANT, deviceId);
+        final var context = new KafkaBasedCommandContext(command, responseSender, NoopSpan.INSTANCE);
+
+        contextHandler.accept(context);
+
+        final ArgumentCaptor<CommandResponse> commandResponse = ArgumentCaptor.forClass(CommandResponse.class);
+        verify(responseSender).sendCommandResponse(
+                any(TenantObject.class),
+                any(RegistrationAssertion.class),
+                commandResponse.capture(),
+                any());
+        assertThat(commandResponse.getValue().getCorrelationId()).isEqualTo("corrId");
+        responseAssertions.accept(commandResponse.getValue());
+    }
+}

--- a/clients/command-kafka/src/test/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandTest.java
+++ b/clients/command-kafka/src/test/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandTest.java
@@ -16,8 +16,6 @@ package org.eclipse.hono.client.command.kafka;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -27,6 +25,7 @@ import java.util.Map;
 
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaRecordHelper;
+import org.eclipse.hono.kafka.test.KafkaClientUnitTestHelper;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessageHelper;
 import org.junit.jupiter.api.Test;
@@ -274,12 +273,11 @@ public class KafkaBasedCommandTest {
         return headers;
     }
 
-    @SuppressWarnings("unchecked")
-    private KafkaConsumerRecord<String, Buffer> getCommandRecord(final String topic, final String key, final List<KafkaHeader> headers) {
-        final KafkaConsumerRecord<String, Buffer> consumerRecord = mock(KafkaConsumerRecord.class);
-        when(consumerRecord.headers()).thenReturn(headers);
-        when(consumerRecord.topic()).thenReturn(topic);
-        when(consumerRecord.key()).thenReturn(key);
-        return consumerRecord;
+    private KafkaConsumerRecord<String, Buffer> getCommandRecord(
+            final String topic,
+            final String key,
+            final List<KafkaHeader> headers) {
+
+        return KafkaClientUnitTestHelper.newMockConsumerRecord(topic, key, headers);
     }
 }

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandContext.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandContext.java
@@ -39,6 +39,7 @@ public interface CommandContext extends ExecutionContext {
      * The key under which the current CommandContext is stored in an ExecutionContext container.
      */
     String KEY_COMMAND_CONTEXT = "command-context";
+    String KEY_TENANT_CONFIG = "tenant-config";
 
     /**
      * Logs information about the command.

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandResponseSender.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandResponseSender.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,6 +14,8 @@ package org.eclipse.hono.client.command;
 
 import org.eclipse.hono.util.Lifecycle;
 import org.eclipse.hono.util.MessagingClient;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
 
 import io.opentracing.SpanContext;
 import io.vertx.core.Future;
@@ -26,6 +28,8 @@ public interface CommandResponseSender extends MessagingClient, Lifecycle {
     /**
      * Sends a device's response to a command.
      *
+     * @param tenant The tenant that the device belongs to.
+     * @param device The registration assertion for the device that the data originates from.
      * @param response The response.
      * @param context The currently active OpenTracing span or {@code null} if no
      *         span is currently active. An implementation should use this as the
@@ -37,7 +41,11 @@ public interface CommandResponseSender extends MessagingClient, Lifecycle {
      *         <p>
      *         The future will be failed with a {@code org.eclipse.hono.client.ServiceInvocationException}
      *         if the response could not be sent.
-     * @throws NullPointerException if response is {@code null}.
+     * @throws NullPointerException if tenant, device or response are {@code null}.
      */
-    Future<Void> sendCommandResponse(CommandResponse response, SpanContext context);
+    Future<Void> sendCommandResponse(
+            TenantObject tenant,
+            RegistrationAssertion device,
+            CommandResponse response,
+            SpanContext context);
 }

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandRouterCommandConsumerFactory.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandRouterCommandConsumerFactory.java
@@ -221,7 +221,7 @@ public class CommandRouterCommandConsumerFactory implements CommandConsumerFacto
                     commandHandlers.removeCommandHandler(tenantId, deviceId);
                 })
                 .map(v -> {
-                    return (CommandConsumer) new CommandConsumer() {
+                    return new CommandConsumer() {
                         @Override
                         public Future<Void> close(final SpanContext spanContext) {
                             return removeCommandConsumer(commandHandlerWrapper, sanitizedLifespan,

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImpl.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImpl.java
@@ -222,9 +222,8 @@ public class CommandRouterServiceImpl implements CommandRouterService, HealthChe
                 })
                 .compose(v -> deviceConnectionInfo
                         .setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, getSanitizedLifespan(lifespan), span)
-                        .recover(thr -> {
+                        .onFailure(thr -> {
                             LOG.info("error setting command handling adapter instance [tenant: {}, device: {}]", tenantId, deviceId, thr);
-                            return Future.failedFuture(thr);
                         }))
                 .map(v -> CommandRouterResult.from(HttpURLConnection.HTTP_NO_CONTENT))
                 .otherwise(t -> CommandRouterResult.from(ServiceInvocationException.extractStatusCode(t)));

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandler.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandler.java
@@ -131,8 +131,11 @@ public class KafkaBasedMappingAndDelegatingCommandHandler extends AbstractMappin
         final Span currentSpan = CommandConsumer.createSpan("map and delegate command", command.getTenant(),
                 command.getDeviceId(), null, tracer, spanContext);
         KafkaTracingHelper.setRecordTags(currentSpan, consumerRecord);
-        final KafkaBasedCommandContext commandContext = new KafkaBasedCommandContext(command, currentSpan,
-                kafkaBasedCommandResponseSender);
+
+        final KafkaBasedCommandContext commandContext = new KafkaBasedCommandContext(
+                command,
+                kafkaBasedCommandResponseSender,
+                currentSpan);
 
         command.logToSpan(currentSpan);
         if (!command.isValid()) {

--- a/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/amqp/ProtonBasedMappingAndDelegatingCommandHandlerTest.java
+++ b/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/amqp/ProtonBasedMappingAndDelegatingCommandHandlerTest.java
@@ -51,6 +51,7 @@ import org.eclipse.hono.util.TenantObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.micrometer.core.instrument.Timer;
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.Context;
@@ -108,6 +109,7 @@ public class ProtonBasedMappingAndDelegatingCommandHandlerTest {
         commandTargetMapper = mock(CommandTargetMapper.class);
 
         final CommandRouterMetrics metrics = mock(CommandRouterMetrics.class);
+        when(metrics.startTimer()).thenReturn(Timer.start());
         mappingAndDelegatingCommandHandler = new ProtonBasedMappingAndDelegatingCommandHandler(tenantClient,
                 connection, commandTargetMapper, metrics);
     }

--- a/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaCommandProcessingQueueTest.java
+++ b/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaCommandProcessingQueueTest.java
@@ -153,7 +153,7 @@ public class KafkaCommandProcessingQueueTest {
         when(consumerRecord.partition()).thenReturn(0);
 
         final KafkaBasedCommand cmd = KafkaBasedCommand.from(consumerRecord);
-        return new KafkaBasedCommandContext(cmd, mock(Span.class), mock(CommandResponseSender.class)) {
+        return new KafkaBasedCommandContext(cmd, mock(CommandResponseSender.class), mock(Span.class)) {
             @Override
             public String toString() {
                 return "Command " + offset;

--- a/test-utils/adapter-base-test-utils/src/main/java/org/eclipse/hono/adapter/test/ProtocolAdapterMockSupport.java
+++ b/test-utils/adapter-base-test-utils/src/main/java/org/eclipse/hono/adapter/test/ProtocolAdapterMockSupport.java
@@ -359,7 +359,12 @@ public abstract class ProtocolAdapterMockSupport {
      * @return The sender that the factory will create.
      */
     protected CommandResponseSender givenACommandResponseSenderForAnyTenant(final Promise<Void> outcome) {
-        when(commandResponseSender.sendCommandResponse(any(CommandResponse.class), (SpanContext) any())).thenReturn(outcome.future());
+        when(commandResponseSender.sendCommandResponse(
+                any(TenantObject.class),
+                any(RegistrationAssertion.class),
+                any(CommandResponse.class),
+                (SpanContext) any()))
+            .thenReturn(outcome.future());
         return commandResponseSender;
     }
 
@@ -571,6 +576,10 @@ public abstract class ProtocolAdapterMockSupport {
      * @throws AssertionError if a message has been sent.
      */
     protected void assertNoCommandResponseHasBeenSentDownstream() {
-        verify(commandResponseSender, never()).sendCommandResponse(any(CommandResponse.class), any());
+        verify(commandResponseSender, never()).sendCommandResponse(
+                any(TenantObject.class),
+                any(RegistrationAssertion.class),
+                any(CommandResponse.class),
+                any());
     }
 }

--- a/test-utils/kafka-test-utils/src/main/java/org/eclipse/hono/kafka/test/KafkaClientUnitTestHelper.java
+++ b/test-utils/kafka-test-utils/src/main/java/org/eclipse/hono/kafka/test/KafkaClientUnitTestHelper.java
@@ -15,10 +15,12 @@ package org.eclipse.hono.kafka.test;
 
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import static com.google.common.truth.Truth.assertThat;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Objects;
 
 import org.apache.kafka.clients.producer.MockProducer;
@@ -34,6 +36,8 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.json.Json;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.producer.KafkaHeader;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.RecordMetadata;
 import io.vertx.kafka.client.serialization.BufferSerializer;
@@ -44,6 +48,29 @@ import io.vertx.kafka.client.serialization.BufferSerializer;
 public class KafkaClientUnitTestHelper {
 
     private KafkaClientUnitTestHelper() {
+    }
+
+    /**
+     * Creates a consumer record for a topic, key and headers.
+     *
+     * @param <K> The type of the record's key.
+     * @param <P> The type of the record's payload.
+     * @param topic The record's topic.
+     * @param key The record's key.
+     * @param headers The record's headers.
+     * @return The record.
+     */
+    public static <K, P> KafkaConsumerRecord<K, P> newMockConsumerRecord(
+            final String topic,
+            final K key,
+            final List<KafkaHeader> headers) {
+
+        @SuppressWarnings("unchecked")
+        final KafkaConsumerRecord<K, P> consumerRecord = mock(KafkaConsumerRecord.class);
+        when(consumerRecord.headers()).thenReturn(headers);
+        when(consumerRecord.topic()).thenReturn(topic);
+        when(consumerRecord.key()).thenReturn(key);
+        return consumerRecord;
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/commandrouter/KafkaBasedCommandConsumerFactoryImplIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/commandrouter/KafkaBasedCommandConsumerFactoryImplIT.java
@@ -13,6 +13,7 @@
 package org.eclipse.hono.tests.commandrouter;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -61,6 +62,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.micrometer.core.instrument.Timer;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
@@ -435,6 +437,8 @@ public class KafkaBasedCommandConsumerFactoryImplIT {
         kafkaConsumerConfig.setConsumerConfig(Map.of(
                 ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS));
         final CommandRouterMetrics metrics = mock(CommandRouterMetrics.class);
+        when(metrics.startTimer()).thenReturn(Timer.start());
+
         final var kafkaBasedCommandConsumerFactoryImpl = new KafkaBasedCommandConsumerFactoryImpl(
                 vertx,
                 tenantClient,


### PR DESCRIPTION
This is more (final?) prep-work for #2702 

The CommandResponseSender interface's sendResponse method has been
extended to require tenant configuration and a registration assertion to
be provided in order to better resemble the TelemetrySender and
EventSender interfaces.

The sender implementations have not (yet) been extended to include the
default properties in the downstream command response in order to keep
the scope of this commit smaller.

The CommandResponseSender implementations as well as the TelemetrySender and
EventSender implementation will be adapted accordingly in the next (final?) PR, bringing
it all together.
