### PR TITLE
[#3016] Use newer Micrometer version with memory leak fix

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -48,6 +48,7 @@
     <jjwt.version>0.11.2</jjwt.version>
     <kafka.image.name>confluentinc/cp-kafka:6.2.2</kafka.image.name>
     <logback.version>1.2.9</logback.version>
+    <micrometer.version>1.7.6</micrometer.version>
     <mongodb-image.name>mongo:4.4</mongodb-image.name>
     <mongodb-driver.version>4.3.3</mongodb-driver.version>
     <native.image.name>registry.access.redhat.com/ubi8/ubi-minimal:8.4</native.image.name>
@@ -287,6 +288,19 @@
         <groupId>org.eclipse.californium</groupId>
         <artifactId>scandium</artifactId>
         <version>${californium.version}</version>
+      </dependency>
+
+      <!-- Micrometer -->
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>${micrometer.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-registry-prometheus</artifactId>
+        <version>${micrometer.version}</version>
+        <scope>runtime</scope>
       </dependency>
 
       <!-- Spring -->

--- a/legal/src/main/resources/legal/DEPENDENCIES
+++ b/legal/src/main/resources/legal/DEPENDENCIES
@@ -52,8 +52,8 @@ maven/mavencentral/io.jaegertracing/jaeger-tracerresolver/1.6.0, Apache-2.0, app
 maven/mavencentral/io.jsonwebtoken/jjwt-api/0.11.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.jsonwebtoken/jjwt-impl/0.11.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.jsonwebtoken/jjwt-jackson/0.11.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.micrometer/micrometer-core/1.7.4, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.micrometer/micrometer-registry-prometheus/1.7.4, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.micrometer/micrometer-core/1.7.6, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.micrometer/micrometer-registry-prometheus/1.7.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.netty/netty-buffer/4.1.68.Final, Apache-2.0, approved, CQ21842
 maven/mavencentral/io.netty/netty-codec/4.1.68.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-codec-dns/4.1.68.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926

--- a/legal/src/main/resources/legal/hono-maven.deps
+++ b/legal/src/main/resources/legal/hono-maven.deps
@@ -52,8 +52,8 @@ io.jaegertracing:jaeger-tracerresolver:jar:1.6.0
 io.jsonwebtoken:jjwt-api:jar:0.11.2
 io.jsonwebtoken:jjwt-impl:jar:0.11.2
 io.jsonwebtoken:jjwt-jackson:jar:0.11.2
-io.micrometer:micrometer-core:jar:1.7.4
-io.micrometer:micrometer-registry-prometheus:jar:1.7.4
+io.micrometer:micrometer-core:jar:1.7.6
+io.micrometer:micrometer-registry-prometheus:jar:1.7.6
 io.netty:netty-buffer:jar:4.1.68.Final
 io.netty:netty-codec-dns:jar:4.1.68.Final
 io.netty:netty-codec-haproxy:jar:4.1.68.Final


### PR DESCRIPTION
This is for #3016:
Micrometer 1.7.6 contains a fix regarding a Kafka metrics memory leak.