### PR TITLE
Pass on device registry notifications via vert.x event bus

### DIFF
--- a/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractProtocolAdapterApplication.java
+++ b/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractProtocolAdapterApplication.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.spring;
+
+import java.util.Objects;
+
+import org.eclipse.hono.notification.NotificationReceiver;
+import org.eclipse.hono.service.spring.AbstractApplication;
+import org.eclipse.hono.util.WrappedLifecycleComponentVerticle;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.vertx.core.Future;
+
+/**
+ * A base class for implementing protocol adapter applications.
+ */
+public class AbstractProtocolAdapterApplication extends AbstractApplication {
+
+    private NotificationReceiver notificationReceiver;
+
+    /**
+     * Sets the notification receiver to use.
+     *
+     * @param notificationReceiver The notification receiver.
+     * @throws NullPointerException if notificationReceiver is {@code null}.
+     */
+    @Autowired
+    public void setNotificationReceiver(final NotificationReceiver notificationReceiver) {
+        this.notificationReceiver = Objects.requireNonNull(notificationReceiver);
+    }
+
+    @Override
+    protected Future<Void> deployRequiredVerticles(final int maxInstances) {
+        return getVertx().deployVerticle(new WrappedLifecycleComponentVerticle(notificationReceiver)).mapEmpty();
+    }
+}

--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/spring/Application.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/spring/Application.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.hono.adapter.amqp.spring;
 
+import org.eclipse.hono.adapter.spring.AbstractProtocolAdapterApplication;
 import org.eclipse.hono.deviceconnection.infinispan.client.HotrodCacheConfig;
-import org.eclipse.hono.service.spring.AbstractApplication;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @Import({ Config.class, HotrodCacheConfig.class })
 @EnableAutoConfiguration
-public class Application extends AbstractApplication {
+public class Application extends AbstractProtocolAdapterApplication {
 
     /**
      * Starts the AMQP Adapter application.

--- a/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/spring/Application.java
+++ b/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/spring/Application.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,8 +12,8 @@
  */
 package org.eclipse.hono.adapter.coap.spring;
 
+import org.eclipse.hono.adapter.spring.AbstractProtocolAdapterApplication;
 import org.eclipse.hono.deviceconnection.infinispan.client.HotrodCacheConfig;
-import org.eclipse.hono.service.spring.AbstractApplication;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @Import({ Config.class, HotrodCacheConfig.class })
 @EnableAutoConfiguration
-public class Application extends AbstractApplication {
+public class Application extends AbstractProtocolAdapterApplication {
 
     /**
      * Starts the COAP Adapter application.

--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/spring/Application.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/spring/Application.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.hono.adapter.http.spring;
 
+import org.eclipse.hono.adapter.spring.AbstractProtocolAdapterApplication;
 import org.eclipse.hono.deviceconnection.infinispan.client.HotrodCacheConfig;
-import org.eclipse.hono.service.spring.AbstractApplication;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @Import({ Config.class, HotrodCacheConfig.class })
 @EnableAutoConfiguration
-public class Application extends AbstractApplication {
+public class Application extends AbstractProtocolAdapterApplication {
 
     /**
      * Starts the HTTP Adapter application.

--- a/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/impl/Application.java
+++ b/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/impl/Application.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,8 +13,8 @@
 
 package org.eclipse.hono.adapter.kura.impl;
 
+import org.eclipse.hono.adapter.spring.AbstractProtocolAdapterApplication;
 import org.eclipse.hono.deviceconnection.infinispan.client.HotrodCacheConfig;
-import org.eclipse.hono.service.spring.AbstractApplication;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @Import({ Config.class, HotrodCacheConfig.class })
 @EnableAutoConfiguration
-public class Application extends AbstractApplication {
+public class Application extends AbstractProtocolAdapterApplication {
 
     /**
      * Starts the Kura Adapter application.

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/Application.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/Application.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,8 +13,8 @@
 
 package org.eclipse.hono.adapter.lora.impl;
 
+import org.eclipse.hono.adapter.spring.AbstractProtocolAdapterApplication;
 import org.eclipse.hono.deviceconnection.infinispan.client.HotrodCacheConfig;
-import org.eclipse.hono.service.spring.AbstractApplication;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Import;
 @ComponentScan("org.eclipse.hono.adapter.lora.providers")
 @Import({ Config.class, HotrodCacheConfig.class })
 @SpringBootApplication
-public class Application extends AbstractApplication {
+public class Application extends AbstractProtocolAdapterApplication {
 
     /**
      * Starts the LoRa Adapter application.

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/spring/Application.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/spring/Application.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,8 +13,8 @@
 
 package org.eclipse.hono.adapter.mqtt.spring;
 
+import org.eclipse.hono.adapter.spring.AbstractProtocolAdapterApplication;
 import org.eclipse.hono.deviceconnection.infinispan.client.HotrodCacheConfig;
-import org.eclipse.hono.service.spring.AbstractApplication;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @Import({ Config.class, HotrodCacheConfig.class })
 @EnableAutoConfiguration
-public class Application extends AbstractApplication {
+public class Application extends AbstractProtocolAdapterApplication {
 
     /**
      * Starts the MQTT Adapter application.

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/Application.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/Application.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,8 +13,8 @@
 
 package org.eclipse.hono.adapter.sigfox.impl;
 
+import org.eclipse.hono.adapter.spring.AbstractProtocolAdapterApplication;
 import org.eclipse.hono.deviceconnection.infinispan.client.HotrodCacheConfig;
-import org.eclipse.hono.service.spring.AbstractApplication;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
@@ -24,7 +24,7 @@ import org.springframework.context.annotation.Import;
  */
 @Import({ Config.class, HotrodCacheConfig.class })
 @SpringBootApplication
-public class Application extends AbstractApplication {
+public class Application extends AbstractProtocolAdapterApplication {
 
     /**
      * Starts the Sigfox Adapter application.

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationConstants.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationConstants.java
@@ -13,6 +13,12 @@
 
 package org.eclipse.hono.notification;
 
+import java.util.List;
+
+import org.eclipse.hono.notification.deviceregistry.AllDevicesOfTenantDeletedNotification;
+import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
+import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
 import org.eclipse.hono.util.Constants;
 
 /**
@@ -59,6 +65,14 @@ public class NotificationConstants {
      * The field name of the JSON object that indicates the device ID.
      */
     public static final String JSON_FIELD_DEVICE_ID = Constants.JSON_FIELD_DEVICE_ID;
+    /**
+     * All device registry notification types.
+     */
+    public static final List<NotificationType<?>> DEVICE_REGISTRY_NOTIFICATION_TYPES = List.of(
+            TenantChangeNotification.TYPE,
+            DeviceChangeNotification.TYPE,
+            CredentialsChangeNotification.TYPE,
+            AllDevicesOfTenantDeletedNotification.TYPE);
 
     private NotificationConstants() {
         // prevent instantiation

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationEventBusSupport.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationEventBusSupport.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.WeakHashMap;
+
+import org.eclipse.hono.util.Constants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.MessageCodec;
+
+/**
+ * Support for sending and receiving notifications via the vert.x event bus.
+ */
+public class NotificationEventBusSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NotificationEventBusSupport.class);
+
+    private static final String NOTIFICATION_EVENT_BUS_CONTAINER_LOCAL_CODEC = "NotificationEventBusContainerLocalCodec";
+
+    private static final Map<Vertx, Boolean> VERTX_INSTANCES_WITH_REGISTERED_CODEC_MAP = new WeakHashMap<>();
+
+    private NotificationEventBusSupport() {
+        // prevent instantiation
+    }
+
+    /**
+     * Registers a consumer to receive notifications via the vert.x event bus.
+     *
+     * @param vertx The vert.x instance to use.
+     * @param notificationType The type of notifications to register the consumer for.
+     * @param consumer The consumer.
+     * @param <T> The class of notifications handled by the given consumer.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public static <T extends AbstractNotification> void registerConsumer(final Vertx vertx,
+            final NotificationType<T> notificationType, final Handler<T> consumer) {
+        Objects.requireNonNull(vertx);
+        Objects.requireNonNull(notificationType);
+        Objects.requireNonNull(consumer);
+
+        vertx.eventBus().<T>consumer(
+                getEventBusAddress(notificationType),
+                msg -> {
+                    final T notification = msg.body();
+                    if (notification != null && notificationType.equals(notification.getType())) {
+                        consumer.handle(notification);
+                    } else {
+                        LOG.warn("got event bus message with unexpected body on address [{}]", getEventBusAddress(notificationType));
+                    }
+                });
+    }
+
+    /**
+     * Sends the given notification via the vert.x event bus.
+     *
+     * @param vertx The vert.x instance to use.
+     * @param notification  The notification to send.
+     * @param <T> The class of the given notification.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public static <T extends AbstractNotification> void sendNotification(final Vertx vertx, final T notification) {
+        Objects.requireNonNull(vertx);
+        Objects.requireNonNull(notification);
+
+        if (VERTX_INSTANCES_WITH_REGISTERED_CODEC_MAP.putIfAbsent(vertx, true) == null) {
+            vertx.eventBus().registerCodec(new NotificationEventBusContainerLocalCodec());
+        }
+
+        final DeliveryOptions options = new DeliveryOptions();
+        options.setCodecName(NOTIFICATION_EVENT_BUS_CONTAINER_LOCAL_CODEC);
+        options.setLocalOnly(true);
+        vertx.eventBus().publish(getEventBusAddress(notification.getType()), notification, options);
+    }
+
+    /**
+     * Gets the event bus address on which notifications of the given type get sent.
+     *
+     * @param notificationType The notification type for which to get the address.
+     * @param <T> The notification class associated with the given type.
+     * @return The address.
+     */
+    public static <T extends AbstractNotification> String getEventBusAddress(final NotificationType<T> notificationType) {
+        return Constants.EVENT_BUS_ADDRESS_NOTIFICATION_PREFIX + notificationType.getTypeName();
+    }
+
+    /**
+     * Codec for {@link AbstractNotification} objects sent via the vert.x event bus.
+     * <p>
+     * Only supports local delivery.
+     */
+    static class NotificationEventBusContainerLocalCodec
+            implements MessageCodec<AbstractNotification, AbstractNotification> {
+
+        @Override
+        public void encodeToWire(final Buffer buffer, final AbstractNotification t) {
+            throw new UnsupportedOperationException(name() + " can only be used for local delivery");
+        }
+
+        @Override
+        public AbstractNotification decodeFromWire(final int pos, final Buffer buffer) {
+            throw new UnsupportedOperationException(name() + " can only be used for local delivery");
+        }
+
+        @Override
+        public AbstractNotification transform(final AbstractNotification instance) {
+            return instance;
+        }
+
+        @Override
+        public String name() {
+            return NOTIFICATION_EVENT_BUS_CONTAINER_LOCAL_CODEC;
+        }
+
+        @Override
+        public byte systemCodecID() {
+            return -1;
+        }
+    }
+}

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationTypeResolver.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationTypeResolver.java
@@ -13,13 +13,6 @@
 
 package org.eclipse.hono.notification;
 
-import java.util.List;
-
-import org.eclipse.hono.notification.deviceregistry.AllDevicesOfTenantDeletedNotification;
-import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
-import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
-import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
-
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.DatabindContext;
 import com.fasterxml.jackson.databind.JavaType;
@@ -28,16 +21,9 @@ import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
 /**
  * Type resolver for notifications.
  * <p>
- * This type resolver knows the types {@link TenantChangeNotification}, {@link DeviceChangeNotification},
- * {@link CredentialsChangeNotification} and {@link AllDevicesOfTenantDeletedNotification}.
+ * This type resolver knows the types contained in {@link NotificationConstants#DEVICE_REGISTRY_NOTIFICATION_TYPES}.
  */
 public final class NotificationTypeResolver extends TypeIdResolverBase {
-
-    private static final List<NotificationType<?>> SUPPORTED_TYPES = List.of(
-            TenantChangeNotification.TYPE,
-            DeviceChangeNotification.TYPE,
-            CredentialsChangeNotification.TYPE,
-            AllDevicesOfTenantDeletedNotification.TYPE);
 
     private JavaType baseType;
 
@@ -74,7 +60,7 @@ public final class NotificationTypeResolver extends TypeIdResolverBase {
 
     @Override
     public JavaType typeFromId(final DatabindContext context, final String id) {
-        for (final NotificationType<?> type : SUPPORTED_TYPES) {
+        for (final NotificationType<?> type : NotificationConstants.DEVICE_REGISTRY_NOTIFICATION_TYPES) {
             if (type.getTypeName().equals(id)) {
                 return context.constructSpecializedType(this.baseType, type.getClazz());
             }

--- a/clients/notification/src/test/java/org/eclipse/hono/notification/NotificationEventBusSupportTest.java
+++ b/clients/notification/src/test/java/org/eclipse/hono/notification/NotificationEventBusSupportTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.notification;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.hono.notification.deviceregistry.LifecycleChange;
+import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Tests verifying the behavior of {@link NotificationEventBusSupport}.
+ *
+ */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public class NotificationEventBusSupportTest {
+
+    /**
+     * Verifies that a notification published on the vert.x event bus is getting received by consumers.
+     *
+     * @param ctx The vert.x test context.
+     * @param vertx The vert.x instance.
+     */
+    @Test
+    public void testPublishedNotificationIsReceived(final VertxTestContext ctx, final Vertx vertx) {
+
+        final TenantChangeNotification notification = new TenantChangeNotification(LifecycleChange.CREATE, "my-tenant",
+                Instant.parse("2007-12-03T10:15:30Z"), false);
+
+        final int consumerCount = 2;
+        final Checkpoint checkpoint = ctx.checkpoint(consumerCount);
+        for (int i = 0; i < consumerCount; i++) {
+            NotificationEventBusSupport.registerConsumer(vertx, notification.getType(), receivedNotification -> {
+                ctx.verify(() -> assertThat(receivedNotification).isEqualTo(notification));
+                checkpoint.flag();
+            });
+        }
+
+        NotificationEventBusSupport.sendNotification(vertx, notification);
+    }
+
+}

--- a/core/src/main/java/org/eclipse/hono/util/Constants.java
+++ b/core/src/main/java/org/eclipse/hono/util/Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -122,6 +122,11 @@ public final class Constants {
      * The vert.x event bus address that the ID of a tenant that timed out is published to.
      */
     public static final String EVENT_BUS_ADDRESS_TENANT_TIMED_OUT = "tenant.timeout";
+
+    /**
+     * The prefix for the vert.x event bus address that notification messages are published to.
+     */
+    public static final String EVENT_BUS_ADDRESS_NOTIFICATION_PREFIX = "notification.";
 
     /**
      * The AMQP 1.0 port defined by IANA for unencrypted connections.

--- a/core/src/main/java/org/eclipse/hono/util/WrappedLifecycleComponentVerticle.java
+++ b/core/src/main/java/org/eclipse/hono/util/WrappedLifecycleComponentVerticle.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.util;
+
+import java.util.Objects;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+
+/**
+ * Enables a component with life cycle support to be used as a vert.x verticle.
+ */
+public class WrappedLifecycleComponentVerticle extends AbstractVerticle {
+
+    private final Lifecycle lifecycleComponent;
+
+    /**
+     * Creates a new WrappedLifecycleComponentVerticle.
+     *
+     * @param lifecycleComponent The component whose <em>start</em> and <em>stop</em> methods shall be called
+     *                           on {@link #start(Promise)} and {@link #stop(Promise)} of this verticle.
+     * @throws NullPointerException If lifecycleComponent is {@code null}.
+     */
+    public WrappedLifecycleComponentVerticle(final Lifecycle lifecycleComponent) {
+        this.lifecycleComponent = Objects.requireNonNull(lifecycleComponent);
+    }
+
+    @Override
+    public void start(final Promise<Void> startPromise) {
+        lifecycleComponent.start().onComplete(startPromise);
+    }
+
+    @Override
+    public void stop(final Promise<Void> stopPromise) {
+        lifecycleComponent.stop().onComplete(stopPromise);
+    }
+}

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsAmqpIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,7 +16,6 @@ import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.registry.CredentialsClient;
 import org.eclipse.hono.client.registry.amqp.ProtonBasedCredentialsClient;
-import org.eclipse.hono.notification.NoOpNotificationReceiver;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -49,7 +48,6 @@ public class CredentialsAmqpIT extends CredentialsApiTests {
                                 IntegrationTestSupport.TENANT_ADMIN_USER,
                                 IntegrationTestSupport.TENANT_ADMIN_PWD)),
                 SendMessageSampler.Factory.noop(),
-                new NoOpNotificationReceiver(),
                 null);
 
         client.start().onComplete(ctx.succeedingThenComplete());

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistrationAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistrationAmqpIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,7 +17,6 @@ import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.client.registry.amqp.ProtonBasedDeviceRegistrationClient;
-import org.eclipse.hono.notification.NoOpNotificationReceiver;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -52,7 +51,6 @@ public class DeviceRegistrationAmqpIT extends DeviceRegistrationApiTests {
                                 IntegrationTestSupport.TENANT_ADMIN_USER,
                                 IntegrationTestSupport.TENANT_ADMIN_PWD)),
                 SendMessageSampler.Factory.noop(),
-                new NoOpNotificationReceiver(),
                 null);
         registrationClient.start().onComplete(ctx.succeedingThenComplete());
     }

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantAmqpIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,7 +17,6 @@ import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.registry.TenantClient;
 import org.eclipse.hono.client.registry.amqp.ProtonBasedTenantClient;
-import org.eclipse.hono.notification.NoOpNotificationReceiver;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -56,7 +55,6 @@ public class TenantAmqpIT extends TenantApiTests {
                                 IntegrationTestSupport.TENANT_ADMIN_USER,
                                 IntegrationTestSupport.TENANT_ADMIN_PWD)),
                 SendMessageSampler.Factory.noop(),
-                new NoOpNotificationReceiver(),
                 null);
 
         allTenantClient.start()
@@ -71,7 +69,6 @@ public class TenantAmqpIT extends TenantApiTests {
                                 IntegrationTestSupport.HONO_USER,
                                 IntegrationTestSupport.HONO_PWD)),
                 SendMessageSampler.Factory.noop(),
-                new NoOpNotificationReceiver(),
                 null);
 
         defaultTenantClient.start()


### PR DESCRIPTION
Refactoring in preparation for #3017:
Usage of the vert.x event bus should allow for more flexibility in adding multiple consumers for device registry notifications.