### PR TITLE
[#2983] Use one notification sender per server verticle

### DIFF
--- a/clients/client-common/src/main/java/org/eclipse/hono/client/util/MessagingClientProvider.java
+++ b/clients/client-common/src/main/java/org/eclipse/hono/client/util/MessagingClientProvider.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import org.eclipse.hono.util.Lifecycle;
@@ -45,6 +46,8 @@ public final class MessagingClientProvider<T extends MessagingClient & Lifecycle
     public static final MessagingType DEFAULT_MESSAGING_TYPE = MessagingType.amqp;
 
     private final Map<MessagingType, T> clientImplementations = new HashMap<>();
+    private final AtomicBoolean startCalled = new AtomicBoolean();
+    private final AtomicBoolean stopCalled = new AtomicBoolean();
 
     private void requireClientsConfigured() {
         if (!containsImplementations()) {
@@ -167,6 +170,9 @@ public final class MessagingClientProvider<T extends MessagingClient & Lifecycle
 
     @Override
     public Future<Void> start() {
+        if (!startCalled.compareAndSet(false, true)) {
+            return Future.succeededFuture();
+        }
         requireClientsConfigured();
 
         @SuppressWarnings("rawtypes")
@@ -179,6 +185,9 @@ public final class MessagingClientProvider<T extends MessagingClient & Lifecycle
 
     @Override
     public Future<Void> stop() {
+        if (!stopCalled.compareAndSet(false, true)) {
+            return Future.succeededFuture();
+        }
         @SuppressWarnings("rawtypes")
         final List<Future> futures = clientImplementations.values()
                 .stream()

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
@@ -416,9 +416,7 @@ public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends
     protected final Future<Void> stopInternal() {
 
         return preShutdown()
-                .compose(s -> {
-                    return CompositeFuture.all(stopServer(), stopInsecureServer());
-                })
+                .compose(s -> CompositeFuture.all(stopServer(), stopInsecureServer()))
                 .compose(s -> stopEndpoints())
                 .compose(v -> postShutdown());
     }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/server/DeviceRegistryHttpServer.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/server/DeviceRegistryHttpServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,12 +13,43 @@
 
 package org.eclipse.hono.deviceregistry.server;
 
+import java.util.Objects;
+
 import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.notification.NoOpNotificationSender;
+import org.eclipse.hono.notification.NotificationSender;
 import org.eclipse.hono.service.http.HttpServiceBase;
+
+import io.vertx.core.Future;
 
 /**
  * Default REST server for Hono's example device registry.
  */
 public class DeviceRegistryHttpServer extends HttpServiceBase<ServiceConfigProperties> {
 
+    private NotificationSender notificationSender = new NoOpNotificationSender();
+
+    /**
+     * Sets the client to publish notifications about changes on devices.
+     * <p>
+     * The {@link org.eclipse.hono.util.Lifecycle#start()} method of the given client will be invoked during startup
+     * of the server, and the {@link org.eclipse.hono.util.Lifecycle#stop()} method will be called on server shutdown.
+     * The outcome of these methods is tied to the outcome of the server start/shutdown.
+     *
+     * @param notificationSender The client.
+     * @throws NullPointerException if notificationSender is {@code null}.
+     */
+    public final void setNotificationSender(final NotificationSender notificationSender) {
+        this.notificationSender = Objects.requireNonNull(notificationSender);
+    }
+
+    @Override
+    protected Future<Void> preStartServers() {
+        return notificationSender.start();
+    }
+
+    @Override
+    protected Future<Void> postShutdown() {
+        return notificationSender.stop();
+    }
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/credentials/AbstractCredentialsManagementService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/credentials/AbstractCredentialsManagementService.java
@@ -36,7 +36,6 @@ import org.eclipse.hono.service.management.credentials.CommonCredential;
 import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
 import org.eclipse.hono.service.management.credentials.PasswordCredential;
 import org.eclipse.hono.util.Futures;
-import org.eclipse.hono.util.Lifecycle;
 import org.eclipse.hono.util.Strings;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -49,7 +48,7 @@ import io.vertx.core.Vertx;
  * <p>
  * It checks the parameters, validate tenant using {@link TenantInformationService} and creates {@link DeviceKey} for looking up the credentials.
  */
-public abstract class AbstractCredentialsManagementService implements CredentialsManagementService, Lifecycle {
+public abstract class AbstractCredentialsManagementService implements CredentialsManagementService {
 
     protected TenantInformationService tenantInformationService = new NoopTenantInformationService();
 
@@ -103,16 +102,6 @@ public abstract class AbstractCredentialsManagementService implements Credential
      */
     public void setNotificationSender(final NotificationSender notificationSender) {
         this.notificationSender = Objects.requireNonNull(notificationSender);
-    }
-
-    @Override
-    public Future<Void> start() {
-        return notificationSender.start();
-    }
-
-    @Override
-    public Future<Void> stop() {
-        return notificationSender.stop();
     }
 
     /**

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AbstractDeviceManagementService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AbstractDeviceManagementService.java
@@ -39,7 +39,6 @@ import org.eclipse.hono.service.management.Sort;
 import org.eclipse.hono.service.management.device.Device;
 import org.eclipse.hono.service.management.device.DeviceManagementService;
 import org.eclipse.hono.service.management.device.DeviceWithId;
-import org.eclipse.hono.util.Lifecycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,7 +53,7 @@ import io.vertx.core.Future;
  * <p>
  * It checks the parameters, validate tenant using {@link TenantInformationService} and creates {@link DeviceKey} for device operations.
  */
-public abstract class AbstractDeviceManagementService implements DeviceManagementService, Lifecycle {
+public abstract class AbstractDeviceManagementService implements DeviceManagementService {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractDeviceManagementService.class);
 
@@ -81,16 +80,6 @@ public abstract class AbstractDeviceManagementService implements DeviceManagemen
      */
     public void setNotificationSender(final NotificationSender notificationSender) {
         this.notificationSender = Objects.requireNonNull(notificationSender);
-    }
-
-    @Override
-    public Future<Void> start() {
-        return notificationSender.start();
-    }
-
-    @Override
-    public Future<Void> stop() {
-        return notificationSender.stop();
     }
 
     /**

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/tenant/AbstractTenantManagementService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/tenant/AbstractTenantManagementService.java
@@ -36,7 +36,6 @@ import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.service.management.tenant.TenantManagementService;
 import org.eclipse.hono.service.management.tenant.TenantWithId;
 import org.eclipse.hono.tracing.TracingHelper;
-import org.eclipse.hono.util.Lifecycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +46,7 @@ import io.vertx.core.Promise;
 /**
  * An abstract base class implementation for {@link TenantManagementService}.
  */
-public abstract class AbstractTenantManagementService implements TenantManagementService, Lifecycle {
+public abstract class AbstractTenantManagementService implements TenantManagementService {
 
     protected NotificationSender notificationSender = new NoOpNotificationSender();
     private final Logger log = LoggerFactory.getLogger(getClass());
@@ -60,16 +59,6 @@ public abstract class AbstractTenantManagementService implements TenantManagemen
      */
     public void setNotificationSender(final NotificationSender notificationSender) {
         this.notificationSender = Objects.requireNonNull(notificationSender);
-    }
-
-    @Override
-    public Future<Void> start() {
-        return notificationSender.start();
-    }
-
-    @Override
-    public Future<Void> stop() {
-        return notificationSender.stop();
     }
 
     /**

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/credentials/AbstractCredentialsManagementServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/credentials/AbstractCredentialsManagementServiceTest.java
@@ -16,7 +16,6 @@ package org.eclipse.hono.deviceregistry.service.credentials;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -76,38 +75,6 @@ public class AbstractCredentialsManagementServiceTest {
     @Test
     public void setNotificationSender() {
         assertThrows(NullPointerException.class, () -> credentialsManagementService.setNotificationSender(null));
-    }
-
-    /**
-     * Verifies that {@link AbstractCredentialsManagementService#start()} starts the notification sender.
-     *
-     * @param context The vert.x test context.
-     */
-    @Test
-    public void start(final VertxTestContext context) {
-        when(notificationSender.start()).thenReturn(Future.succeededFuture());
-
-        credentialsManagementService.start()
-                .onComplete(context.succeeding(result -> context.verify(() -> {
-                    verify(notificationSender).start();
-                    context.completeNow();
-                })));
-    }
-
-    /**
-     * Verifies that {@link AbstractCredentialsManagementService#stop()} stops the notification sender.
-     *
-     * @param context The vert.x test context.
-     */
-    @Test
-    public void stop(final VertxTestContext context) {
-        when(notificationSender.stop()).thenReturn(Future.succeededFuture());
-
-        credentialsManagementService.stop()
-                .onComplete(context.succeeding(result -> context.verify(() -> {
-                    verify(notificationSender).stop();
-                    context.completeNow();
-                })));
     }
 
     /**

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/device/AbstractDeviceManagementServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/device/AbstractDeviceManagementServiceTest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -73,38 +72,6 @@ public class AbstractDeviceManagementServiceTest {
     @Test
     public void setNotificationSender() {
         assertThrows(NullPointerException.class, () -> deviceManagementService.setNotificationSender(null));
-    }
-
-    /**
-     * Verifies that {@link AbstractDeviceManagementService#start()} starts the notification sender.
-     *
-     * @param context The vert.x test context.
-     */
-    @Test
-    public void start(final VertxTestContext context) {
-        when(notificationSender.start()).thenReturn(Future.succeededFuture());
-
-        deviceManagementService.start()
-                .onComplete(context.succeeding(result -> context.verify(() -> {
-                    verify(notificationSender).start();
-                    context.completeNow();
-                })));
-    }
-
-    /**
-     * Verifies that {@link AbstractDeviceManagementService#stop()} stops the notification sender.
-     *
-     * @param context The vert.x test context.
-     */
-    @Test
-    public void stop(final VertxTestContext context) {
-        when(notificationSender.stop()).thenReturn(Future.succeededFuture());
-
-        deviceManagementService.stop()
-                .onComplete(context.succeeding(result -> context.verify(() -> {
-                    verify(notificationSender).stop();
-                    context.completeNow();
-                })));
     }
 
     /**

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/tenant/AbstractTenantManagementServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/tenant/AbstractTenantManagementServiceTest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -71,38 +70,6 @@ public class AbstractTenantManagementServiceTest {
     @Test
     public void setNotificationSender() {
         assertThrows(NullPointerException.class, () -> tenantManagementService.setNotificationSender(null));
-    }
-
-    /**
-     * Verifies that {@link AbstractTenantManagementService#start()} starts the notification sender.
-     *
-     * @param context The vert.x test context.
-     */
-    @Test
-    public void start(final VertxTestContext context) {
-        when(notificationSender.start()).thenReturn(Future.succeededFuture());
-
-        tenantManagementService.start()
-                .onComplete(context.succeeding(result -> context.verify(() -> {
-                    verify(notificationSender).start();
-                    context.completeNow();
-                })));
-    }
-
-    /**
-     * Verifies that {@link AbstractTenantManagementService#stop()} stops the notification sender.
-     *
-     * @param context The vert.x test context.
-     */
-    @Test
-    public void stop(final VertxTestContext context) {
-        when(notificationSender.stop()).thenReturn(Future.succeededFuture());
-
-        tenantManagementService.stop()
-                .onComplete(context.succeeding(result -> context.verify(() -> {
-                    verify(notificationSender).stop();
-                    context.completeNow();
-                })));
     }
 
     /**


### PR DESCRIPTION
For #2983:
This reduces the number of notification senders (and corresponding AMQP connections) in the device registry from 13 to 2 (one for each server verticle).
Similarly, there is only 1 eventSenderProvider for each server verticle being used now.
Also fixes handling of spring profiles in the JDBC device registry (#2997).

Changes in the device registry `ApplicationConfig` files here could also be seen as making them less dependent on Spring dependency injection (endpoint objects are no beans anymore, they are added explicitly to the server objects). This is also helpful for a potential future migration to Quarkus.

Also includes a fix that will prevent `HonoConnectionImpl` reconnect attempts (and corresponding errors) if Vert.x has already been closed (see 1st commit).