### PR TITLE
Use single registry type property for configuring capabilities

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -24,8 +24,10 @@
   <artifactId>hono-tests</artifactId>
 
   <name>Hono Integration Tests</name>
-  <description>Integration tests verifying Hono's APIs.
-Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch Router and ActiveMQ Artemis broker).</description>
+  <description>
+    Integration tests verifying Hono's APIs. Test cases are run against Docker images of Hono server
+    + (Apache Qpid Dispatch Router and ActiveMQ Artemis broker).
+  </description>
   <url>https://www.eclipse.org/hono</url>
 
   <properties>
@@ -116,12 +118,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
     <!--
       Device Registry related properties - The MongoDB based device registry is used as the default one.
     -->
-    <!-- should be set to false if testing against a registry that doesn't support GW mode -->
-    <hono.deviceregistry.supportsGatewayMode>true</hono.deviceregistry.supportsGatewayMode>
-    <!-- should be set to false if testing against a registry that doesn't support the "search Devices" operation -->
-    <hono.deviceregistry.supportsSearchDevices>true</hono.deviceregistry.supportsSearchDevices>
-    <!-- should be set to false if testing against a registry that doesn't support the "search Tenants" operation -->
-    <hono.deviceregistry.supportsSearchTenants>true</hono.deviceregistry.supportsSearchTenants>
+    <hono.deviceregistry.type>mongodb</hono.deviceregistry.type>
     <hono.deviceregistry.image>hono-service-device-registry-mongodb</hono.deviceregistry.image>
     <hono.deviceregistry.resources.folder>deviceregistry-mongodb</hono.deviceregistry.resources.folder>
     <!-- default memory limit of the device registry container is 400MB -->
@@ -493,11 +490,10 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
       <properties>
         <hono.mongodb.disabled>true</hono.mongodb.disabled>
         <hono.postgres.disabled>true</hono.postgres.disabled>
+        <hono.deviceregistry.type>file</hono.deviceregistry.type>
         <hono.deviceregistry.image>hono-service-device-registry-jdbc</hono.deviceregistry.image>
         <hono.deviceregistry.resources.folder>deviceregistry-jdbc-h2</hono.deviceregistry.resources.folder>
         <hono.deviceregistry.spring.profiles>registry-adapter,registry-management,tenant-service,create-schema,${logging.profile}</hono.deviceregistry.spring.profiles>
-        <hono.deviceregistry.supportsSearchDevices>false</hono.deviceregistry.supportsSearchDevices>
-        <hono.deviceregistry.supportsSearchTenants>false</hono.deviceregistry.supportsSearchTenants>
         <!-- increase memory limit of the device registry container to 400MB in order to accommodate for embedded H2 DB -->
         <hono.deviceregistry.containerMemoryLimit>400000000</hono.deviceregistry.containerMemoryLimit>
         <hono.jdbc.db.url>jdbc:h2:file://var/tmp/hono</hono.jdbc.db.url>
@@ -514,11 +510,10 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
       <properties>
         <hono.mongodb.disabled>true</hono.mongodb.disabled>
         <hono.postgres.disabled>false</hono.postgres.disabled>
+        <hono.deviceregistry.type>jdbc</hono.deviceregistry.type>
         <hono.deviceregistry.image>hono-service-device-registry-jdbc</hono.deviceregistry.image>
         <hono.deviceregistry.resources.folder>deviceregistry-jdbc-postgres</hono.deviceregistry.resources.folder>
         <hono.deviceregistry.spring.profiles>registry-adapter,registry-management,tenant-service,create-schema,${logging.profile}</hono.deviceregistry.spring.profiles>
-        <hono.deviceregistry.supportsSearchDevices>false</hono.deviceregistry.supportsSearchDevices>
-        <hono.deviceregistry.supportsSearchTenants>false</hono.deviceregistry.supportsSearchTenants>
         <hono.jdbc.db.url>jdbc:postgresql://hono-jdbc-db:5432/</hono.jdbc.db.url>
         <hono.jdbc.db.admin.username>postgres</hono.jdbc.db.admin.username>
         <hono.jdbc.db.admin.password>change-me</hono.jdbc.db.admin.password>
@@ -1712,14 +1707,12 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                 <deviceconnection.amqp.port>${deviceconnection.amqp.port}</deviceconnection.amqp.port>
                 <commandrouter.host>${commandrouter.ip}</commandrouter.host>
                 <commandrouter.amqp.port>${commandrouter.amqp.port}</commandrouter.amqp.port>
+                <deviceregistry.type>${hono.deviceregistry.type}</deviceregistry.type>
                 <deviceregistry.host>${deviceregistry.ip}</deviceregistry.host>
                 <deviceregistry.amqp.port>${deviceregistry.amqp.port}</deviceregistry.amqp.port>
                 <deviceregistry.http.port>${deviceregistry.http.port}</deviceregistry.http.port>
                 <deviceregistry.http.authConfig.username>${hono.deviceregistry.http.authConfig.username}</deviceregistry.http.authConfig.username>
                 <deviceregistry.http.authConfig.password>${hono.deviceregistry.http.authConfig.password}</deviceregistry.http.authConfig.password>
-                <deviceregistry.supportsGatewayMode>${hono.deviceregistry.supportsGatewayMode}</deviceregistry.supportsGatewayMode>
-                <deviceregistry.supportsSearchDevices>${hono.deviceregistry.supportsSearchDevices}</deviceregistry.supportsSearchDevices>
-                <deviceregistry.supportsSearchTenants>${hono.deviceregistry.supportsSearchTenants}</deviceregistry.supportsSearchTenants>
                 <adapter.coap.host>${coap.ip}</adapter.coap.host>
                 <adapter.coap.port>${coap.port}</adapter.coap.port>
                 <adapter.coaps.port>${coaps.port}</adapter.coaps.port>

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -7,11 +7,14 @@ This module contains integration tests for Hono. The tests are executed against 
 In order to run the tests you will need the following:
 
 * a working *Docker Engine* installation (either local or on a separate host)
-* the Docker images of the Hono components. See the [Developer Guide on the project web site](https://www.eclipse.org/hono/docs/dev-guide/building_hono/) for instructions on building the Docker images.
+* the Docker images of the Hono components. See the
+  [Developer Guide on the project web site](https://www.eclipse.org/hono/docs/dev-guide/building_hono/) for
+  instructions on building the Docker images.
 
 ## Running the Tests
 
-Run the tests by executing the following command from the `tests` directory (add `-Ddocker.host=tcp://${host}:${port}` if Docker is not installed locally)
+Run the tests by executing the following command from the `tests` directory (add `-Ddocker.host=tcp://${host}:${port}`
+if Docker is not installed locally)
 
 ```sh
 # in directory: hono/tests/
@@ -20,10 +23,15 @@ mvn verify -Prun-tests
 
 This starts the following Docker containers and runs the test cases against them
 
+* Infinispan server
+* MongoDB server
 * Hono Authentication service
 * Hono Device Registration service
-* ActiveMQ Artemis message broker
-* Qpid Dispatch Router
+* Apache ActiveMQ Artemis message broker
+* Apache Qpid Dispatch Router
+* Apache Zookeeper
+* Apache Kafka
+* Hono Command Router service
 * Hono HTTP adapter
 * Hono MQTT adapter
 * Hono AMQP adapter
@@ -36,7 +44,8 @@ mvn verify -Prun-tests -Dit.test=TelemetryHttpIT
 mvn verify -Prun-tests -Dit.test=TelemetryHttpIT#testUploadUsingQoS1
 ```
 
-The `logging.profile` property with a value of either `prod`, `dev` or `trace` can be used to set the log level in the Hono Docker containers and the integration tests:
+The `logging.profile` property with a value of either `prod`, `dev` or `trace` can be used to set the log level in
+the Hono Docker containers and the integration tests:
 
 ```sh
 mvn verify -Prun-tests -Dlogging.profile=trace
@@ -44,13 +53,15 @@ mvn verify -Prun-tests -Dlogging.profile=trace
 
 ### Running the Tests without starting/stopping the containers
 
-When running the tests with the `docker.keepRunning` property, the Docker containers will not be stopped and removed once the tests are complete:
+When running the tests with the `docker.keepRunning` property, the Docker containers will not be stopped and removed
+once the tests are complete:
 
 ```sh
 mvn verify -Prun-tests -Ddocker.keepRunning
 ```
 
-Subsequent test runs can use the running containers and will thereby finish much faster by adding the `useRunningContainers` profile to the maven command:
+Subsequent test runs can use the running containers and will thereby finish much faster by adding the
+`useRunningContainers` profile to the Maven command:
 
 ```sh
 mvn verify -Prun-tests,useRunningContainers
@@ -64,36 +75,42 @@ In order to stop and remove the Docker containers started by a test run, use:
 mvn verify -PstopContainers
 ```
 
-### Running the Tests with the MongoDB based device registry
+### Running the Tests with the JDBC based device registry using Postgres
 
-By default, the integration tests include the file based device registry. In order to include the MongoDB based device registry instead of the file based counterpart, use the `device-registry-mongodb` maven profile:
+By default, the integration tests are run using the Mongo DB based device registry.
+In order to use the JDBC based device registry with a dedicated Postgres server,
+the `hono.deviceregistry.type` Maven property needs to be set to value `jdbc`:
 
 ```sh
-mvn verify -Prun-tests,device-registry-mongodb
+mvn verify -Prun-tests -Dhono.deviceregistry.type=jdbc
 ```
 
-### Running the Tests with the JDBC based device registry
+### Running the Tests with the JDBC based device registry using embedded H2
 
-By default, the integration tests include the file based device registry. In order to include the JDBC based device registry instead of the file based counterpart, use the `device-registry-jdbc` maven profile:
+By default, the integration tests are run using the Mongo DB based device registry.
+In order to use the JDBC based device registry with an embedded H2 database,
+the `hono.deviceregistry.type` Maven property needs to be set to value `file`:
 
 ```sh
-mvn verify -Prun-tests,device-registry-jdbc
+mvn verify -Prun-tests -Dhono.deviceregistry.type=file
 ```
 
 ### Running the Tests with the Jaeger tracing component
 
-The tests can be run in such a way, that the OpenTracing trace spans created in the Hono components as part of a test run can be inspected later on. The OpenTracing component used for this is Jaeger.
- 
-To include the Jaeger client, build the Hono Docker images using the `jaeger` maven profile:
+The tests can be run in such a way, that the OpenTracing trace spans created in the Hono components
+as part of a test run can be inspected later on. The OpenTracing component used for this is Jaeger.
+
+To include the Jaeger client, build the Hono Docker images using the `jaeger` Maven profile:
 
 ```sh
 # in the "hono" folder containing the source code
 mvn clean install -Pbuild-docker-image,metrics-prometheus,jaeger
 ```
 
-(Add a `-Ddocker.host` property definition if needed, as described in the [Developer Guide](https://www.eclipse.org/hono/docs/dev-guide/building_hono/).)
+(Add a `-Ddocker.host` property definition if needed, as described in the
+[Developer Guide](https://www.eclipse.org/hono/docs/dev-guide/building_hono/).)
 
-Then run the tests using the `jaeger` maven profile:
+Then run the tests using the `jaeger` Maven profile:
 
 ```sh
 # in directory: hono/tests/
@@ -106,13 +123,16 @@ To run a single test instead, use e.g.:
 mvn verify -Prun-tests,jaeger -Ddocker.keepRunning -Dit.test=TelemetryHttpIT#testUploadUsingQoS1
 ```
 
-Note that in order to be able to view the traces after a test run, the `docker.keepRunning` property has to be used as well, as shown above.  
+Note that in order to be able to view the traces after a test run, the `docker.keepRunning` property has
+to be used as well, as shown above.  
 
 The Jaeger UI, showing the traces of the test run, can be accessed at `http://localhost:18080`
 
-if the Docker engine is running on `localhost`, otherwise the appropriate Docker host has to be used in the above URL. To choose a different port for the Jaeger UI, set the `jaeger.query.port` maven property to the desired port when running the tests. 
+if the Docker engine is running on `localhost`, otherwise the appropriate Docker host has to be used in the
+above URL. To choose a different port for the Jaeger UI, set the `jaeger.query.port` Maven property to the
+desired port when running the tests. 
 
-Start subsequent test runs using the running containers with the `useRunningContainers` maven profile, e.g.:
+Start subsequent test runs using the running containers with the `useRunningContainers` Maven profile, e.g.:
 
 ```sh
 mvn verify -Prun-tests,jaeger,useRunningContainers -Dit.test=TelemetryHttpIT#testUploadUsingQoS1
@@ -127,14 +147,8 @@ mvn verify -PstopContainers
 ### Running the Tests with the Quarkus based Components
 
 By default, the integration tests are run using the Spring Boot based Hono components. For some components there are
-Quarkus based alternative implementations. The tests can be run using these Quarkus based components by means of activating
-the `components-quarkus-jvm` maven profile:
-
-```sh
-mvn verify -Prun-tests,components-quarkus-jvm
-```
-
-Note: the profile can also be activated by setting the Maven property *hono.components.type* to value `quarkus-jvm`.
+Quarkus based alternative implementations. The tests can be run using these Quarkus based components by means of
+activating setting the `hono.components.type` Maven property to value `quarkus-jvm`:
 
 ```sh
 mvn verify -Prun-tests -Dhono.components.type=quarkus-jvm
@@ -143,8 +157,8 @@ mvn verify -Prun-tests -Dhono.components.type=quarkus-jvm
 ### Running the Tests with the Command Router using an embedded Cache
 
 The Command Router component by default stores routing information in a dedicated Infinispan server.
-The router can also be configured to instead store the data in an embedded cache by means of activating the `embedded_cache`
-profile:
+The router can also be configured to instead store the data in an embedded cache by means of
+setting the `hono.commandrouting.cache` Maven property to value `embedded`:
 
 ```sh
 mvn verify -Prun-tests -Dhono.commandrouting.cache=embedded
@@ -153,7 +167,8 @@ mvn verify -Prun-tests -Dhono.commandrouting.cache=embedded
 ### Running the Tests with the Device Connection service component
 
 By default, the integration tests are run using the Command Router service component. In order to use the Device
-Connection service component instead, the `device-connection-service` maven profile can be activated:
+Connection service component instead, the `hono.commandrouting.mode` Maven property needs to be set to
+value `dev-con-service`:
 
 ```sh
 mvn verify -Prun-tests -Dhono.commandrouting.mode=dev-con-service
@@ -163,7 +178,8 @@ Note that the Quarkus based component images cannot be used in this case.
 ### Running the Tests with Kafka as the Messaging Infrastructure
 
 By default, the integration tests are run using the AMQP 1.0 based QPid Dispatch Router and ActiveMQ Artemis message
-broker as messaging infrastructure. In order to use a Kafka broker instead, the `kafka` Maven profile can be activated:
+broker as messaging infrastructure. In order to use a Kafka broker instead, the `hono.messaging-infra.type` Maven
+property needs to be set to value `kafka`:
 
 ```sh
 mvn verify -Prun-tests -Dhono.messaging-infra.type=kafka

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceManagementIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceManagementIT.java
@@ -39,7 +39,7 @@ import org.eclipse.hono.util.RegistryManagementConstants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -617,7 +617,9 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
      *      Device Registry Management API - Search Devices</a>
      */
     @Nested
-    @EnabledIfSystemProperty(named = "deviceregistry.supportsSearchDevices", matches = "true")
+    @EnabledIf(
+            value = "org.eclipse.hono.tests.IntegrationTestSupport#isSearchDevicesSupportedByRegistry",
+            disabledReason = "device registry does not support search Devices operation")
     class SearchDevicesIT {
         /**
          * Verifies that a request to search devices fails with a {@value HttpURLConnection#HTTP_NOT_FOUND}

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistrationApiTests.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistrationApiTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,8 +12,6 @@
  */
 
 package org.eclipse.hono.tests.registry;
-
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -67,10 +65,6 @@ abstract class DeviceRegistrationApiTests extends DeviceRegistryTestBase {
      * @return The client.
      */
     protected abstract DeviceRegistrationClient getClient();
-
-    private Boolean isGatewayModeSupported() {
-        return getHelper().isGatewayModeSupported();
-    }
 
     /**
      * Verifies that the registry succeeds a request to assert a device's registration status.
@@ -236,8 +230,6 @@ abstract class DeviceRegistrationApiTests extends DeviceRegistryTestBase {
     @Test
     public void testAssertRegistrationFailsForDisabledGateway(final VertxTestContext ctx) {
 
-        assumeTrue(isGatewayModeSupported());
-
         final String deviceId = getHelper().getRandomDeviceId(tenantId);
         final String gatewayId = getHelper().getRandomDeviceId(tenantId);
 
@@ -266,8 +258,6 @@ abstract class DeviceRegistrationApiTests extends DeviceRegistryTestBase {
     @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
     @Test
     public void testAssertRegistrationFailsForUnauthorizedGateway(final VertxTestContext ctx) {
-
-        assumeTrue(isGatewayModeSupported());
 
         // Prepare the identities to insert
         final String deviceId = getHelper().getRandomDeviceId(tenantId);

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantManagementIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantManagementIT.java
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -621,7 +621,9 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
      *      Device Registry Management API - Search Tenants</a>
      */
     @Nested
-    @EnabledIfSystemProperty(named = "deviceregistry.supportsSearchTenants", matches = "true")
+    @EnabledIf(
+            value = "org.eclipse.hono.tests.IntegrationTestSupport#isSearchTenantsSupportedByRegistry",
+            disabledReason = "device registry does not support search Tenants operation")
     class SearchTenantsIT {
 
         /**


### PR DESCRIPTION
The ITs currently rely on multiple different system properties for
configuring the registry implementation's capabilities.

The capabilities are now determined by means of a single property only.
