### PR TITLE
[#2984] Clean Caches on Device Registry Notifications

### DIFF
--- a/adapter-base-quarkus/pom.xml
+++ b/adapter-base-quarkus/pom.xml
@@ -56,6 +56,10 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-notification-kafka</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-client-telemetry-kafka</artifactId>
     </dependency>
     <dependency>

--- a/adapter-base-spring/pom.xml
+++ b/adapter-base-spring/pom.xml
@@ -41,6 +41,10 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-notification-kafka</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-client-registry-amqp</artifactId>
     </dependency>
     <dependency>

--- a/clients/client-common/src/main/java/org/eclipse/hono/client/util/AnnotatedCacheKey.java
+++ b/clients/client-common/src/main/java/org/eclipse/hono/client/util/AnnotatedCacheKey.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A cache key that supports adding metadata attributes to be used to filter cache entries.
+ * <p>
+ * The metadata attributes are not taken into account by the {@link #equals(Object)} and {@link #hashCode()} methods and
+ * are therefore not part of the identity checks by the cache implementation.
+ *
+ * @param <T> The type of the cache key.
+ */
+public final class AnnotatedCacheKey<T> {
+
+    private final T key;
+    private final Map<String, String> attributes = new HashMap<>();
+
+    /**
+     * Creates an instance for the given key.
+     *
+     * @param key The cache key to be used.
+     * @throws NullPointerException if the key is {@code null}.
+     */
+    public AnnotatedCacheKey(final T key) {
+        this.key = Objects.requireNonNull(key);
+    }
+
+    /**
+     * Gets the cache key.
+     *
+     * @return The key.
+     */
+    public T getKey() {
+        return key;
+    }
+
+    /**
+     * Puts the given attribute to the metadata.
+     *
+     * @param attributeKey The key of the attribute.
+     * @param value The value of the attribute.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public void putAttribute(final String attributeKey, final String value) {
+        Objects.requireNonNull(attributeKey);
+        Objects.requireNonNull(value);
+
+        attributes.put(attributeKey, value);
+    }
+
+    /**
+     * Gets the attribute value for the given key.
+     *
+     * @param attributeKey The key of the attribute
+     * @return An optional that contains the value or an empty Optional if no value is present for the given attribute
+     *         key.
+     * @throws NullPointerException if the attribute key is {@code null}.
+     */
+    public Optional<String> getAttribute(final String attributeKey) {
+        Objects.requireNonNull(attributeKey);
+
+        return Optional.ofNullable(attributes.get(attributeKey));
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final AnnotatedCacheKey<?> that = (AnnotatedCacheKey<?>) o;
+        return key.equals(that.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key);
+    }
+
+    @Override
+    public String toString() {
+        return "AnnotatedCacheKey{" +
+                "key=" + key +
+                ", attributes=" + attributes +
+                '}';
+    }
+}

--- a/clients/client-common/src/test/java/org/eclipse/hono/client/util/AnnotatedCacheKeyTest.java
+++ b/clients/client-common/src/test/java/org/eclipse/hono/client/util/AnnotatedCacheKeyTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests verifying behavior of {@link AnnotatedCacheKey}.
+ *
+ */
+public class AnnotatedCacheKeyTest {
+
+    public static final String RAW_KEY_UNDER_TEST = "test";
+    private AnnotatedCacheKey<String> underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new AnnotatedCacheKey<>(RAW_KEY_UNDER_TEST);
+    }
+
+    /**
+     * Verifies that the key added in the constructor is returned by {@link AnnotatedCacheKey#getKey()}.
+     */
+    @Test
+    public void testThatKeyIsReturned() {
+        assertThat(underTest.getKey()).isEqualTo(RAW_KEY_UNDER_TEST);
+
+        final AnnotatedCacheKey<Long> longAnnotatedCacheKey = new AnnotatedCacheKey<>(99L);
+        assertThat(longAnnotatedCacheKey.getKey()).isEqualTo(99L);
+    }
+
+    /**
+     * Verifies that the attributes can be added and retrieved.
+     */
+    @Test
+    public void testThatAttributeIsAdded() {
+        final String attributeKey = "the-key";
+        final String attributeValue = "the-value";
+
+        underTest.putAttribute(attributeKey, attributeValue);
+
+        assertThat(
+                underTest.getAttribute(attributeKey)
+                        .orElseThrow(() -> new RuntimeException("the expected attribute is missing")))
+                                .isEqualTo(attributeValue);
+    }
+
+    /**
+     * Verifies that {@link AnnotatedCacheKey#equals(Object)} only compares the key and not the attributes.
+     */
+    @Test
+    public void testThatEqualsDoesNotTakeAttributesIntoAccount() {
+        underTest.putAttribute("attribute1", "value1");
+
+        final AnnotatedCacheKey<String> second = new AnnotatedCacheKey<>(RAW_KEY_UNDER_TEST);
+        second.putAttribute("attribute1", "other-value");
+        second.putAttribute("attribute2", "value2");
+
+        assertThat(second).isEqualTo(underTest);
+    }
+
+    /**
+     * Verifies that {@link AnnotatedCacheKey#hashCode()} only compares the key and not the attributes.
+     */
+    @Test
+    public void testThatHashCodeDoesNotTakeAttributesIntoAccount() {
+        underTest.putAttribute("attribute1", "value1");
+
+        final AnnotatedCacheKey<String> second = new AnnotatedCacheKey<>(RAW_KEY_UNDER_TEST);
+        second.putAttribute("attribute1", "other-value");
+        second.putAttribute("attribute2", "value2");
+
+        assertThat(second.hashCode()).isEqualTo(underTest.hashCode());
+    }
+}

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/NoOpNotificationReceiver.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/NoOpNotificationReceiver.java
@@ -14,15 +14,17 @@
 package org.eclipse.hono.notification;
 
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 
 /**
- * A no-op implementation for the notification sender.
+ * A no-op implementation for the notification receiver.
  */
-public final class NoOpNotificationSender implements NotificationSender {
+public final class NoOpNotificationReceiver implements NotificationReceiver {
 
     @Override
-    public Future<Void> publish(final AbstractNotification notification) {
-        return Future.succeededFuture();
+    public <T extends AbstractNotification> void registerConsumer(final Class<T> notificationType,
+            final Handler<T> consumer) {
+
     }
 
     @Override

--- a/clients/registry-amqp/pom.xml
+++ b/clients/registry-amqp/pom.xml
@@ -38,6 +38,10 @@
       <artifactId>hono-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-notification</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
     </dependency>

--- a/core/src/main/java/org/eclipse/hono/util/CredentialsObject.java
+++ b/core/src/main/java/org/eclipse/hono/util/CredentialsObject.java
@@ -74,7 +74,7 @@ public final class CredentialsObject extends JsonBackedValueObject {
     }
 
     /**
-     * Adds a property to this tenant.
+     * Adds a property to these credentials.
      *
      * @param name The property name.
      * @param value The property value.

--- a/services/command-router-base/pom.xml
+++ b/services/command-router-base/pom.xml
@@ -45,6 +45,10 @@
       <artifactId>hono-client-registry-amqp</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-notification-kafka</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
     </dependency>

--- a/test-utils/core-test-utils/src/main/java/org/eclipse/hono/test/VertxMockSupport.java
+++ b/test-utils/core-test-utils/src/main/java/org/eclipse/hono/test/VertxMockSupport.java
@@ -26,6 +26,7 @@ import org.mockito.invocation.InvocationOnMock;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -131,6 +132,12 @@ public final class VertxMockSupport {
 
         doAnswer(VertxMockSupport::handleExecuteBlockingInvocation)
                 .when(context).executeBlocking(anyHandler(), any());
+
+        when(vertx.executeBlocking(anyHandler()))
+                .thenAnswer(VertxMockSupport::handleExecuteBlockingInvocationReturningFuture);
+
+        when(context.executeBlocking(anyHandler()))
+                .thenAnswer(VertxMockSupport::handleExecuteBlockingInvocationReturningFuture);
     }
 
     private static Void handleExecuteBlockingInvocation(final InvocationOnMock invocation) {
@@ -142,6 +149,13 @@ public final class VertxMockSupport {
             resultHandler.handle(result.future());
         }
         return null;
+    }
+
+    private static <T> Future<T> handleExecuteBlockingInvocationReturningFuture(final InvocationOnMock invocation) {
+        final Promise<T> result = Promise.promise();
+        final Handler<Promise<?>> blockingCodeHandler = invocation.getArgument(0);
+        blockingCodeHandler.handle(result);
+        return result.future();
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsAmqpIT.java
@@ -16,6 +16,7 @@ import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.registry.CredentialsClient;
 import org.eclipse.hono.client.registry.amqp.ProtonBasedCredentialsClient;
+import org.eclipse.hono.notification.NoOpNotificationReceiver;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -48,6 +49,7 @@ public class CredentialsAmqpIT extends CredentialsApiTests {
                                 IntegrationTestSupport.TENANT_ADMIN_USER,
                                 IntegrationTestSupport.TENANT_ADMIN_PWD)),
                 SendMessageSampler.Factory.noop(),
+                new NoOpNotificationReceiver(),
                 null);
 
         client.start().onComplete(ctx.succeedingThenComplete());

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistrationAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistrationAmqpIT.java
@@ -17,6 +17,7 @@ import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.client.registry.amqp.ProtonBasedDeviceRegistrationClient;
+import org.eclipse.hono.notification.NoOpNotificationReceiver;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -51,6 +52,7 @@ public class DeviceRegistrationAmqpIT extends DeviceRegistrationApiTests {
                                 IntegrationTestSupport.TENANT_ADMIN_USER,
                                 IntegrationTestSupport.TENANT_ADMIN_PWD)),
                 SendMessageSampler.Factory.noop(),
+                new NoOpNotificationReceiver(),
                 null);
         registrationClient.start().onComplete(ctx.succeedingThenComplete());
     }

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantAmqpIT.java
@@ -17,6 +17,7 @@ import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.registry.TenantClient;
 import org.eclipse.hono.client.registry.amqp.ProtonBasedTenantClient;
+import org.eclipse.hono.notification.NoOpNotificationReceiver;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -55,6 +56,7 @@ public class TenantAmqpIT extends TenantApiTests {
                                 IntegrationTestSupport.TENANT_ADMIN_USER,
                                 IntegrationTestSupport.TENANT_ADMIN_PWD)),
                 SendMessageSampler.Factory.noop(),
+                new NoOpNotificationReceiver(),
                 null);
 
         allTenantClient.start()
@@ -69,6 +71,7 @@ public class TenantAmqpIT extends TenantApiTests {
                                 IntegrationTestSupport.HONO_USER,
                                 IntegrationTestSupport.HONO_PWD)),
                 SendMessageSampler.Factory.noop(),
+                new NoOpNotificationReceiver(),
                 null);
 
         defaultTenantClient.start()


### PR DESCRIPTION
This fixes #2984.
The clients for the device registry APIs may register receivers for notifications of the device registry that are used to remove
objects from the response cache if the corresponding data has changed.

I have created new classes for the cache keys. The reason is that before, some elements of the keys were concatenated (like "${tenantId}-${deviceId}"). This makes it difficult to find e.g. all keys for a tenant.
Previously, the name of the API operation in question was part of the keys. I left it out because none of the clients provide multiple operations. If that ever changes, it's easy to add the operation to the key. @sophokles73 Is this ok for you? Or am I missing something?

Sometimes data that is not part of the key is needed to find affected cache entries. For example, the device ID was not stored with the credentials. 
In order to find the cache entries by means of the Device ID, I could have created an additional map in which I keep track of which credentials belong to which Device ID. The problem is that entries are evicted from the cache and then would have remained in the map. Instead, I created the class AnnotatedCacheKey, which allows storing additional attributes to a key without them having to become part of the key. 
