### PR TITLE
Do not require cache to return previous value

### DIFF
--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/BasicCache.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/BasicCache.java
@@ -154,20 +154,20 @@ public abstract class BasicCache<K, V> implements Cache<K, V>, Lifecycle {
     }
 
     @Override
-    public Future<V> put(final K key, final V value) {
+    public Future<Void> put(final K key, final V value) {
         Objects.requireNonNull(key);
         Objects.requireNonNull(value);
 
-        return withCache(aCache -> aCache.putAsync(key, value));
+        return withCache(aCache -> aCache.putAsync(key, value).thenApply(v -> (Void) null));
     }
 
     @Override
-    public Future<V> put(final K key, final V value, final long lifespan, final TimeUnit lifespanUnit) {
+    public Future<Void> put(final K key, final V value, final long lifespan, final TimeUnit lifespanUnit) {
         Objects.requireNonNull(key);
         Objects.requireNonNull(value);
         Objects.requireNonNull(lifespanUnit);
 
-        return withCache(aCache -> aCache.putAsync(key, value, lifespan, lifespanUnit));
+        return withCache(aCache -> aCache.putAsync(key, value, lifespan, lifespanUnit).thenApply(v -> (Void) null));
     }
 
     @Override

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/Cache.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/Cache.java
@@ -44,12 +44,11 @@ public interface Cache<K, V> {
      *
      * @param key The key.
      * @param value The value.
-     * @return A succeeded future containing the previous value or {@code null} if the
-     *         cache didn't contain the key yet.
+     * @return A succeeded future if the value has been stored successfully.
      *         A failed future if the value could not be stored in the cache.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
-    Future<V> put(K key, V value);
+    Future<Void> put(K key, V value);
 
     /**
      * Puts a value to the cache.
@@ -58,12 +57,11 @@ public interface Cache<K, V> {
      * @param value The value.
      * @param lifespan The lifespan of the entry. A negative value is interpreted as an unlimited lifespan.
      * @param lifespanUnit The time unit for the lifespan.
-     * @return A succeeded future containing the previous value or {@code null} if the
-     *         cache didn't contain the key yet.
+     * @return A succeeded future if the value has been stored successfully.
      *         A failed future if the value could not be stored in the cache.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
-    Future<V> put(K key, V value, long lifespan, TimeUnit lifespanUnit);
+    Future<Void> put(K key, V value, long lifespan, TimeUnit lifespanUnit);
 
     /**
      * Puts all values of the given map to the cache.
@@ -105,7 +103,7 @@ public interface Cache<K, V> {
      * @param value The value.
      * @return A succeeded future containing {@code true} if the key was
      *         mapped to the value, {@code false} otherwise.
-     *         A failed future if the value could not be remove from the cache.
+     *         A failed future if the value could not be removed from the cache.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     Future<Boolean> remove(K key, V value);

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodCache.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodCache.java
@@ -100,12 +100,10 @@ public final class HotrodCache<K, V> extends BasicCache<K, V> {
 
         final var configBuilder = properties.getConfigurationBuilder();
         configBuilder.marshaller(new ProtoStreamMarshaller());
-        // make sure that put() and remove() methods return previous values
-        // because they are required by the
-        // org.eclipse.hono.deviceconnection.infinispan.client.Cache API.
-        configBuilder.remoteCache(commonCacheConfig.getCacheName()).forceReturnValues(true);
         final var configuration = configBuilder.build();
-        LOG.info("creating HotrodCache using configuration: {}", configuration);
+        if (LOG.isInfoEnabled()) {
+            LOG.info("creating HotrodCache using configuration: {}", configuration);
+        }
         return new HotrodCache<>(
                 vertx,
                 new RemoteCacheManager(configuration, false),

--- a/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/AbstractBasicCacheTest.java
+++ b/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/AbstractBasicCacheTest.java
@@ -125,13 +125,12 @@ abstract class AbstractBasicCacheTest {
     @Test
     void testPutSucceeds(final VertxTestContext ctx) {
         final var grid = givenAConnectedInfinispanCache();
-        when(grid.putAsync(anyString(), anyString())).thenReturn(CompletableFuture.completedFuture("oldValue"));
+        when(grid.putAsync(anyString(), anyString())).thenReturn(CompletableFuture.completedFuture((Void) null));
         getCache().start()
             .compose(ok -> getCache().put("key", "value"))
-            .onComplete(ctx.succeeding(v -> {
+            .onComplete(ctx.succeeding(ok -> {
                 ctx.verify(() -> {
                     verify(grid).putAsync("key", "value");
-                    assertThat(v).isEqualTo("oldValue");
                 });
                 ctx.completeNow();
             }));
@@ -147,13 +146,12 @@ abstract class AbstractBasicCacheTest {
     void testPutWithLifespanSucceeds(final VertxTestContext ctx) {
         final var grid = givenAConnectedInfinispanCache();
         when(grid.putAsync(anyString(), anyString(), anyLong(), any(TimeUnit.class)))
-                .thenReturn(CompletableFuture.completedFuture("oldValue"));
+                .thenReturn(CompletableFuture.completedFuture((Void) null));
         getCache().start()
                 .compose(ok -> getCache().put("key", "value", 1, TimeUnit.SECONDS))
                 .onComplete(ctx.succeeding(v -> {
                     ctx.verify(() -> {
                         verify(grid).putAsync("key", "value", 1, TimeUnit.SECONDS);
-                        assertThat(v).isEqualTo("oldValue");
                     });
                     ctx.completeNow();
                 }));

--- a/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionInfoTest.java
+++ b/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionInfoTest.java
@@ -111,7 +111,7 @@ public class CacheBasedDeviceConnectionInfoTest {
     @Test
     public void testSetLastKnownGatewaySucceedsForSingleEntry(final VertxTestContext ctx) {
 
-        when(cache.put(anyString(), anyString(), anyLong(), any(TimeUnit.class))).thenReturn(Future.succeededFuture("oldValue"));
+        when(cache.put(anyString(), anyString(), anyLong(), any(TimeUnit.class))).thenReturn(Future.succeededFuture());
 
         info.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, "device-id", "gw-id", span)
             .onComplete(ctx.succeeding(ok -> {
@@ -254,7 +254,7 @@ public class CacheBasedDeviceConnectionInfoTest {
     @Test
     public void testSetCommandHandlingAdapterInstanceSucceeds(final VertxTestContext ctx) {
 
-        when(cache.put(anyString(), anyString(), anyLong(), any())).thenReturn(Future.succeededFuture("oldValue"));
+        when(cache.put(anyString(), anyString(), anyLong(), any())).thenReturn(Future.succeededFuture());
 
         info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, "testDevice", "adapterInstance", null, span)
                 .onComplete(ctx.succeeding(ok -> {
@@ -278,7 +278,7 @@ public class CacheBasedDeviceConnectionInfoTest {
     @Test
     public void testSetCommandHandlingAdapterInstanceWithLifespanSucceeds(final VertxTestContext ctx) {
 
-        when(cache.put(anyString(), anyString(), anyLong(), any(TimeUnit.class))).thenReturn(Future.succeededFuture("oldValue"));
+        when(cache.put(anyString(), anyString(), anyLong(), any(TimeUnit.class))).thenReturn(Future.succeededFuture());
 
         info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, "testDevice", "adapterInstance", Duration.ofSeconds(10), span)
                 .onComplete(ctx.succeeding(ok -> {


### PR DESCRIPTION
The Cache interface's put methods have been changed to no longer return
the previous value from the cache because the DeviceConnectionInfo
implementation does not require it.