### PR TITLE
[#2984] Use ProtonBasedNotificationReceiver

### DIFF
--- a/adapter-base-quarkus/pom.xml
+++ b/adapter-base-quarkus/pom.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -53,6 +53,10 @@
     <dependency>
       <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-client-command-kafka</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-notification-amqp</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>

--- a/adapter-base-spring/pom.xml
+++ b/adapter-base-spring/pom.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -38,6 +38,10 @@
     <dependency>
       <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-client-command-amqp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-notification-amqp</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>

--- a/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractAdapterConfig.java
+++ b/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractAdapterConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -50,6 +50,7 @@ import org.eclipse.hono.client.kafka.metrics.KafkaClientMetricsSupport;
 import org.eclipse.hono.client.kafka.metrics.KafkaMetricsConfig;
 import org.eclipse.hono.client.kafka.metrics.MicrometerKafkaClientMetricsSupport;
 import org.eclipse.hono.client.kafka.metrics.NoopKafkaClientMetricsSupport;
+import org.eclipse.hono.client.notification.amqp.ProtonBasedNotificationReceiver;
 import org.eclipse.hono.client.notification.kafka.KafkaBasedNotificationReceiver;
 import org.eclipse.hono.client.notification.kafka.NotificationKafkaConsumerConfigProperties;
 import org.eclipse.hono.client.registry.CredentialsClient;
@@ -59,10 +60,10 @@ import org.eclipse.hono.client.registry.amqp.ProtonBasedCredentialsClient;
 import org.eclipse.hono.client.registry.amqp.ProtonBasedDeviceRegistrationClient;
 import org.eclipse.hono.client.registry.amqp.ProtonBasedTenantClient;
 import org.eclipse.hono.config.ApplicationConfigProperties;
+import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.config.ServerConfig;
 import org.eclipse.hono.config.VertxProperties;
-import org.eclipse.hono.notification.NoOpNotificationReceiver;
 import org.eclipse.hono.notification.NotificationReceiver;
 import org.eclipse.hono.service.HealthCheckServer;
 import org.eclipse.hono.service.VertxBasedHealthCheckServer;
@@ -789,8 +790,9 @@ public abstract class AbstractAdapterConfig extends AbstractMessagingClientConfi
         if (kafkaConsumerConfig.isConfigured()) {
             return new KafkaBasedNotificationReceiver(vertx(), kafkaConsumerConfig);
         } else {
-            // TODO provide AMQP based notification receiver
-            return new NoOpNotificationReceiver();
+            final ClientConfigProperties notificationConfig = new ClientConfigProperties(downstreamSenderConfig());
+            notificationConfig.setServerRole("Notification");
+            return new ProtonBasedNotificationReceiver(HonoConnection.newConnection(vertx(), notificationConfig, getTracer()));
         }
     }
 

--- a/clients/registry-amqp/src/main/java/org/eclipse/hono/client/registry/amqp/ProtonBasedCredentialsClient.java
+++ b/clients/registry-amqp/src/main/java/org/eclipse/hono/client/registry/amqp/ProtonBasedCredentialsClient.java
@@ -94,6 +94,20 @@ public class ProtonBasedCredentialsClient extends AbstractRequestResponseService
                 Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
                 this::handleTenantTimeout);
         this.notificationReceiver = Objects.requireNonNull(notificationReceiver);
+
+        if (isCachingEnabled()) {
+            notificationReceiver.registerConsumer(AllDevicesOfTenantDeletedNotification.class,
+                    n -> removeResultsForTenantFromCache(n.getTenantId()));
+            notificationReceiver.registerConsumer(DeviceChangeNotification.class,
+                    n -> {
+                        if (LifecycleChange.DELETE.equals(n.getChange())
+                                || (LifecycleChange.UPDATE.equals(n.getChange()) && !n.isEnabled())) {
+                            removeResultsForDeviceFromCache(n.getTenantId(), n.getDeviceId());
+                        }
+                    });
+            notificationReceiver.registerConsumer(CredentialsChangeNotification.class,
+                    n -> removeResultsForDeviceFromCache(n.getTenantId(), n.getDeviceId()));
+        }
     }
 
     /**
@@ -276,40 +290,14 @@ public class ProtonBasedCredentialsClient extends AbstractRequestResponseService
 
     @Override
     public Future<Void> start() {
-        if (isCachingEnabled()) {
-
-            notificationReceiver.registerConsumer(AllDevicesOfTenantDeletedNotification.class,
-                    n -> removeResultsForTenantFromCache(n.getTenantId()));
-
-            notificationReceiver.registerConsumer(DeviceChangeNotification.class,
-                    n -> {
-                        if (LifecycleChange.DELETE.equals(n.getChange())
-                                || (LifecycleChange.UPDATE.equals(n.getChange()) && !n.isEnabled())) {
-
-                            removeResultsForDeviceFromCache(n.getTenantId(), n.getDeviceId());
-                        }
-                    });
-
-            notificationReceiver.registerConsumer(CredentialsChangeNotification.class,
-                    n -> removeResultsForDeviceFromCache(n.getTenantId(), n.getDeviceId()));
-
-            return notificationReceiver.start()
-                    .compose(v -> super.start());
-        } else {
-            return super.start();
-        }
+        final Future<Void> future = isCachingEnabled() ? notificationReceiver.start() : Future.succeededFuture();
+        return future.compose(v -> super.start());
     }
 
     @Override
     public Future<Void> stop() {
         return super.stop()
-                .compose(v -> {
-                    if (isCachingEnabled()) {
-                        return notificationReceiver.stop();
-                    } else {
-                        return Future.succeededFuture();
-                    }
-                });
+                .compose(v -> isCachingEnabled() ? notificationReceiver.stop() : Future.succeededFuture());
     }
 
     private static class CacheKey {

--- a/clients/registry-amqp/src/test/java/org/eclipse/hono/client/registry/amqp/ProtonBasedCredentialsClientTest.java
+++ b/clients/registry-amqp/src/test/java/org/eclipse/hono/client/registry/amqp/ProtonBasedCredentialsClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -444,14 +444,13 @@ class ProtonBasedCredentialsClientTest {
         final String tenantId = "the-tenant-id";
         final String deviceId = "the-device-id";
 
-        givenAClient(cache);
-
         final var notificationHandlerCaptor = getHandlerArgumentCaptor(AllDevicesOfTenantDeletedNotification.class);
+
+        givenAClient(cache);
 
         final Set<AnnotatedCacheKey<?>> expectedCacheRemovals = new HashSet<>();
 
         // GIVEN a client with a cache containing credentials of two tenants
-        // the client is started to register for notifications
         client.start()
                 .compose(v -> addResultToCache("other-tenant", deviceId, "other"))
                 .compose(v -> addResultToCache(tenantId, deviceId, "auth-id1"))
@@ -481,14 +480,13 @@ class ProtonBasedCredentialsClientTest {
         final String tenantId = "the-tenant-id";
         final String deviceId = "the-device-id";
 
-        givenAClient(cache);
-
         final var notificationHandlerCaptor = getHandlerArgumentCaptor(DeviceChangeNotification.class);
+
+        givenAClient(cache);
 
         final Set<AnnotatedCacheKey<?>> expectedCacheRemovals = new HashSet<>();
 
         // GIVEN a client with a cache containing credentials of two tenants
-        // the client is started to register for notifications
         client.start()
                 .compose(v -> addResultToCache("other-tenant", deviceId, "other"))
                 .compose(v -> addResultToCache(tenantId, "other-device", "other"))
@@ -520,14 +518,13 @@ class ProtonBasedCredentialsClientTest {
         final String tenantId = "the-tenant-id";
         final String deviceId = "the-device-id";
 
-        givenAClient(cache);
-
         final var notificationHandlerCaptor = getHandlerArgumentCaptor(CredentialsChangeNotification.class);
+
+        givenAClient(cache);
 
         final Set<AnnotatedCacheKey<?>> expectedCacheRemovals = new HashSet<>();
 
         // GIVEN a client with a cache containing credentials of two tenants
-        // the client is started to register for notifications
         client.start()
                 .compose(v -> addResultToCache("other-tenant", deviceId, "other"))
                 .compose(v -> addResultToCache(tenantId, deviceId, "auth-id1"))

--- a/clients/registry-amqp/src/test/java/org/eclipse/hono/client/registry/amqp/ProtonBasedDeviceRegistrationClientTest.java
+++ b/clients/registry-amqp/src/test/java/org/eclipse/hono/client/registry/amqp/ProtonBasedDeviceRegistrationClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -330,14 +330,13 @@ class ProtonBasedDeviceRegistrationClientTest {
     public void testAllDevicesOfTenantDeletedNotificationRemovesValueFromCache(final VertxTestContext ctx) {
         final String tenantId = "the-tenant-id";
 
-        givenAClient(cache);
-
         final var notificationHandlerCaptor = getHandlerArgumentCaptor(AllDevicesOfTenantDeletedNotification.class);
+
+        givenAClient(cache);
 
         final Set<AnnotatedCacheKey<?>> expectedCacheRemovals = new HashSet<>();
 
         // GIVEN a client with a cache containing device registrations of two tenants
-        // the client is started to register for notifications
         client.start()
                 .compose(v -> addResultToCache("other-tenant", "device-id1", "gateway-id"))
                 .compose(v -> addResultToCache(tenantId, "device-id1", "gateway-id"))
@@ -367,14 +366,13 @@ class ProtonBasedDeviceRegistrationClientTest {
         final String tenantId = "the-tenant-id";
         final String deviceId = "the-device-id";
 
-        givenAClient(cache);
-
         final var notificationHandlerCaptor = getHandlerArgumentCaptor(DeviceChangeNotification.class);
+
+        givenAClient(cache);
 
         final Set<AnnotatedCacheKey<?>> expectedCacheRemovals = new HashSet<>();
 
         // GIVEN a client with a cache containing device registrations of two tenants
-        // the client is started to register for notifications
         client.start()
                 .compose(v -> addResultToCache("other-tenant", deviceId, "gateway-id"))
                 .compose(v -> addResultToCache(tenantId, "other-device", "gateway-id"))
@@ -407,14 +405,13 @@ class ProtonBasedDeviceRegistrationClientTest {
         final String deviceId = "the-device-id";
         final String gatewayId = "the-device-id";
 
-        givenAClient(cache);
-
         final var notificationHandlerCaptor = getHandlerArgumentCaptor(DeviceChangeNotification.class);
+
+        givenAClient(cache);
 
         final Set<AnnotatedCacheKey<?>> expectedCacheRemovals = new HashSet<>();
 
         // GIVEN a client with a cache containing device registrations of two tenants
-        // the client is started to register for notifications
         client.start()
                 .compose(v -> addResultToCache("other-tenant", deviceId, "gateway-id"))
                 .compose(v -> addResultToCache(tenantId, "other-device", "gateway-id"))

--- a/clients/registry-amqp/src/test/java/org/eclipse/hono/client/registry/amqp/ProtonBasedTenantClientTest.java
+++ b/clients/registry-amqp/src/test/java/org/eclipse/hono/client/registry/amqp/ProtonBasedTenantClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -493,12 +493,11 @@ class ProtonBasedTenantClientTest {
     public void testTenantChangeNotificationRemovesValueFromCache(final VertxTestContext ctx) {
         final String tenantId = "the-tenant-id";
 
-        givenAClient(cache);
-
         final var notificationHandlerCaptor = getHandlerArgumentCaptor(TenantChangeNotification.class);
 
+        givenAClient(cache);
+
         // GIVEN a client with a cache containing two tenants
-        // the client is started to register for notifications
         client.start()
                 .compose(v -> addResultToCache("other-tenant"))
                 .compose(v -> addResultToCache(tenantId))

--- a/services/command-router-base/pom.xml
+++ b/services/command-router-base/pom.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -43,6 +43,10 @@
     <dependency>
       <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-client-registry-amqp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-notification-amqp</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>


### PR DESCRIPTION
This is for #2984 and is related to #2983. It addresses the TODO mentioned in https://github.com/eclipse/hono/pull/2996#discussion_r771359986.

Use ProtonBasedNotificationReceiver. Also add integration test for testing adapter registration client cache invalidation triggered via notifications.
