### PR TITLE
[#2936] Add Kafka broker configuration guide

### DIFF
--- a/site/documentation/content/admin-guide/device-connection-config.md
+++ b/site/documentation/content/admin-guide/device-connection-config.md
@@ -151,7 +151,7 @@ The following table provides an overview of the configuration variables and corr
 
 The Device Connection component requires a connection to an implementation of Hono's Authentication API in order to authenticate and authorize client requests.
 
-The connection is configured according to [Hono Client Configuration]({{< relref "hono-client-configuration.md" >}})
+The connection is configured according to the [Hono Client Configuration]({{< relref "hono-client-configuration.md" >}})
 where the `${PREFIX}` is set to `HONO_AUTH`. Since Hono's Authentication Service does not allow caching of the responses, the cache properties
 can be ignored.
 

--- a/site/documentation/content/admin-guide/file-based-device-registry-config.md
+++ b/site/documentation/content/admin-guide/file-based-device-registry-config.md
@@ -185,7 +185,7 @@ arbitrary (unused) port numbers determined by the operating system during startu
 
 The Device Registry requires a connection to an implementation of Hono's Authentication API in order to authenticate and authorize client requests.
 
-The connection is configured according to [Hono Client Configuration]({{< relref "hono-client-configuration.md" >}})
+The connection is configured according to the [Hono Client Configuration]({{< relref "hono-client-configuration.md" >}})
 where the `${PREFIX}` is set to `HONO_AUTH`. Since Hono's Authentication Service does not allow caching of the responses, the cache properties
 can be ignored.
 
@@ -246,3 +246,38 @@ device that connects directly to the adapter.
 
 The example configuration file (located at `$HONO/services/device-registry-file/src/test/resources/device-identities.json`)
 includes a device and a corresponding gateway configured in this way.
+
+## Messaging Configuration
+
+The Device Registry uses a connection to an *AMQP 1.0 Messaging Network* and/or an *Apache Kafka cluster* to
+* send [Device Provisioning Notification]({{< relref "/api/event#device-provisioning-notification" >}}) event messages
+  to convey provisioning related changes regarding a device, to be received by downstream applications,
+* send notification messages about changes to tenant/device/credentials data, to be processed by other Hono components.
+
+For the event messages a connection to an *AMQP 1.0 Messaging Network* is used by default, if configured.
+If both kinds of messaging are configured, the decision which one to use is done according to the
+[Tenant Configuration]({{< relref "admin-guide/hono-kafka-client-configuration#configuring-tenants-to-use-kafka-based-messaging" >}}).
+
+For notification messages, the Kafka connection is used by default, if configured. Otherwise the *AMQP messaging network*
+is used.
+
+### AMQP 1.0 Messaging Network Connection Configuration
+
+The connection to the *AMQP 1.0 Messaging Network* is configured according to the
+[Hono Client Configuration]({{< relref "hono-client-configuration.md" >}}) with `HONO_MESSAGING` being used as `${PREFIX}`. 
+Since there are no responses being received, the properties for configuring response caching can be ignored.
+
+### Kafka based Messaging Configuration
+
+The connection to an *Apache Kafka cluster* can be configured according to the
+[Hono Kafka Client Configuration]({{< relref "hono-kafka-client-configuration.md" >}}).
+
+The following table shows the prefixes to be used to individually configure the Kafka clients used by the Device Registry.
+The individual client configuration is optional, a minimal configuration may only contain a common client
+configuration consisting of properties prefixed with `HONO_KAFKA_COMMONCLIENTCONFIG_` and `hono.kafka.commonClientConfig.`
+respectively.
+
+| OS Environment Variable Prefix<br>Java System Property Prefix                          | Description                                                                                                         |
+|:---------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------|
+| `HONO_KAFKA_EVENT_PRODUCERCONFIG_`<br>`hono.kafka.event.producerConfig.`               | Configures the Kafka producer that publishes event messages.                                                        |
+| `HONO_KAFKA_NOTIFICATION_PRODUCERCONFIG_`<br>`hono.kafka.notification.producerConfig.` | Configures the Kafka producer that publishes notification messages about changes to tenant/device/credentials data. |

--- a/site/documentation/content/admin-guide/jdbc-device-registry-config.md
+++ b/site/documentation/content/admin-guide/jdbc-device-registry-config.md
@@ -129,3 +129,38 @@ for more information.
 
 See [Monitoring & Tracing Admin Guide]({{< relref "monitoring-tracing-config.md" >}}) for details on how to configure
 the reporting of metrics.
+
+## Messaging Configuration
+
+The Device Registry uses a connection to an *AMQP 1.0 Messaging Network* and/or an *Apache Kafka cluster* to
+* send [Device Provisioning Notification]({{< relref "/api/event#device-provisioning-notification" >}}) event messages
+  to convey provisioning related changes regarding a device, to be received by downstream applications,
+* send notification messages about changes to tenant/device/credentials data, to be processed by other Hono components.
+
+For the event messages a connection to an *AMQP 1.0 Messaging Network* is used by default, if configured.
+If both kinds of messaging are configured, the decision which one to use is done according to the
+[Tenant Configuration]({{< relref "admin-guide/hono-kafka-client-configuration#configuring-tenants-to-use-kafka-based-messaging" >}}).
+
+For notification messages, the Kafka connection is used by default, if configured. Otherwise the *AMQP messaging network*
+is used.
+
+### AMQP 1.0 Messaging Network Connection Configuration
+
+The connection to the *AMQP 1.0 Messaging Network* is configured according to the
+[Hono Client Configuration]({{< relref "hono-client-configuration.md" >}}) with `HONO_MESSAGING` being used as `${PREFIX}`.
+Since there are no responses being received, the properties for configuring response caching can be ignored.
+
+### Kafka based Messaging Configuration
+
+The connection to an *Apache Kafka cluster* can be configured according to the
+[Hono Kafka Client Configuration]({{< relref "hono-kafka-client-configuration.md" >}}).
+
+The following table shows the prefixes to be used to individually configure the Kafka clients used by the Device Registry.
+The individual client configuration is optional, a minimal configuration may only contain a common client
+configuration consisting of properties prefixed with `HONO_KAFKA_COMMONCLIENTCONFIG_` and `hono.kafka.commonClientConfig.`
+respectively.
+
+| OS Environment Variable Prefix<br>Java System Property Prefix                          | Description                                                                                                         |
+|:---------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------|
+| `HONO_KAFKA_EVENT_PRODUCERCONFIG_`<br>`hono.kafka.event.producerConfig.`               | Configures the Kafka producer that publishes event messages.                                                        |
+| `HONO_KAFKA_NOTIFICATION_PRODUCERCONFIG_`<br>`hono.kafka.notification.producerConfig.` | Configures the Kafka producer that publishes notification messages about changes to tenant/device/credentials data. |

--- a/site/documentation/content/admin-guide/kafka-config.md
+++ b/site/documentation/content/admin-guide/kafka-config.md
@@ -1,0 +1,65 @@
++++
+title = "Kafka Configuration"
+weight = 347
++++
+
+Hono may use an *Apache Kafka cluster* as messaging infrastructure.
+<!--more-->
+
+In order to configure the Hono components for using a Kafka cluster, see the [protocol adapter]({{< relref "/admin-guide/common-config#kafka-based-messaging-configuration" >}}),
+[command router]({{< relref "/admin-guide/command-router-config#kafka-based-messaging-configuration" >}}) and device
+registry admin guides.
+
+{{% notice info %}}
+The support of Kafka as a messaging system is currently a preview and not yet ready for production.
+The implementation as well as its APIs may change with the next version.
+{{% /notice %}}
+
+## Kafka Broker Configuration
+
+Hono requires the following broker configuration properties to be set:
+
+| Broker config property      | Required value | Description                                                                                                                                                                                |
+|:----------------------------|----------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `delete.topic.enable`       | `true`         | Enables deletion of topics. This is needed for the automatic deletion of `hono.command_internal.[adapterInstanceId]` topics after the corresponding protocol adapter instance was stopped. |
+
+## Used Topics
+
+### For Telemetry, Event and Command & Control Messages
+
+The Hono components publish messages to the following, tenant-specific Kafka topics, 
+from which downstream applications will consume the messages:
+
+| Topic name                         | Description                           |
+|:-----------------------------------|:--------------------------------------|
+| `hono.telemetry.[tenantId]`        | Topic for telemetry messages.         |
+| `hono.event.[tenantId]`            | Topic for event messages.             |
+| `hono.command_response.[tenantId]` | Topic for command response messages.  |
+
+For command & control messages published by downstream applications and consumed by the Hono command router,
+the following topic is used:
+
+| Topic name                         | Description                           |
+|:-----------------------------------|:--------------------------------------|
+| `hono.command.[tenantId]`          | Topic for command & control messages. |
+
+The above topics may be created in advance with appropriate replication factor and partition count settings. Otherwise,
+the `auto.create.topics.enable` broker configuration property needs to be set to `true` to enable auto-creation of these
+topics.
+
+### For Hono internal messages
+
+For messages published and consumed only by Hono components, the following topics are used:
+
+| Topic name                                  | Description                                                                                             |
+|:--------------------------------------------|:--------------------------------------------------------------------------------------------------------|
+| `hono.command_internal.[adapterInstanceId]` | Topic used for routing of command & control messages between Hono components.                           |
+| `hono.notification.registry-tenant`         | Topic used for notification messages between Hono components about changes to tenant registration data. |
+| `hono.notification.registry-device`         | Topic used for notification messages between Hono components about changes to device registration data. |
+
+The `hono.command_internal.[adapterInstanceId]` topic name contains a unique identifier as suffix, created dynamically
+on protocol adapter start. Therefore this topic cannot be created in advance. It has to be made sure that the Kafka
+admin clients in the protocol adapters are able to create this kind of topic.
+
+The `hono.notification.[suffix]` topics either need to be created in advance, or the `auto.create.topics.enable` broker
+configuration property needs to be set to `true` to enable auto-creation of these topics.

--- a/site/documentation/content/admin-guide/mongodb-device-registry-config.md
+++ b/site/documentation/content/admin-guide/mongodb-device-registry-config.md
@@ -128,3 +128,38 @@ The file needs to contain at least all versions of the key that values in the da
 Otherwise the registry will not be able to decrypt these values during reading. The `defaultKey` property indicates the
 version of the key that should be used when encrypting values. Please refer to the
 [CryptVault project](https://github.com/bolcom/cryptvault) for additional information regarding key rotation.
+
+## Messaging Configuration
+
+The Device Registry uses a connection to an *AMQP 1.0 Messaging Network* and/or an *Apache Kafka cluster* to
+* send [Device Provisioning Notification]({{< relref "/api/event#device-provisioning-notification" >}}) event messages
+  to convey provisioning related changes regarding a device, to be received by downstream applications,
+* send notification messages about changes to tenant/device/credentials data, to be processed by other Hono components.
+
+For the event messages a connection to an *AMQP 1.0 Messaging Network* is used by default, if configured.
+If both kinds of messaging are configured, the decision which one to use is done according to the
+[Tenant Configuration]({{< relref "admin-guide/hono-kafka-client-configuration#configuring-tenants-to-use-kafka-based-messaging" >}}).
+
+For notification messages, the Kafka connection is used by default, if configured. Otherwise the *AMQP messaging network*
+is used.
+
+### AMQP 1.0 Messaging Network Connection Configuration
+
+The connection to the *AMQP 1.0 Messaging Network* is configured according to the
+[Hono Client Configuration]({{< relref "hono-client-configuration.md" >}}) with `HONO_MESSAGING` being used as `${PREFIX}`.
+Since there are no responses being received, the properties for configuring response caching can be ignored.
+
+### Kafka based Messaging Configuration
+
+The connection to an *Apache Kafka cluster* can be configured according to the
+[Hono Kafka Client Configuration]({{< relref "hono-kafka-client-configuration.md" >}}).
+
+The following table shows the prefixes to be used to individually configure the Kafka clients used by the Device Registry.
+The individual client configuration is optional, a minimal configuration may only contain a common client
+configuration consisting of properties prefixed with `HONO_KAFKA_COMMONCLIENTCONFIG_` and `hono.kafka.commonClientConfig.`
+respectively.
+
+| OS Environment Variable Prefix<br>Java System Property Prefix                          | Description                                                                                                         |
+|:---------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------|
+| `HONO_KAFKA_EVENT_PRODUCERCONFIG_`<br>`hono.kafka.event.producerConfig.`               | Configures the Kafka producer that publishes event messages.                                                        |
+| `HONO_KAFKA_NOTIFICATION_PRODUCERCONFIG_`<br>`hono.kafka.notification.producerConfig.` | Configures the Kafka producer that publishes notification messages about changes to tenant/device/credentials data. |

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -17,7 +17,7 @@ description = "Information about changes in recent Hono releases. Includes new f
   configuration. The prefixes that are prepended to the configuration properties of the native Kafka client have
   changed. For existing configuration properties prefixed with `hono.kafka.commonClientConfig` properties, no change is
   needed. Other configurations with specific consumer/producer/admin client properties have to be adapted. Please refer
-  to [Hono Kafka Client Configuration]({{% doclink "/admin-guide/hono-kafka-client-configuration" %}}) for details.
+  to the [Hono Kafka Client Configuration Guide]({{% doclink "/admin-guide/hono-kafka-client-configuration" %}}) for details.
 * The protocol adapters now include a *ttl* header/property in every message being forwarded, regardless of message
   type. This allows a consumer of a message to easily determine if the message should be processed or considered
   *expired* already. The device registry supports the definition of default *ttl* values for the different types of


### PR DESCRIPTION
Also apply corrections to the messaging sections of the other admin guides.

This fixes #2936.