### PR TITLE
[#2979] Use configured poll timeout in HonoKafkaConsumer

### DIFF
--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaApplicationClientImpl.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaApplicationClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.application.client.kafka.impl;
 
+import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -166,6 +167,7 @@ public class KafkaApplicationClientImpl extends KafkaBasedCommandSender implemen
         };
         final HonoKafkaConsumer consumer = new HonoKafkaConsumer(vertx, Set.of(topic), recordHandler,
                 consumerConfig.getConsumerConfig(type.toString()));
+        consumer.setPollTimeout(Duration.ofMillis(consumerConfig.getPollTimeout()));
         Optional.ofNullable(kafkaConsumerSupplier)
                 .ifPresent(consumer::setKafkaConsumerSupplier);
         return consumer.start()

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -368,6 +368,7 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
                     .handle(new KafkaDownstreamMessage(record));
         };
         final HonoKafkaConsumer consumer = new HonoKafkaConsumer(vertx, Set.of(topic), recordHandler, consumerConfig);
+        consumer.setPollTimeout(Duration.ofMillis(this.consumerConfig.getPollTimeout()));
         Optional.ofNullable(kafkaConsumerSupplier)
                 .ifPresent(consumer::setKafkaConsumerSupplier);
         return consumer.start()

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/KafkaConsumerConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/KafkaConsumerConfigProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -35,12 +35,12 @@ public class KafkaConsumerConfigProperties extends AbstractKafkaConfigProperties
     /**
      * The default amount of time (milliseconds) to wait for records when polling records.
      */
-    public static final long DEFAULT_POLL_TIMEOUT = 100L; // ms
+    public static final long DEFAULT_POLL_TIMEOUT_MILLIS = 250L; // ms
 
     private final Class<? extends Deserializer<?>> keyDeserializerClass;
     private final Class<? extends Deserializer<?>> valueDeserializerClass;
 
-    private long pollTimeout = DEFAULT_POLL_TIMEOUT;
+    private long pollTimeout = DEFAULT_POLL_TIMEOUT_MILLIS;
 
     /**
      * Creates an instance.
@@ -138,7 +138,7 @@ public class KafkaConsumerConfigProperties extends AbstractKafkaConfigProperties
     /**
      * Sets the timeout for polling records.
      * <p>
-     * The default value of this property is {@value #DEFAULT_POLL_TIMEOUT}.
+     * The default value of this property is {@value #DEFAULT_POLL_TIMEOUT_MILLIS}.
      *
      * @param pollTimeoutMillis The maximum number of milliseconds to wait.
      * @throws IllegalArgumentException if poll timeout is negative.
@@ -154,7 +154,7 @@ public class KafkaConsumerConfigProperties extends AbstractKafkaConfigProperties
     /**
      * Gets the timeout for polling records.
      * <p>
-     * The default value of this property is {@value #DEFAULT_POLL_TIMEOUT}.
+     * The default value of this property is {@value #DEFAULT_POLL_TIMEOUT_MILLIS}.
      *
      * @return The maximum number of milliseconds to wait.
      */

--- a/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/kafka/KafkaBasedNotificationReceiver.java
+++ b/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/kafka/KafkaBasedNotificationReceiver.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.client.notification.kafka;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -84,6 +85,7 @@ public class KafkaBasedNotificationReceiver implements NotificationReceiver {
     @Override
     public Future<Void> start() {
         honoKafkaConsumer = new HonoKafkaConsumer(vertx, topics, getRecordHandler(), consumerConfig.getConsumerConfig(NAME));
+        honoKafkaConsumer.setPollTimeout(Duration.ofMillis(consumerConfig.getPollTimeout()));
         honoKafkaConsumer.setConsumerCreationRetriesTimeout(KafkaClientFactory.UNLIMITED_RETRIES_DURATION);
         Optional.ofNullable(kafkaConsumerSupplier).ifPresent(honoKafkaConsumer::setKafkaConsumerSupplier);
         return honoKafkaConsumer

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.hono.commandrouter.impl.kafka;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -173,6 +174,7 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
         consumerConfig.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         kafkaConsumer = new AsyncHandlingAutoCommitKafkaConsumer(vertx, COMMANDS_TOPIC_PATTERN,
                 commandHandler::mapAndDelegateIncomingCommandMessage, consumerConfig);
+        kafkaConsumer.setPollTimeout(Duration.ofMillis(kafkaConsumerConfig.getPollTimeout()));
         kafkaConsumer.setConsumerCreationRetriesTimeout(KafkaClientFactory.UNLIMITED_RETRIES_DURATION);
         kafkaConsumer.setMetricsSupport(kafkaClientMetricsSupport);
         kafkaConsumer.setOnRebalanceDoneHandler(

--- a/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
+++ b/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
@@ -109,6 +109,12 @@ The following properties can _not_ be set because
 Kafka clients used in Hono will get a unique client identifier, containing client name and component identifier.
 If the property `client.id` is provided, its value will be used as prefix for the created client identifier.
 
+Apart from the standard Kafka client consumer properties, this additional property may be set:
+
+| OS Environment Variable<br>Java System Property                                  | Mandatory | Default | Description                                                                                                                                                                                                                                                                                                                                                                                                               |
+|:---------------------------------------------------------------------------------|:---------:|:--------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `HONO_KAFKA_${CLIENTNAME}_POLLTIMEOUT`<br>`hono.kafka.${clientName}.pollTimeout` |    no     | `250`   | The maximum number of milliseconds to wait for records on each consumer poll operation. Setting the timeout to a lower value will make the client more responsive, for example concerning consumer-group membership changes, in times when no messages are available for the consumer to poll. At the same time, the client will poll more frequently and thus will potentially create a higher load on the Kafka Broker. |
+
 ## Admin Client Configuration Properties
 
 Admin clients for Hono's Kafka based APIs are configured with instances of the class

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -57,6 +57,9 @@ description = "Information about changes in recent Hono releases. Includes new f
 * The native image variant of the Command Router component failed to connect to an Infinispan server using SASL
   SCRAM. This has been fixed.
 * The lora adapter supports unconfirmed uplink data for the firefly provider.
+* The poll timeout used by the Kafka consumer clients in the Hono components can now be configured individually.
+  Please refer to the [Hono Kafka Client Configuration Guide]({{% doclink "/admin-guide/hono-kafka-client-configuration/#consumer-configuration-properties" %}})
+  for details.
 
 ## API Changes
 


### PR DESCRIPTION
This is for #2979.
Using the poll timeout configured in `KafkaConsumerConfigProperties` in the `HonoKafkaConsumer` instances.