### PR TITLE
Explicitly register additional security providers

### DIFF
--- a/client-device-connection-infinispan/src/main/resources/META-INF/native-image/org.eclipse.hono/client-device-connection-infinispan/native-image.properties
+++ b/client-device-connection-infinispan/src/main/resources/META-INF/native-image/org.eclipse.hono/client-device-connection-infinispan/native-image.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -8,4 +8,9 @@
 # http://www.eclipse.org/legal/epl-2.0
 #
 # SPDX-License-Identifier: EPL-2.0
-Args = -H:ReflectionConfigurationResources=${.}/reflection-config.json, -H:ResourceConfigurationResources=${.}/resources-config.json
+Args = -H:ReflectionConfigurationResources=${.}/reflection-config.json, \
+  -H:ResourceConfigurationResources=${.}/resources-config.json \
+  -H:AdditionalSecurityProviders=org.wildfly.security.sasl.digest.WildFlyElytronSaslDigestProvider \
+  -H:AdditionalSecurityProviders=org.wildfly.security.sasl.external.WildFlyElytronSaslExternalProvider \
+  -H:AdditionalSecurityProviders=org.wildfly.security.sasl.plain.WildFlyElytronSaslPlainProvider \
+  -H:AdditionalSecurityProviders=org.wildfly.security.sasl.scram.WildFlyElytronSaslScramProvider

--- a/client-device-connection-infinispan/src/main/resources/META-INF/native-image/org.eclipse.hono/client-device-connection-infinispan/reflection-config.json
+++ b/client-device-connection-infinispan/src/main/resources/META-INF/native-image/org.eclipse.hono/client-device-connection-infinispan/reflection-config.json
@@ -1,5 +1,11 @@
 [
   {
+    "name" : "io.netty.channel.socket.nio.NioSocketChannel",
+    "methods": [
+      { "name": "<init>", "parameterTypes": [] }
+    ]
+  },
+  {
     "name" : "org.infinispan.CoreModuleImpl",
     "methods": [
       { "name": "<init>", "parameterTypes": [] }
@@ -171,93 +177,174 @@
     "allPublicFields" : true
   },
   {
+    "name" : "org.wildfly.security.password.impl.DigestPasswordAlgorithmParametersSpiImpl",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "org.wildfly.security.password.impl.IteratedSaltedPasswordAlgorithmParametersSpiImpl",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "org.wildfly.security.password.impl.OneTimePasswordAlgorithmParametersSpiImpl",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "org.wildfly.security.password.impl.SaltedPasswordAlgorithmParametersSpiImpl",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
     "name" : "org.wildfly.security.password.impl.PasswordFactorySpiImpl",
-    "methods": [
-      { "name": "<init>", "parameterTypes": [] }
-    ]
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   },
   {
     "name" : "org.wildfly.security.sasl.digest.DigestClientFactory",
-    "methods": [
-      { "name": "<init>", "parameterTypes": [] }
-    ]
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   },
   {
     "name" : "org.wildfly.security.sasl.digest.WildFlyElytronSaslDigestProvider",
-    "methods": [
-      { "name": "<init>", "parameterTypes": [] }
-    ]
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   },
   {
     "name" : "org.wildfly.security.sasl.external.ExternalSaslClientFactory",
-    "methods": [
-      { "name": "<init>", "parameterTypes": [] }
-    ]
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   },
   {
     "name" : "org.wildfly.security.sasl.external.WildFlyElytronSaslExternalProvider",
-    "methods": [
-      { "name": "<init>", "parameterTypes": [] }
-    ]
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   },
   {
     "name" : "org.wildfly.security.sasl.gs2.Gs2SaslClientFactory",
-    "methods": [
-      { "name": "<init>", "parameterTypes": [] }
-    ]
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   },
   {
     "name" : "org.wildfly.security.sasl.gs2.WildFlyElytronSaslGs2Provider",
-    "methods": [
-      { "name": "<init>", "parameterTypes": [] }
-    ]
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   },
   {
     "name" : "org.wildfly.security.sasl.gssapi.GssapiClientFactory",
-    "methods": [
-      { "name": "<init>", "parameterTypes": [] }
-    ]
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   },
   {
     "name" : "org.wildfly.security.sasl.gssapi.WildFlyElytronSaslGssapiProvider",
-    "methods": [
-      { "name": "<init>", "parameterTypes": [] }
-    ]
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   },
   {
     "name" : "org.wildfly.security.sasl.oauth2.OAuth2SaslClientFactory",
-    "methods": [
-      { "name": "<init>", "parameterTypes": [] }
-    ]
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   },
   {
     "name" : "org.wildfly.security.sasl.oauth2.WildFlyElytronSaslOAuth2Provider",
-    "methods": [
-      { "name": "<init>", "parameterTypes": [] }
-    ]
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   },
   {
     "name" : "org.wildfly.security.sasl.plain.PlainSaslClientFactory",
-    "methods": [
-      { "name": "<init>", "parameterTypes": [] }
-    ]
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   },
   {
     "name" : "org.wildfly.security.sasl.plain.WildFlyElytronSaslPlainProvider",
-    "methods": [
-      { "name": "<init>", "parameterTypes": [] }
-    ]
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   },
   {
     "name" : "org.wildfly.security.sasl.scram.ScramSaslClientFactory",
-    "methods": [
-      { "name": "<init>", "parameterTypes": [] }
-    ]
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   },
   {
     "name" : "org.wildfly.security.sasl.scram.WildFlyElytronSaslScramProvider",
-    "methods": [
-      { "name": "<init>", "parameterTypes": [] }
-    ]
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   }
 ]


### PR DESCRIPTION
The Infinispan client module has been changed to explicitly add the
WildFly security providers required for performing SASL handshakes with
the Infinispan server.

Fixes #3027