### PR TITLE
Add NotificationType class

### DIFF
--- a/clients/notification-amqp/src/main/java/org/eclipse/hono/client/notification/amqp/NotificationAddressHelper.java
+++ b/clients/notification-amqp/src/main/java/org/eclipse/hono/client/notification/amqp/NotificationAddressHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,20 +15,12 @@ package org.eclipse.hono.client.notification.amqp;
 
 import org.eclipse.hono.notification.AbstractNotification;
 import org.eclipse.hono.notification.NotificationConstants;
-import org.eclipse.hono.notification.deviceregistry.AllDevicesOfTenantDeletedNotification;
-import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
-import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
-import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
+import org.eclipse.hono.notification.NotificationType;
 
 /**
  * Utility methods to determine the AMQP address for a given type of notification.
  */
 public final class NotificationAddressHelper {
-
-    private static final String TENANT_CHANGE_ADDRESS = addNotificationEndpointPrefix(TenantChangeNotification.ADDRESS);
-    private static final String DEVICE_CHANGE_ADDRESS = addNotificationEndpointPrefix(DeviceChangeNotification.ADDRESS);
-    private static final String CREDENTIALS_CHANGE_ADDRESS = addNotificationEndpointPrefix(CredentialsChangeNotification.ADDRESS);
-    private static final String ALL_DEVICES_OF_TENANT_CHANGE_ADDRESS = addNotificationEndpointPrefix(AllDevicesOfTenantDeletedNotification.ADDRESS);
 
     private NotificationAddressHelper() {
         // prevent instantiation
@@ -40,25 +32,9 @@ public final class NotificationAddressHelper {
      * @param notificationType The class of the notifications.
      * @param <T> The type of notifications.
      * @return The address.
-     * @throws IllegalArgumentException If the given type is not a known subclass of {@link AbstractNotification}.
      */
-    public static <T extends AbstractNotification> String getAddress(final Class<T> notificationType) {
-        final String address;
-        if (TenantChangeNotification.class.equals(notificationType)) {
-            address = TENANT_CHANGE_ADDRESS;
-        } else if (DeviceChangeNotification.class.equals(notificationType)) {
-            address = DEVICE_CHANGE_ADDRESS;
-        } else if (CredentialsChangeNotification.class.equals(notificationType)) {
-            address = CREDENTIALS_CHANGE_ADDRESS;
-        } else if (AllDevicesOfTenantDeletedNotification.class.equals(notificationType)) {
-            address = ALL_DEVICES_OF_TENANT_CHANGE_ADDRESS;
-        } else {
-            throw new IllegalArgumentException("Unknown notification type " + notificationType.getName());
-        }
-        return address;
+    public static <T extends AbstractNotification> String getAddress(final NotificationType<T> notificationType) {
+        return NotificationConstants.NOTIFICATION_ENDPOINT + "/" + notificationType.getAddress();
     }
 
-    private static String addNotificationEndpointPrefix(final String address) {
-        return NotificationConstants.NOTIFICATION_ENDPOINT + "/" + address;
-    }
 }

--- a/clients/notification-amqp/src/main/java/org/eclipse/hono/client/notification/amqp/ProtonBasedNotificationSender.java
+++ b/clients/notification-amqp/src/main/java/org/eclipse/hono/client/notification/amqp/ProtonBasedNotificationSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -46,7 +46,7 @@ public class ProtonBasedNotificationSender extends SenderCachingServiceClient im
     @Override
     public Future<Void> publish(final AbstractNotification notification) {
         Objects.requireNonNull(notification);
-        return getOrCreateSenderLink(NotificationAddressHelper.getAddress(notification.getClass()))
+        return getOrCreateSenderLink(NotificationAddressHelper.getAddress(notification.getType()))
                 .compose(sender -> sender.sendAndWaitForOutcome(createMessage(notification), NoopSpan.INSTANCE)
                         .onFailure(thr -> log.debug("error sending notification [{}]", notification, thr)))
                 .mapEmpty();
@@ -56,7 +56,7 @@ public class ProtonBasedNotificationSender extends SenderCachingServiceClient im
         final Message msg = ProtonHelper.message();
         final JsonObject value = JsonObject.mapFrom(notification);
         MessageHelper.setJsonPayload(msg, value);
-        msg.setAddress(NotificationAddressHelper.getAddress(notification.getClass()));
+        msg.setAddress(NotificationAddressHelper.getAddress(notification.getType()));
         return msg;
     }
 

--- a/clients/notification-amqp/src/test/java/org/eclipse/hono/client/notification/amqp/ProtonBasedNotificationReceiverTest.java
+++ b/clients/notification-amqp/src/test/java/org/eclipse/hono/client/notification/amqp/ProtonBasedNotificationReceiverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -110,7 +110,7 @@ public class ProtonBasedNotificationReceiverTest {
 
         // GIVEN a client where a TenantChangeNotification consumer gets registered
         final AtomicReference<TenantChangeNotification> receivedNotificationRef = new AtomicReference<>();
-        client.registerConsumer(TenantChangeNotification.class, receivedNotificationRef::set);
+        client.registerConsumer(TenantChangeNotification.TYPE, receivedNotificationRef::set);
 
         // WHEN starting the client
         client.start()
@@ -163,25 +163,25 @@ public class ProtonBasedNotificationReceiverTest {
 
         final Checkpoint handlerInvokedCheckpoint = ctx.checkpoint(4);
 
-        client.registerConsumer(TenantChangeNotification.class,
+        client.registerConsumer(TenantChangeNotification.TYPE,
                 notification -> ctx.verify(() -> {
                     assertThat(notification).isInstanceOf(TenantChangeNotification.class);
                     handlerInvokedCheckpoint.flag();
                 }));
 
-        client.registerConsumer(DeviceChangeNotification.class,
+        client.registerConsumer(DeviceChangeNotification.TYPE,
                 notification -> ctx.verify(() -> {
                     assertThat(notification).isInstanceOf(DeviceChangeNotification.class);
                     handlerInvokedCheckpoint.flag();
                 }));
 
-        client.registerConsumer(CredentialsChangeNotification.class,
+        client.registerConsumer(CredentialsChangeNotification.TYPE,
                 notification -> ctx.verify(() -> {
                     assertThat(notification).isInstanceOf(CredentialsChangeNotification.class);
                     handlerInvokedCheckpoint.flag();
                 }));
 
-        client.registerConsumer(AllDevicesOfTenantDeletedNotification.class,
+        client.registerConsumer(AllDevicesOfTenantDeletedNotification.TYPE,
                 notification -> ctx.verify(() -> {
                     assertThat(notification).isInstanceOf(AllDevicesOfTenantDeletedNotification.class);
                     handlerInvokedCheckpoint.flag();
@@ -194,22 +194,22 @@ public class ProtonBasedNotificationReceiverTest {
                     final Map<String, ProtonMessageHandler> receiverMsgHandlersPerAddress = assertReceiverLinkCreated(connection);
 
                     assertThat(receiverMsgHandlersPerAddress)
-                            .containsKey(NotificationAddressHelper.getAddress(TenantChangeNotification.class));
+                            .containsKey(NotificationAddressHelper.getAddress(TenantChangeNotification.TYPE));
                     assertThat(receiverMsgHandlersPerAddress)
-                            .containsKey(NotificationAddressHelper.getAddress(DeviceChangeNotification.class));
+                            .containsKey(NotificationAddressHelper.getAddress(DeviceChangeNotification.TYPE));
                     assertThat(receiverMsgHandlersPerAddress)
-                            .containsKey(NotificationAddressHelper.getAddress(CredentialsChangeNotification.class));
+                            .containsKey(NotificationAddressHelper.getAddress(CredentialsChangeNotification.TYPE));
                     assertThat(receiverMsgHandlersPerAddress)
-                            .containsKey(NotificationAddressHelper.getAddress(AllDevicesOfTenantDeletedNotification.class));
+                            .containsKey(NotificationAddressHelper.getAddress(AllDevicesOfTenantDeletedNotification.TYPE));
 
                     final ProtonMessageHandler tenantChangeReceiverMsgHandler = receiverMsgHandlersPerAddress
-                            .get(NotificationAddressHelper.getAddress(TenantChangeNotification.class));
+                            .get(NotificationAddressHelper.getAddress(TenantChangeNotification.TYPE));
                     final ProtonMessageHandler deviceChangeReceiverMsgHandler = receiverMsgHandlersPerAddress
-                            .get(NotificationAddressHelper.getAddress(DeviceChangeNotification.class));
+                            .get(NotificationAddressHelper.getAddress(DeviceChangeNotification.TYPE));
                     final ProtonMessageHandler credentialsChangeReceiverMsgHandler = receiverMsgHandlersPerAddress
-                            .get(NotificationAddressHelper.getAddress(CredentialsChangeNotification.class));
+                            .get(NotificationAddressHelper.getAddress(CredentialsChangeNotification.TYPE));
                     final ProtonMessageHandler allDevicesOfTenantDeletedChangeReceiverMsgHandler = receiverMsgHandlersPerAddress
-                            .get(NotificationAddressHelper.getAddress(AllDevicesOfTenantDeletedNotification.class));
+                            .get(NotificationAddressHelper.getAddress(AllDevicesOfTenantDeletedNotification.TYPE));
                     // and sending notifications on the links
                     tenantChangeReceiverMsgHandler.handle(mock(ProtonDelivery.class), tenantChangeNotificationMsg);
                     deviceChangeReceiverMsgHandler.handle(mock(ProtonDelivery.class), deviceChangeNotificationMsg);

--- a/clients/notification-amqp/src/test/java/org/eclipse/hono/client/notification/amqp/ProtonBasedNotificationSenderTest.java
+++ b/clients/notification-amqp/src/test/java/org/eclipse/hono/client/notification/amqp/ProtonBasedNotificationSenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -122,7 +122,7 @@ public class ProtonBasedNotificationSenderTest {
 
         // VERIFY that the message is as expected
         final Message message = messageCaptor.getValue();
-        assertThat(message.getAddress()).isEqualTo(NotificationAddressHelper.getAddress(notification.getClass()));
+        assertThat(message.getAddress()).isEqualTo(NotificationAddressHelper.getAddress(notification.getType()));
         assertThat(message.getContentType()).isEqualTo(NotificationConstants.CONTENT_TYPE);
         final AbstractNotification decodedNotification = Json.decodeValue(MessageHelper.getPayload(message),
                 AbstractNotification.class);

--- a/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/kafka/KafkaBasedNotificationReceiver.java
+++ b/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/kafka/KafkaBasedNotificationReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -26,6 +26,7 @@ import org.eclipse.hono.client.kafka.KafkaClientFactory;
 import org.eclipse.hono.client.kafka.consumer.HonoKafkaConsumer;
 import org.eclipse.hono.notification.AbstractNotification;
 import org.eclipse.hono.notification.NotificationReceiver;
+import org.eclipse.hono.notification.NotificationType;
 
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -91,7 +92,7 @@ public class KafkaBasedNotificationReceiver implements NotificationReceiver {
     }
 
     @Override
-    public <T extends AbstractNotification> void registerConsumer(final Class<T> notificationType,
+    public <T extends AbstractNotification> void registerConsumer(final NotificationType<T> notificationType,
             final Handler<T> consumer) {
 
         if (started) {
@@ -99,7 +100,7 @@ public class KafkaBasedNotificationReceiver implements NotificationReceiver {
         }
 
         topics.add(NotificationTopicHelper.getTopicName(notificationType));
-        handlerPerType.put(notificationType, consumer);
+        handlerPerType.put(notificationType.getClazz(), consumer);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/kafka/NotificationTopicHelper.java
+++ b/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/kafka/NotificationTopicHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,20 +15,12 @@ package org.eclipse.hono.client.notification.kafka;
 
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.notification.AbstractNotification;
-import org.eclipse.hono.notification.deviceregistry.AllDevicesOfTenantDeletedNotification;
-import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
-import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
-import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
+import org.eclipse.hono.notification.NotificationType;
 
 /**
  * Utility methods to determine the Kafka topic for a given type of notification.
  */
 public final class NotificationTopicHelper {
-
-    private static final String TENANT_CHANGE_TOPIC = getTopicNameForAddress(TenantChangeNotification.ADDRESS);
-    private static final String DEVICE_CHANGE_TOPIC = getTopicNameForAddress(DeviceChangeNotification.ADDRESS);
-    private static final String CREDENTIALS_CHANGE_TOPIC = getTopicNameForAddress(CredentialsChangeNotification.ADDRESS);
-    private static final String ALL_DEVICES_OF_TENANT_CHANGE_TOPIC = getTopicNameForAddress(AllDevicesOfTenantDeletedNotification.ADDRESS);
 
     private NotificationTopicHelper() {
         // prevent instantiation
@@ -40,25 +32,9 @@ public final class NotificationTopicHelper {
      * @param notificationType The class of the notification.
      * @param <T> The type of notification.
      * @return The topic name.
-     * @throws IllegalArgumentException If the given type is not a known subclass of {@link AbstractNotification}.
      */
-    public static <T extends AbstractNotification> String getTopicName(final Class<T> notificationType) {
-        final String topic;
-        if (TenantChangeNotification.class.equals(notificationType)) {
-            topic = TENANT_CHANGE_TOPIC;
-        } else if (DeviceChangeNotification.class.equals(notificationType)) {
-            topic = DEVICE_CHANGE_TOPIC;
-        } else if (CredentialsChangeNotification.class.equals(notificationType)) {
-            topic = CREDENTIALS_CHANGE_TOPIC;
-        } else if (AllDevicesOfTenantDeletedNotification.class.equals(notificationType)) {
-            topic = ALL_DEVICES_OF_TENANT_CHANGE_TOPIC;
-        } else {
-            throw new IllegalArgumentException("Unknown notification type " + notificationType.getName());
-        }
-        return topic;
+    public static <T extends AbstractNotification> String getTopicName(final NotificationType<T> notificationType) {
+        return new HonoTopic(HonoTopic.Type.NOTIFICATION, notificationType.getAddress()).toString();
     }
 
-    private static String getTopicNameForAddress(final String address) {
-        return new HonoTopic(HonoTopic.Type.NOTIFICATION, address).toString();
-    }
 }

--- a/clients/notification-kafka/src/test/java/org/eclipse/hono/client/notification/kafka/KafkaBasedNotificationReceiverTest.java
+++ b/clients/notification-kafka/src/test/java/org/eclipse/hono/client/notification/kafka/KafkaBasedNotificationReceiverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -83,7 +83,7 @@ public class KafkaBasedNotificationReceiverTest {
 
         final var receiver = createReceiver();
 
-        receiver.registerConsumer(TenantChangeNotification.class, notification -> {
+        receiver.registerConsumer(TenantChangeNotification.TYPE, notification -> {
                 });
 
         receiver.start()
@@ -91,7 +91,7 @@ public class KafkaBasedNotificationReceiverTest {
                     final Set<String> subscription = mockConsumer.subscription();
                     assertThat(subscription).isNotNull();
                     assertThat(subscription)
-                            .contains(NotificationTopicHelper.getTopicName(TenantChangeNotification.class));
+                            .contains(NotificationTopicHelper.getTopicName(TenantChangeNotification.TYPE));
                     assertThat(mockConsumer.closed()).isFalse();
                     ctx.completeNow();
                 })));
@@ -107,7 +107,7 @@ public class KafkaBasedNotificationReceiverTest {
 
         final var receiver = createReceiver();
 
-        receiver.registerConsumer(TenantChangeNotification.class, notification -> {
+        receiver.registerConsumer(TenantChangeNotification.TYPE, notification -> {
         });
 
         receiver.start()
@@ -148,25 +148,25 @@ public class KafkaBasedNotificationReceiverTest {
 
         final Checkpoint handlerInvokedCheckpoint = ctx.checkpoint(4);
 
-        receiver.registerConsumer(TenantChangeNotification.class,
+        receiver.registerConsumer(TenantChangeNotification.TYPE,
                 notification -> ctx.verify(() -> {
                     assertThat(notification).isInstanceOf(TenantChangeNotification.class);
                     handlerInvokedCheckpoint.flag();
                 }));
 
-        receiver.registerConsumer(DeviceChangeNotification.class,
+        receiver.registerConsumer(DeviceChangeNotification.TYPE,
                 notification -> ctx.verify(() -> {
                     assertThat(notification).isInstanceOf(DeviceChangeNotification.class);
                     handlerInvokedCheckpoint.flag();
                 }));
 
-        receiver.registerConsumer(CredentialsChangeNotification.class,
+        receiver.registerConsumer(CredentialsChangeNotification.TYPE,
                 notification -> ctx.verify(() -> {
                     assertThat(notification).isInstanceOf(CredentialsChangeNotification.class);
                     handlerInvokedCheckpoint.flag();
                 }));
 
-        receiver.registerConsumer(AllDevicesOfTenantDeletedNotification.class,
+        receiver.registerConsumer(AllDevicesOfTenantDeletedNotification.TYPE,
                 notification -> ctx.verify(() -> {
                     assertThat(notification).isInstanceOf(AllDevicesOfTenantDeletedNotification.class);
                     handlerInvokedCheckpoint.flag();
@@ -179,9 +179,9 @@ public class KafkaBasedNotificationReceiverTest {
     private KafkaBasedNotificationReceiver createReceiver() {
 
         final TopicPartition tenantTopicPartition = new TopicPartition(
-                NotificationTopicHelper.getTopicName(TenantChangeNotification.class), 0);
+                NotificationTopicHelper.getTopicName(TenantChangeNotification.TYPE), 0);
         final TopicPartition deviceTopicPartition = new TopicPartition(
-                NotificationTopicHelper.getTopicName(DeviceChangeNotification.class), 0);
+                NotificationTopicHelper.getTopicName(DeviceChangeNotification.TYPE), 0);
 
         mockConsumer.updateBeginningOffsets(Map.of(tenantTopicPartition, 0L, deviceTopicPartition, 0L));
         mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(tenantTopicPartition, deviceTopicPartition));
@@ -195,7 +195,7 @@ public class KafkaBasedNotificationReceiverTest {
     private ConsumerRecord<String, Buffer> createKafkaRecord(final AbstractNotification notification,
             final long offset) {
         final Buffer json = JsonObject.mapFrom(notification).toBuffer();
-        final String topicName = NotificationTopicHelper.getTopicName(notification.getClass());
+        final String topicName = NotificationTopicHelper.getTopicName(notification.getType());
         return new ConsumerRecord<>(topicName, 0, offset, null, json);
     }
 

--- a/clients/notification-kafka/src/test/java/org/eclipse/hono/client/notification/kafka/KafkaBasedNotificationSenderTest.java
+++ b/clients/notification-kafka/src/test/java/org/eclipse/hono/client/notification/kafka/KafkaBasedNotificationSenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -154,10 +154,10 @@ public class KafkaBasedNotificationSenderTest {
                         final ProducerRecord<String, JsonObject> record = mockProducer.history().get(0);
 
                         assertThat(record.topic())
-                                .isEqualTo(NotificationTopicHelper.getTopicName(notificationToSend.getClass()));
+                                .isEqualTo(NotificationTopicHelper.getTopicName(notificationToSend.getType()));
                         assertThat(record.key()).isEqualTo(expectedRecordKey);
                         assertThat(record.value().getString(NotificationConstants.JSON_FIELD_TYPE))
-                                .isEqualTo(notificationToSend.getType());
+                                .isEqualTo(notificationToSend.getType().getTypeName());
                     });
                     ctx.completeNow();
                 }));

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/AbstractNotification.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/AbstractNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -52,10 +52,22 @@ public abstract class AbstractNotification {
 
     /**
      * Gets the type of the notification.
+     * <p>
+     * Note for implementing classes: The generic type of the returned {@code NotificationType} has to be the class of
+     * the object, this method is invoked on.
      *
-     * @return The type name.
+     * @return The type.
      */
-    public abstract String getType();
+    public abstract NotificationType<? extends AbstractNotification> getType();
+
+    /**
+     * Gets the key identifier of this notification, referring to the resource that this notification is about.
+     * <p>
+     * E.g. for a TenantChangeNotification the key would be the tenant identifier.
+     *
+     * @return The key.
+     */
+    public abstract String getKey();
 
     /**
      * Gets the canonical name of the component that publishes the notification.

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/NoOpNotificationReceiver.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/NoOpNotificationReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,7 +22,7 @@ import io.vertx.core.Handler;
 public final class NoOpNotificationReceiver implements NotificationReceiver {
 
     @Override
-    public <T extends AbstractNotification> void registerConsumer(final Class<T> notificationType,
+    public <T extends AbstractNotification> void registerConsumer(final NotificationType<T> notificationType,
             final Handler<T> consumer) {
 
     }

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationReceiver.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -33,5 +33,5 @@ public interface NotificationReceiver extends Lifecycle {
      * @param <T> The type of notifications to consume.
      * @throws IllegalStateException If invoked after the {@link #start()} method was called.
      */
-    <T extends AbstractNotification> void registerConsumer(Class<T> notificationType, Handler<T> consumer);
+    <T extends AbstractNotification> void registerConsumer(NotificationType<T> notificationType, Handler<T> consumer);
 }

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationType.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationType.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification;
+
+import java.util.Objects;
+
+/**
+ * The type of an {@link AbstractNotification}.
+ *
+ * @param <T> The {@link AbstractNotification} class.
+ */
+public final class NotificationType<T extends AbstractNotification> {
+
+    private final String typeName;
+    private final Class<T> clazz;
+    private final String address;
+
+    /**
+     * Creates a new NotificationType.
+     *
+     * @param typeName The name of this type.
+     * @param clazz The class of notifications having this type.
+     * @param address The (significant part of the) address used when sending notifications of this type.
+     * @throws NullPointerException If any of the parameters is {@code null}.
+     */
+    public NotificationType(final String typeName, final Class<T> clazz, final String address) {
+        this.typeName = Objects.requireNonNull(typeName);
+        this.clazz = Objects.requireNonNull(clazz);
+        this.address = Objects.requireNonNull(address);
+    }
+
+    /**
+     * The name of this type. The name is unique to this notification type.
+     *
+     * @return The type name.
+     */
+    public String getTypeName() {
+        return typeName;
+    }
+
+    /**
+     * The class of notifications of this type.
+     *
+     * @return The class.
+     */
+    public Class<T> getClazz() {
+        return clazz;
+    }
+
+    /**
+     * The address used when sending notifications of this type.
+     * <p>
+     * Note that this address may not be unique to this notification type.
+     *
+     * @return The address.
+     */
+    public String getAddress() {
+        return address;
+    }
+
+}

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationTypeResolver.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationTypeResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,6 +12,8 @@
  *******************************************************************************/
 
 package org.eclipse.hono.notification;
+
+import java.util.List;
 
 import org.eclipse.hono.notification.deviceregistry.AllDevicesOfTenantDeletedNotification;
 import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
@@ -30,6 +32,12 @@ import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
  * {@link CredentialsChangeNotification} and {@link AllDevicesOfTenantDeletedNotification}.
  */
 public final class NotificationTypeResolver extends TypeIdResolverBase {
+
+    private static final List<NotificationType<?>> SUPPORTED_TYPES = List.of(
+            TenantChangeNotification.TYPE,
+            DeviceChangeNotification.TYPE,
+            CredentialsChangeNotification.TYPE,
+            AllDevicesOfTenantDeletedNotification.TYPE);
 
     private JavaType baseType;
 
@@ -59,24 +67,18 @@ public final class NotificationTypeResolver extends TypeIdResolverBase {
     public String idFromValueAndType(final Object obj, final Class<?> subType) {
 
         if (obj instanceof AbstractNotification) {
-            return ((AbstractNotification) obj).getType();
+            return ((AbstractNotification) obj).getType().getTypeName();
         }
         return null;
     }
 
     @Override
     public JavaType typeFromId(final DatabindContext context, final String id) {
-        switch (id) {
-        case TenantChangeNotification.TYPE:
-            return context.constructSpecializedType(this.baseType, TenantChangeNotification.class);
-        case DeviceChangeNotification.TYPE:
-            return context.constructSpecializedType(this.baseType, DeviceChangeNotification.class);
-        case CredentialsChangeNotification.TYPE:
-            return context.constructSpecializedType(this.baseType, CredentialsChangeNotification.class);
-        case AllDevicesOfTenantDeletedNotification.TYPE:
-            return context.constructSpecializedType(this.baseType, AllDevicesOfTenantDeletedNotification.class);
-        default:
-            return null;
+        for (final NotificationType<?> type : SUPPORTED_TYPES) {
+            if (type.getTypeName().equals(id)) {
+                return context.constructSpecializedType(this.baseType, type.getClazz());
+            }
         }
+        return null;
     }
 }

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/AllDevicesOfTenantDeletedNotification.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/AllDevicesOfTenantDeletedNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,6 +19,7 @@ import java.util.Objects;
 import org.eclipse.hono.annotation.HonoTimestamp;
 import org.eclipse.hono.notification.AbstractNotification;
 import org.eclipse.hono.notification.NotificationConstants;
+import org.eclipse.hono.notification.NotificationType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -29,10 +30,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Notification that informs that all devices of a tenant have been deleted.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class AllDevicesOfTenantDeletedNotification extends AbstractNotification {
+public final class AllDevicesOfTenantDeletedNotification extends AbstractNotification {
 
-    public static final String TYPE = "all-devices-of-tenant-deleted-v1";
+    public static final String TYPE_NAME = "all-devices-of-tenant-deleted-v1";
     public static final String ADDRESS = DeviceChangeNotification.ADDRESS;
+    public static final NotificationType<AllDevicesOfTenantDeletedNotification> TYPE = new NotificationType<>(
+            TYPE_NAME,
+            AllDevicesOfTenantDeletedNotification.class,
+            ADDRESS);
 
     private final String tenantId;
 
@@ -68,14 +73,20 @@ public class AllDevicesOfTenantDeletedNotification extends AbstractNotification 
      * @return The tenant ID.
      */
     @JsonProperty(value = NotificationConstants.JSON_FIELD_TENANT_ID)
-    public final String getTenantId() {
+    public String getTenantId() {
         return tenantId;
     }
 
     @Override
     @JsonIgnore
-    public final String getType() {
+    public NotificationType<AllDevicesOfTenantDeletedNotification> getType() {
         return TYPE;
+    }
+
+    @Override
+    @JsonIgnore
+    public String getKey() {
+        return getTenantId();
     }
 
     @Override

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/CredentialsChangeNotification.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/CredentialsChangeNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,6 +19,7 @@ import java.util.Objects;
 import org.eclipse.hono.annotation.HonoTimestamp;
 import org.eclipse.hono.notification.AbstractNotification;
 import org.eclipse.hono.notification.NotificationConstants;
+import org.eclipse.hono.notification.NotificationType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -34,10 +35,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * enforce re-authentication.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class CredentialsChangeNotification extends AbstractNotification {
+public final class CredentialsChangeNotification extends AbstractNotification {
 
-    public static final String TYPE = "credentials-change-v1";
+    public static final String TYPE_NAME = "credentials-change-v1";
     public static final String ADDRESS = DeviceChangeNotification.ADDRESS;
+    public static final NotificationType<CredentialsChangeNotification> TYPE = new NotificationType<>(
+            TYPE_NAME,
+            CredentialsChangeNotification.class,
+            ADDRESS);
 
     private final String tenantId;
     private final String deviceId;
@@ -78,7 +83,7 @@ public class CredentialsChangeNotification extends AbstractNotification {
      * @return The tenant ID.
      */
     @JsonProperty(value = NotificationConstants.JSON_FIELD_TENANT_ID)
-    public final String getTenantId() {
+    public String getTenantId() {
         return tenantId;
     }
 
@@ -88,14 +93,20 @@ public class CredentialsChangeNotification extends AbstractNotification {
      * @return The device ID.
      */
     @JsonProperty(value = NotificationConstants.JSON_FIELD_DEVICE_ID)
-    public final String getDeviceId() {
+    public String getDeviceId() {
         return deviceId;
     }
 
     @Override
     @JsonIgnore
-    public final String getType() {
+    public NotificationType<CredentialsChangeNotification> getType() {
         return TYPE;
+    }
+
+    @Override
+    @JsonIgnore
+    public String getKey() {
+        return getDeviceId();
     }
 
     @Override

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/DeviceChangeNotification.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/DeviceChangeNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,6 +19,7 @@ import java.util.Objects;
 import org.eclipse.hono.annotation.HonoTimestamp;
 import org.eclipse.hono.notification.AbstractNotification;
 import org.eclipse.hono.notification.NotificationConstants;
+import org.eclipse.hono.notification.NotificationType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -29,10 +30,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Notification that informs about changes on a device.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class DeviceChangeNotification extends AbstractNotification {
+public final class DeviceChangeNotification extends AbstractNotification {
 
-    public static final String TYPE = "device-change-v1";
+    public static final String TYPE_NAME = "device-change-v1";
     public static final String ADDRESS = "registry-device";
+    public static final NotificationType<DeviceChangeNotification> TYPE = new NotificationType<>(
+            TYPE_NAME,
+            DeviceChangeNotification.class,
+            ADDRESS);
 
     private final LifecycleChange change;
     private final String tenantId;
@@ -88,7 +93,7 @@ public class DeviceChangeNotification extends AbstractNotification {
      * @return The change.
      */
     @JsonProperty(value = NotificationConstants.JSON_FIELD_DATA_CHANGE)
-    public final LifecycleChange getChange() {
+    public LifecycleChange getChange() {
         return change;
     }
 
@@ -98,7 +103,7 @@ public class DeviceChangeNotification extends AbstractNotification {
      * @return The tenant ID.
      */
     @JsonProperty(value = NotificationConstants.JSON_FIELD_TENANT_ID)
-    public final String getTenantId() {
+    public String getTenantId() {
         return tenantId;
     }
 
@@ -108,7 +113,7 @@ public class DeviceChangeNotification extends AbstractNotification {
      * @return The device ID.
      */
     @JsonProperty(value = NotificationConstants.JSON_FIELD_DEVICE_ID)
-    public final String getDeviceId() {
+    public String getDeviceId() {
         return deviceId;
     }
 
@@ -118,14 +123,20 @@ public class DeviceChangeNotification extends AbstractNotification {
      * @return {@code true} if this device is enabled.
      */
     @JsonProperty(value = NotificationConstants.JSON_FIELD_DATA_ENABLED)
-    public final boolean isEnabled() {
+    public boolean isEnabled() {
         return enabled;
     }
 
     @Override
     @JsonIgnore
-    public final String getType() {
+    public NotificationType<DeviceChangeNotification> getType() {
         return TYPE;
+    }
+
+    @Override
+    @JsonIgnore
+    public String getKey() {
+        return getDeviceId();
     }
 
     @Override

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/TenantChangeNotification.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/TenantChangeNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,6 +19,7 @@ import java.util.Objects;
 import org.eclipse.hono.annotation.HonoTimestamp;
 import org.eclipse.hono.notification.AbstractNotification;
 import org.eclipse.hono.notification.NotificationConstants;
+import org.eclipse.hono.notification.NotificationType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -29,10 +30,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Notification that informs about changes on a tenant.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class TenantChangeNotification extends AbstractNotification {
+public final class TenantChangeNotification extends AbstractNotification {
 
-    public static final String TYPE = "tenant-change-v1";
+    public static final String TYPE_NAME = "tenant-change-v1";
     public static final String ADDRESS = "registry-tenant";
+    public static final NotificationType<TenantChangeNotification> TYPE = new NotificationType<>(
+            TYPE_NAME,
+            TenantChangeNotification.class,
+            ADDRESS);
 
     private final LifecycleChange change;
     private final String tenantId;
@@ -79,7 +84,7 @@ public class TenantChangeNotification extends AbstractNotification {
      * @return The change.
      */
     @JsonProperty(value = NotificationConstants.JSON_FIELD_DATA_CHANGE)
-    public final LifecycleChange getChange() {
+    public LifecycleChange getChange() {
         return change;
     }
 
@@ -89,7 +94,7 @@ public class TenantChangeNotification extends AbstractNotification {
      * @return The tenant ID.
      */
     @JsonProperty(value = NotificationConstants.JSON_FIELD_TENANT_ID)
-    public final String getTenantId() {
+    public String getTenantId() {
         return tenantId;
     }
 
@@ -99,14 +104,20 @@ public class TenantChangeNotification extends AbstractNotification {
      * @return {@code true} if this tenant is enabled.
      */
     @JsonProperty(value = NotificationConstants.JSON_FIELD_DATA_ENABLED)
-    public final boolean isEnabled() {
+    public boolean isEnabled() {
         return enabled;
     }
 
     @Override
     @JsonIgnore
-    public final String getType() {
+    public NotificationType<TenantChangeNotification> getType() {
         return TYPE;
+    }
+
+    @Override
+    @JsonIgnore
+    public String getKey() {
+        return getTenantId();
     }
 
     @Override

--- a/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/AllDevicesOfTenantDeletedNotificationTest.java
+++ b/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/AllDevicesOfTenantDeletedNotificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -58,7 +58,7 @@ public class AllDevicesOfTenantDeletedNotificationTest {
         assertThat(json.getInstant(NotificationConstants.JSON_FIELD_CREATION_TIME).toString()).isEqualTo(CREATION_TIME);
 
         assertThat(json.getString(NotificationConstants.JSON_FIELD_TYPE))
-                .isEqualTo(AllDevicesOfTenantDeletedNotification.TYPE);
+                .isEqualTo(AllDevicesOfTenantDeletedNotification.TYPE_NAME);
         assertThat(json.getString(NotificationConstants.JSON_FIELD_TENANT_ID)).isEqualTo(TENANT_ID);
     }
 

--- a/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/CredentialsChangeNotificationTest.java
+++ b/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/CredentialsChangeNotificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -58,7 +58,7 @@ public class CredentialsChangeNotificationTest {
                 .isEqualTo(NotificationConstants.SOURCE_DEVICE_REGISTRY);
         assertThat(json.getInstant(NotificationConstants.JSON_FIELD_CREATION_TIME).toString()).isEqualTo(CREATION_TIME);
 
-        assertThat(json.getString(NotificationConstants.JSON_FIELD_TYPE)).isEqualTo(CredentialsChangeNotification.TYPE);
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_TYPE)).isEqualTo(CredentialsChangeNotification.TYPE_NAME);
         assertThat(json.getString(NotificationConstants.JSON_FIELD_TENANT_ID)).isEqualTo(TENANT_ID);
         assertThat(json.getString(NotificationConstants.JSON_FIELD_DEVICE_ID)).isEqualTo(DEVICE_ID);
     }

--- a/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/DeviceChangeNotificationTest.java
+++ b/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/DeviceChangeNotificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -60,7 +60,7 @@ public class DeviceChangeNotificationTest {
                 .isEqualTo(NotificationConstants.SOURCE_DEVICE_REGISTRY);
         assertThat(json.getInstant(NotificationConstants.JSON_FIELD_CREATION_TIME).toString()).isEqualTo(CREATION_TIME);
 
-        assertThat(json.getString(NotificationConstants.JSON_FIELD_TYPE)).isEqualTo(DeviceChangeNotification.TYPE);
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_TYPE)).isEqualTo(DeviceChangeNotification.TYPE_NAME);
         assertThat(json.getString(NotificationConstants.JSON_FIELD_DATA_CHANGE)).isEqualTo(CHANGE.toString());
         assertThat(json.getString(NotificationConstants.JSON_FIELD_TENANT_ID)).isEqualTo(TENANT_ID);
         assertThat(json.getString(NotificationConstants.JSON_FIELD_DEVICE_ID)).isEqualTo(DEVICE_ID);

--- a/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/TenantChangeNotificationTest.java
+++ b/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/TenantChangeNotificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -59,7 +59,7 @@ public class TenantChangeNotificationTest {
                 .isEqualTo(NotificationConstants.SOURCE_DEVICE_REGISTRY);
         assertThat(json.getInstant(NotificationConstants.JSON_FIELD_CREATION_TIME).toString()).isEqualTo(CREATION_TIME);
 
-        assertThat(json.getString(NotificationConstants.JSON_FIELD_TYPE)).isEqualTo(TenantChangeNotification.TYPE);
+        assertThat(json.getString(NotificationConstants.JSON_FIELD_TYPE)).isEqualTo(TenantChangeNotification.TYPE_NAME);
         assertThat(json.getString(NotificationConstants.JSON_FIELD_TENANT_ID)).isEqualTo(TENANT_ID);
         assertThat(json.getBoolean(NotificationConstants.JSON_FIELD_DATA_ENABLED)).isEqualTo(ENABLED);
         assertThat(json.getString(NotificationConstants.JSON_FIELD_DATA_CHANGE)).isEqualTo(CHANGE.toString());

--- a/clients/registry-amqp/src/main/java/org/eclipse/hono/client/registry/amqp/ProtonBasedCredentialsClient.java
+++ b/clients/registry-amqp/src/main/java/org/eclipse/hono/client/registry/amqp/ProtonBasedCredentialsClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -96,16 +96,16 @@ public class ProtonBasedCredentialsClient extends AbstractRequestResponseService
         this.notificationReceiver = Objects.requireNonNull(notificationReceiver);
 
         if (isCachingEnabled()) {
-            notificationReceiver.registerConsumer(AllDevicesOfTenantDeletedNotification.class,
+            notificationReceiver.registerConsumer(AllDevicesOfTenantDeletedNotification.TYPE,
                     n -> removeResultsForTenantFromCache(n.getTenantId()));
-            notificationReceiver.registerConsumer(DeviceChangeNotification.class,
+            notificationReceiver.registerConsumer(DeviceChangeNotification.TYPE,
                     n -> {
                         if (LifecycleChange.DELETE.equals(n.getChange())
                                 || (LifecycleChange.UPDATE.equals(n.getChange()) && !n.isEnabled())) {
                             removeResultsForDeviceFromCache(n.getTenantId(), n.getDeviceId());
                         }
                     });
-            notificationReceiver.registerConsumer(CredentialsChangeNotification.class,
+            notificationReceiver.registerConsumer(CredentialsChangeNotification.TYPE,
                     n -> removeResultsForDeviceFromCache(n.getTenantId(), n.getDeviceId()));
         }
     }

--- a/clients/registry-amqp/src/main/java/org/eclipse/hono/client/registry/amqp/ProtonBasedDeviceRegistrationClient.java
+++ b/clients/registry-amqp/src/main/java/org/eclipse/hono/client/registry/amqp/ProtonBasedDeviceRegistrationClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -95,9 +95,9 @@ public class ProtonBasedDeviceRegistrationClient extends AbstractRequestResponse
         this.notificationReceiver = Objects.requireNonNull(notificationReceiver);
 
         if (isCachingEnabled()) {
-            notificationReceiver.registerConsumer(AllDevicesOfTenantDeletedNotification.class,
+            notificationReceiver.registerConsumer(AllDevicesOfTenantDeletedNotification.TYPE,
                     n -> removeResultsForTenantFromCache(n.getTenantId()));
-            notificationReceiver.registerConsumer(DeviceChangeNotification.class,
+            notificationReceiver.registerConsumer(DeviceChangeNotification.TYPE,
                     n -> {
                         if (LifecycleChange.DELETE.equals(n.getChange())
                                 || (LifecycleChange.UPDATE.equals(n.getChange()) && !n.isEnabled())) {

--- a/clients/registry-amqp/src/main/java/org/eclipse/hono/client/registry/amqp/ProtonBasedTenantClient.java
+++ b/clients/registry-amqp/src/main/java/org/eclipse/hono/client/registry/amqp/ProtonBasedTenantClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -97,7 +97,7 @@ public final class ProtonBasedTenantClient extends AbstractRequestResponseServic
         this.notificationReceiver = Objects.requireNonNull(notificationReceiver);
 
         if (isCachingEnabled()) {
-            notificationReceiver.registerConsumer(TenantChangeNotification.class,
+            notificationReceiver.registerConsumer(TenantChangeNotification.TYPE,
                     n -> {
                         if (LifecycleChange.DELETE.equals(n.getChange())
                                 || (LifecycleChange.UPDATE.equals(n.getChange()) && !n.isEnabled())) {

--- a/clients/registry-amqp/src/test/java/org/eclipse/hono/client/registry/amqp/ProtonBasedCredentialsClientTest.java
+++ b/clients/registry-amqp/src/test/java/org/eclipse/hono/client/registry/amqp/ProtonBasedCredentialsClientTest.java
@@ -46,6 +46,7 @@ import org.eclipse.hono.client.amqp.test.AmqpClientUnitTestHelper;
 import org.eclipse.hono.client.util.AnnotatedCacheKey;
 import org.eclipse.hono.notification.AbstractNotification;
 import org.eclipse.hono.notification.NotificationReceiver;
+import org.eclipse.hono.notification.NotificationType;
 import org.eclipse.hono.notification.deviceregistry.AllDevicesOfTenantDeletedNotification;
 import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
 import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
@@ -419,11 +420,11 @@ class ProtonBasedCredentialsClientTest {
 
                     // THEN the expected consumers for notifications are registered
                     ctx.verify(() -> {
-                        verify(notificationReceiver).registerConsumer(eq(AllDevicesOfTenantDeletedNotification.class),
+                        verify(notificationReceiver).registerConsumer(eq(AllDevicesOfTenantDeletedNotification.TYPE),
                                 VertxMockSupport.anyHandler());
-                        verify(notificationReceiver).registerConsumer(eq(DeviceChangeNotification.class),
+                        verify(notificationReceiver).registerConsumer(eq(DeviceChangeNotification.TYPE),
                                 VertxMockSupport.anyHandler());
-                        verify(notificationReceiver).registerConsumer(eq(CredentialsChangeNotification.class),
+                        verify(notificationReceiver).registerConsumer(eq(CredentialsChangeNotification.TYPE),
                                 VertxMockSupport.anyHandler());
 
                         verify(notificationReceiver).start();
@@ -444,7 +445,7 @@ class ProtonBasedCredentialsClientTest {
         final String tenantId = "the-tenant-id";
         final String deviceId = "the-device-id";
 
-        final var notificationHandlerCaptor = getHandlerArgumentCaptor(AllDevicesOfTenantDeletedNotification.class);
+        final var notificationHandlerCaptor = getHandlerArgumentCaptor(AllDevicesOfTenantDeletedNotification.TYPE);
 
         givenAClient(cache);
 
@@ -480,7 +481,7 @@ class ProtonBasedCredentialsClientTest {
         final String tenantId = "the-tenant-id";
         final String deviceId = "the-device-id";
 
-        final var notificationHandlerCaptor = getHandlerArgumentCaptor(DeviceChangeNotification.class);
+        final var notificationHandlerCaptor = getHandlerArgumentCaptor(DeviceChangeNotification.TYPE);
 
         givenAClient(cache);
 
@@ -518,7 +519,7 @@ class ProtonBasedCredentialsClientTest {
         final String tenantId = "the-tenant-id";
         final String deviceId = "the-device-id";
 
-        final var notificationHandlerCaptor = getHandlerArgumentCaptor(CredentialsChangeNotification.class);
+        final var notificationHandlerCaptor = getHandlerArgumentCaptor(CredentialsChangeNotification.TYPE);
 
         givenAClient(cache);
 
@@ -544,12 +545,12 @@ class ProtonBasedCredentialsClientTest {
     }
 
     private <T extends AbstractNotification> ArgumentCaptor<Handler<T>> getHandlerArgumentCaptor(
-            final Class<T> notificationClass) {
+            final NotificationType<T> notificationType) {
 
         final ArgumentCaptor<Handler<T>> notificationHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
 
         doNothing().when(notificationReceiver)
-                .registerConsumer(eq(notificationClass), notificationHandlerCaptor.capture());
+                .registerConsumer(eq(notificationType), notificationHandlerCaptor.capture());
 
         return notificationHandlerCaptor;
     }

--- a/clients/registry-amqp/src/test/java/org/eclipse/hono/client/registry/amqp/ProtonBasedDeviceRegistrationClientTest.java
+++ b/clients/registry-amqp/src/test/java/org/eclipse/hono/client/registry/amqp/ProtonBasedDeviceRegistrationClientTest.java
@@ -44,6 +44,7 @@ import org.eclipse.hono.client.amqp.test.AmqpClientUnitTestHelper;
 import org.eclipse.hono.client.util.AnnotatedCacheKey;
 import org.eclipse.hono.notification.AbstractNotification;
 import org.eclipse.hono.notification.NotificationReceiver;
+import org.eclipse.hono.notification.NotificationType;
 import org.eclipse.hono.notification.deviceregistry.AllDevicesOfTenantDeletedNotification;
 import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
 import org.eclipse.hono.notification.deviceregistry.LifecycleChange;
@@ -308,9 +309,9 @@ class ProtonBasedDeviceRegistrationClientTest {
 
                     // THEN the expected consumers for notifications are registered
                     ctx.verify(() -> {
-                        verify(notificationReceiver).registerConsumer(eq(AllDevicesOfTenantDeletedNotification.class),
+                        verify(notificationReceiver).registerConsumer(eq(AllDevicesOfTenantDeletedNotification.TYPE),
                                 VertxMockSupport.anyHandler());
-                        verify(notificationReceiver).registerConsumer(eq(DeviceChangeNotification.class),
+                        verify(notificationReceiver).registerConsumer(eq(DeviceChangeNotification.TYPE),
                                 VertxMockSupport.anyHandler());
 
                         verify(notificationReceiver).start();
@@ -330,7 +331,7 @@ class ProtonBasedDeviceRegistrationClientTest {
     public void testAllDevicesOfTenantDeletedNotificationRemovesValueFromCache(final VertxTestContext ctx) {
         final String tenantId = "the-tenant-id";
 
-        final var notificationHandlerCaptor = getHandlerArgumentCaptor(AllDevicesOfTenantDeletedNotification.class);
+        final var notificationHandlerCaptor = getHandlerArgumentCaptor(AllDevicesOfTenantDeletedNotification.TYPE);
 
         givenAClient(cache);
 
@@ -366,7 +367,7 @@ class ProtonBasedDeviceRegistrationClientTest {
         final String tenantId = "the-tenant-id";
         final String deviceId = "the-device-id";
 
-        final var notificationHandlerCaptor = getHandlerArgumentCaptor(DeviceChangeNotification.class);
+        final var notificationHandlerCaptor = getHandlerArgumentCaptor(DeviceChangeNotification.TYPE);
 
         givenAClient(cache);
 
@@ -405,7 +406,7 @@ class ProtonBasedDeviceRegistrationClientTest {
         final String deviceId = "the-device-id";
         final String gatewayId = "the-device-id";
 
-        final var notificationHandlerCaptor = getHandlerArgumentCaptor(DeviceChangeNotification.class);
+        final var notificationHandlerCaptor = getHandlerArgumentCaptor(DeviceChangeNotification.TYPE);
 
         givenAClient(cache);
 
@@ -434,12 +435,12 @@ class ProtonBasedDeviceRegistrationClientTest {
     }
 
     private <T extends AbstractNotification> ArgumentCaptor<Handler<T>> getHandlerArgumentCaptor(
-            final Class<T> notificationClass) {
+            final NotificationType<T> notificationType) {
 
         final ArgumentCaptor<Handler<T>> notificationHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
 
         doNothing().when(notificationReceiver)
-                .registerConsumer(eq(notificationClass), notificationHandlerCaptor.capture());
+                .registerConsumer(eq(notificationType), notificationHandlerCaptor.capture());
 
         return notificationHandlerCaptor;
     }

--- a/clients/registry-amqp/src/test/java/org/eclipse/hono/client/registry/amqp/ProtonBasedTenantClientTest.java
+++ b/clients/registry-amqp/src/test/java/org/eclipse/hono/client/registry/amqp/ProtonBasedTenantClientTest.java
@@ -49,6 +49,7 @@ import org.eclipse.hono.client.amqp.test.AmqpClientUnitTestHelper;
 import org.eclipse.hono.client.util.AnnotatedCacheKey;
 import org.eclipse.hono.notification.AbstractNotification;
 import org.eclipse.hono.notification.NotificationReceiver;
+import org.eclipse.hono.notification.NotificationType;
 import org.eclipse.hono.notification.deviceregistry.LifecycleChange;
 import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
 import org.eclipse.hono.test.TracingMockSupport;
@@ -472,7 +473,7 @@ class ProtonBasedTenantClientTest {
 
                     // THEN the expected consumers for notifications are registered
                     ctx.verify(() -> {
-                        verify(notificationReceiver).registerConsumer(eq(TenantChangeNotification.class),
+                        verify(notificationReceiver).registerConsumer(eq(TenantChangeNotification.TYPE),
                                 VertxMockSupport.anyHandler());
 
                         verify(notificationReceiver).start();
@@ -493,7 +494,7 @@ class ProtonBasedTenantClientTest {
     public void testTenantChangeNotificationRemovesValueFromCache(final VertxTestContext ctx) {
         final String tenantId = "the-tenant-id";
 
-        final var notificationHandlerCaptor = getHandlerArgumentCaptor(TenantChangeNotification.class);
+        final var notificationHandlerCaptor = getHandlerArgumentCaptor(TenantChangeNotification.TYPE);
 
         givenAClient(cache);
 
@@ -515,12 +516,12 @@ class ProtonBasedTenantClientTest {
     }
 
     private <T extends AbstractNotification> ArgumentCaptor<Handler<T>> getHandlerArgumentCaptor(
-            final Class<T> notificationClass) {
+            final NotificationType<T> notificationType) {
 
         final ArgumentCaptor<Handler<T>> notificationHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
 
         doNothing().when(notificationReceiver)
-                .registerConsumer(eq(notificationClass), notificationHandlerCaptor.capture());
+                .registerConsumer(eq(notificationType), notificationHandlerCaptor.capture());
 
         return notificationHandlerCaptor;
     }

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistryNotificationsIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistryNotificationsIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -149,21 +149,21 @@ public class DeviceRegistryNotificationsIT {
         final Checkpoint notificationsReceivedCheckpoint = notificationsReceivedContext.checkpoint(3);
 
         final VertxTestContext setup = new VertxTestContext();
-        receiver.registerConsumer(TenantChangeNotification.class,
+        receiver.registerConsumer(TenantChangeNotification.TYPE,
                 notification -> {
                     ctx.verify(() -> {
                         assertThat(notification).isInstanceOf(TenantChangeNotification.class);
                     });
                     notificationsReceivedCheckpoint.flag();
                 });
-        receiver.registerConsumer(DeviceChangeNotification.class,
+        receiver.registerConsumer(DeviceChangeNotification.TYPE,
                 notification -> {
                     ctx.verify(() -> {
                         assertThat(notification).isInstanceOf(DeviceChangeNotification.class);
                     });
                     notificationsReceivedCheckpoint.flag();
                 });
-        receiver.registerConsumer(CredentialsChangeNotification.class,
+        receiver.registerConsumer(CredentialsChangeNotification.TYPE,
                 notification -> {
                     ctx.verify(() -> {
                         assertThat(notification).isInstanceOf(CredentialsChangeNotification.class);


### PR DESCRIPTION
Preparation for #3017:
Combine static properties of `AbstractNotification` sub classes into new `NotificationType` class, getting rid of `AbstractNotification` sub class specific code in several places.