### PR TITLE
Use vert.x event bus with NotificationSender.

### DIFF
--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/server/DeviceRegistryAmqpServer.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/server/DeviceRegistryAmqpServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,50 +13,18 @@
 
 package org.eclipse.hono.deviceregistry.server;
 
-
-import java.util.Objects;
-
 import org.eclipse.hono.config.ServiceConfigProperties;
-import org.eclipse.hono.notification.NoOpNotificationSender;
-import org.eclipse.hono.notification.NotificationSender;
 import org.eclipse.hono.service.amqp.AmqpServiceBase;
 import org.eclipse.hono.util.Constants;
-
-import io.vertx.core.Future;
 
 /**
  * Default AMQP server for Hono's example device registry.
  */
 public final class DeviceRegistryAmqpServer extends AmqpServiceBase<ServiceConfigProperties> {
 
-    private NotificationSender notificationSender = new NoOpNotificationSender();
-
-    /**
-     * Sets the client to publish notifications about changes on devices.
-     * <p>
-     * The {@link org.eclipse.hono.util.Lifecycle#start()} method of the given client will be invoked during startup
-     * of the server, and the {@link org.eclipse.hono.util.Lifecycle#stop()} method will be called on server shutdown.
-     * The outcome of these methods is tied to the outcome of the server start/shutdown.
-     *
-     * @param notificationSender The client.
-     * @throws NullPointerException if notificationSender is {@code null}.
-     */
-    public void setNotificationSender(final NotificationSender notificationSender) {
-        this.notificationSender = Objects.requireNonNull(notificationSender);
-    }
-
     @Override
     protected String getServiceName() {
         return Constants.SERVICE_NAME_DEVICE_REGISTRY;
     }
 
-    @Override
-    protected Future<Void> preStartServers() {
-        return notificationSender.start();
-    }
-
-    @Override
-    protected Future<Void> postShutdown() {
-        return notificationSender.stop();
-    }
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/server/DeviceRegistryHttpServer.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/server/DeviceRegistryHttpServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,43 +13,11 @@
 
 package org.eclipse.hono.deviceregistry.server;
 
-import java.util.Objects;
-
 import org.eclipse.hono.config.ServiceConfigProperties;
-import org.eclipse.hono.notification.NoOpNotificationSender;
-import org.eclipse.hono.notification.NotificationSender;
 import org.eclipse.hono.service.http.HttpServiceBase;
-
-import io.vertx.core.Future;
 
 /**
  * Default REST server for Hono's example device registry.
  */
 public class DeviceRegistryHttpServer extends HttpServiceBase<ServiceConfigProperties> {
-
-    private NotificationSender notificationSender = new NoOpNotificationSender();
-
-    /**
-     * Sets the client to publish notifications about changes on devices.
-     * <p>
-     * The {@link org.eclipse.hono.util.Lifecycle#start()} method of the given client will be invoked during startup
-     * of the server, and the {@link org.eclipse.hono.util.Lifecycle#stop()} method will be called on server shutdown.
-     * The outcome of these methods is tied to the outcome of the server start/shutdown.
-     *
-     * @param notificationSender The client.
-     * @throws NullPointerException if notificationSender is {@code null}.
-     */
-    public final void setNotificationSender(final NotificationSender notificationSender) {
-        this.notificationSender = Objects.requireNonNull(notificationSender);
-    }
-
-    @Override
-    protected Future<Void> preStartServers() {
-        return notificationSender.start();
-    }
-
-    @Override
-    protected Future<Void> postShutdown() {
-        return notificationSender.stop();
-    }
 }

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/credentials/AbstractCredentialsManagementServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/credentials/AbstractCredentialsManagementServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,9 +13,11 @@
 
 package org.eclipse.hono.deviceregistry.service.credentials;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -28,8 +30,7 @@ import java.util.Set;
 
 import org.eclipse.hono.auth.HonoPasswordEncoder;
 import org.eclipse.hono.deviceregistry.service.device.DeviceKey;
-import org.eclipse.hono.notification.AbstractNotification;
-import org.eclipse.hono.notification.NotificationSender;
+import org.eclipse.hono.notification.NotificationEventBusSupport;
 import org.eclipse.hono.notification.deviceregistry.CredentialsChangeNotification;
 import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.credentials.CommonCredential;
@@ -42,6 +43,7 @@ import io.opentracing.Span;
 import io.opentracing.noop.NoopSpan;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
@@ -56,25 +58,15 @@ public class AbstractCredentialsManagementServiceTest {
     private static final Span SPAN = NoopSpan.INSTANCE;
 
     private TestCredentialsManagementService credentialsManagementService;
-
-    private final NotificationSender notificationSender = mock(NotificationSender.class);
-    private final ArgumentCaptor<AbstractNotification> notificationArgumentCaptor = ArgumentCaptor
-            .forClass(AbstractNotification.class);
+    private EventBus eventBus;
 
     @BeforeEach
     void setUp() {
-        credentialsManagementService = new TestCredentialsManagementService(mock(Vertx.class),
+        eventBus = mock(EventBus.class);
+        final Vertx vertx = mock(Vertx.class);
+        when(vertx.eventBus()).thenReturn(eventBus);
+        credentialsManagementService = new TestCredentialsManagementService(vertx,
                 mock(HonoPasswordEncoder.class), 9, new HashSet<>());
-        credentialsManagementService.setNotificationSender(notificationSender);
-    }
-
-    /**
-     * Verifies that {@link AbstractCredentialsManagementService#setNotificationSender(NotificationSender)} throws a
-     * null pointer exception if the notification sender is {@code null}.
-     */
-    @Test
-    public void setNotificationSender() {
-        assertThrows(NullPointerException.class, () -> credentialsManagementService.setNotificationSender(null));
     }
 
     /**
@@ -86,17 +78,25 @@ public class AbstractCredentialsManagementServiceTest {
      */
     @Test
     public void testNotificationOnUpdateCredentials(final VertxTestContext context) {
+        final var notificationArgumentCaptor = ArgumentCaptor.forClass(CredentialsChangeNotification.class);
         credentialsManagementService
                 .updateCredentials(DEFAULT_TENANT_ID, DEFAULT_DEVICE_ID, new ArrayList<>(), Optional.empty(), SPAN)
-                .onComplete(context.succeeding(result -> context.verify(() -> {
-                    verify(notificationSender).publish(notificationArgumentCaptor.capture());
+                .onComplete(context.succeeding(result -> {
+                    context.verify(() -> {
+                        verify(eventBus).publish(
+                                eq(NotificationEventBusSupport.getEventBusAddress(CredentialsChangeNotification.TYPE)),
+                                notificationArgumentCaptor.capture(),
+                                any());
 
-                    final var notification = (CredentialsChangeNotification) notificationArgumentCaptor.getValue();
-                    assertThat(notification.getTenantId()).isEqualTo(DEFAULT_TENANT_ID);
-                    assertThat(notification.getDeviceId()).isEqualTo(DEFAULT_DEVICE_ID);
-                    assertThat(notification.getCreationTime()).isNotNull();
+                        assertThat(notificationArgumentCaptor.getAllValues().size()).isEqualTo(1);
+                        final var notification = notificationArgumentCaptor.getValue();
+                        assertThat(notification).isNotNull();
+                        assertThat(notification.getTenantId()).isEqualTo(DEFAULT_TENANT_ID);
+                        assertThat(notification.getDeviceId()).isEqualTo(DEFAULT_DEVICE_ID);
+                        assertThat(notification.getCreationTime()).isNotNull();
+                    });
                     context.completeNow();
-                })));
+                }));
     }
 
     private static class TestCredentialsManagementService extends AbstractCredentialsManagementService {

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/device/AbstractDeviceManagementServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/device/AbstractDeviceManagementServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,18 +13,19 @@
 
 package org.eclipse.hono.deviceregistry.service.device;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 import java.util.Optional;
 
-import org.eclipse.hono.notification.AbstractNotification;
-import org.eclipse.hono.notification.NotificationSender;
+import org.eclipse.hono.notification.NotificationEventBusSupport;
 import org.eclipse.hono.notification.deviceregistry.AllDevicesOfTenantDeletedNotification;
 import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
 import org.eclipse.hono.notification.deviceregistry.LifecycleChange;
@@ -40,6 +41,8 @@ import org.mockito.ArgumentCaptor;
 import io.opentracing.Span;
 import io.opentracing.noop.NoopSpan;
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
@@ -54,24 +57,14 @@ public class AbstractDeviceManagementServiceTest {
     private static final Span SPAN = NoopSpan.INSTANCE;
 
     private TestDeviceManagementService deviceManagementService;
-
-    private final NotificationSender notificationSender = mock(NotificationSender.class);
-    private final ArgumentCaptor<AbstractNotification> notificationArgumentCaptor = ArgumentCaptor
-            .forClass(AbstractNotification.class);
+    private EventBus eventBus;
 
     @BeforeEach
     void setUp() {
-        deviceManagementService = new TestDeviceManagementService();
-        deviceManagementService.setNotificationSender(notificationSender);
-    }
-
-    /**
-     * Verifies that {@link AbstractDeviceManagementService#setNotificationSender(NotificationSender)} throws a null
-     * pointer exception if the notification sender is {@code null}.
-     */
-    @Test
-    public void setNotificationSender() {
-        assertThrows(NullPointerException.class, () -> deviceManagementService.setNotificationSender(null));
+        eventBus = mock(EventBus.class);
+        final Vertx vertx = mock(Vertx.class);
+        when(vertx.eventBus()).thenReturn(eventBus);
+        deviceManagementService = new TestDeviceManagementService(vertx);
     }
 
     /**
@@ -82,20 +75,27 @@ public class AbstractDeviceManagementServiceTest {
      */
     @Test
     public void testNotificationOnCreateDevice(final VertxTestContext context) {
+        final var notificationArgumentCaptor = ArgumentCaptor.forClass(DeviceChangeNotification.class);
         deviceManagementService
                 .createDevice(DEFAULT_TENANT_ID, Optional.of(DEFAULT_DEVICE_ID), new Device().setEnabled(false), SPAN)
-                .onComplete(context.succeeding(result -> context.verify(() -> {
+                .onComplete(context.succeeding(result -> {
+                    context.verify(() -> {
+                        verify(eventBus).publish(
+                                eq(NotificationEventBusSupport.getEventBusAddress(DeviceChangeNotification.TYPE)),
+                                notificationArgumentCaptor.capture(),
+                                any());
 
-                    verify(notificationSender).publish(notificationArgumentCaptor.capture());
-
-                    final var notification = (DeviceChangeNotification) notificationArgumentCaptor.getValue();
-                    assertThat(notification.getChange()).isEqualTo(LifecycleChange.CREATE);
-                    assertThat(notification.getTenantId()).isEqualTo(DEFAULT_TENANT_ID);
-                    assertThat(notification.getDeviceId()).isEqualTo(DEFAULT_DEVICE_ID);
-                    assertThat(notification.getCreationTime()).isNotNull();
-                    assertThat(notification.isEnabled()).isFalse();
+                        assertThat(notificationArgumentCaptor.getAllValues().size()).isEqualTo(1);
+                        final var notification = notificationArgumentCaptor.getValue();
+                        assertThat(notification).isNotNull();
+                        assertThat(notification.getChange()).isEqualTo(LifecycleChange.CREATE);
+                        assertThat(notification.getTenantId()).isEqualTo(DEFAULT_TENANT_ID);
+                        assertThat(notification.getDeviceId()).isEqualTo(DEFAULT_DEVICE_ID);
+                        assertThat(notification.getCreationTime()).isNotNull();
+                        assertThat(notification.isEnabled()).isFalse();
+                    });
                     context.completeNow();
-                })));
+                }));
     }
 
     /**
@@ -106,21 +106,29 @@ public class AbstractDeviceManagementServiceTest {
      */
     @Test
     public void testNotificationOnUpdateDevice(final VertxTestContext context) {
+        final var notificationArgumentCaptor = ArgumentCaptor.forClass(DeviceChangeNotification.class);
         deviceManagementService
                 .createDevice(DEFAULT_TENANT_ID, Optional.of(DEFAULT_DEVICE_ID), new Device(), SPAN)
                 .compose(result -> deviceManagementService.updateDevice(DEFAULT_TENANT_ID, DEFAULT_DEVICE_ID,
                         new Device().setEnabled(false), Optional.empty(), SPAN))
-                .onComplete(context.succeeding(result -> context.verify(() -> {
-                    verify(notificationSender, times(2)).publish(notificationArgumentCaptor.capture());
+                .onComplete(context.succeeding(result -> {
+                    context.verify(() -> {
+                        verify(eventBus, times(2)).publish(
+                                eq(NotificationEventBusSupport.getEventBusAddress(DeviceChangeNotification.TYPE)),
+                                notificationArgumentCaptor.capture(),
+                                any());
 
-                    final var notification = (DeviceChangeNotification) notificationArgumentCaptor.getValue();
-                    assertThat(notification.getChange()).isEqualTo(LifecycleChange.UPDATE);
-                    assertThat(notification.getTenantId()).isEqualTo(DEFAULT_TENANT_ID);
-                    assertThat(notification.getDeviceId()).isEqualTo(DEFAULT_DEVICE_ID);
-                    assertThat(notification.getCreationTime()).isNotNull();
-                    assertThat(notification.isEnabled()).isFalse();
+                        assertThat(notificationArgumentCaptor.getAllValues().size()).isEqualTo(2);
+                        final var notification = notificationArgumentCaptor.getValue();
+                        assertThat(notification).isNotNull();
+                        assertThat(notification.getChange()).isEqualTo(LifecycleChange.UPDATE);
+                        assertThat(notification.getTenantId()).isEqualTo(DEFAULT_TENANT_ID);
+                        assertThat(notification.getDeviceId()).isEqualTo(DEFAULT_DEVICE_ID);
+                        assertThat(notification.getCreationTime()).isNotNull();
+                        assertThat(notification.isEnabled()).isFalse();
+                    });
                     context.completeNow();
-                })));
+                }));
     }
 
     /**
@@ -131,21 +139,29 @@ public class AbstractDeviceManagementServiceTest {
      */
     @Test
     public void testNotificationOnDeleteDevice(final VertxTestContext context) {
+        final var notificationArgumentCaptor = ArgumentCaptor.forClass(DeviceChangeNotification.class);
         deviceManagementService
                 .createDevice(DEFAULT_TENANT_ID, Optional.of(DEFAULT_DEVICE_ID), new Device(), SPAN)
                 .compose(result -> deviceManagementService.deleteDevice(DEFAULT_TENANT_ID, DEFAULT_DEVICE_ID,
                         Optional.empty(), SPAN))
-                .onComplete(context.succeeding(result -> context.verify(() -> {
-                    verify(notificationSender, times(2)).publish(notificationArgumentCaptor.capture());
+                .onComplete(context.succeeding(result -> {
+                    context.verify(() -> {
+                        verify(eventBus, times(2)).publish(
+                                eq(NotificationEventBusSupport.getEventBusAddress(DeviceChangeNotification.TYPE)),
+                                notificationArgumentCaptor.capture(),
+                                any());
 
-                    final var notification = (DeviceChangeNotification) notificationArgumentCaptor.getValue();
-                    assertThat(notification.getChange()).isEqualTo(LifecycleChange.DELETE);
-                    assertThat(notification.getTenantId()).isEqualTo(DEFAULT_TENANT_ID);
-                    assertThat(notification.getDeviceId()).isEqualTo(DEFAULT_DEVICE_ID);
-                    assertThat(notification.getCreationTime()).isNotNull();
-                    assertThat(notification.isEnabled()).isFalse();
+                        assertThat(notificationArgumentCaptor.getAllValues().size()).isEqualTo(2);
+                        final var notification = notificationArgumentCaptor.getValue();
+                        assertThat(notification).isNotNull();
+                        assertThat(notification.getChange()).isEqualTo(LifecycleChange.DELETE);
+                        assertThat(notification.getTenantId()).isEqualTo(DEFAULT_TENANT_ID);
+                        assertThat(notification.getDeviceId()).isEqualTo(DEFAULT_DEVICE_ID);
+                        assertThat(notification.getCreationTime()).isNotNull();
+                        assertThat(notification.isEnabled()).isFalse();
+                    });
                     context.completeNow();
-                })));
+                }));
     }
 
     /**
@@ -156,20 +172,32 @@ public class AbstractDeviceManagementServiceTest {
      */
     @Test
     public void testNotificationOnDeleteDevicesOfTenant(final VertxTestContext context) {
+        final var notificationArgumentCaptor = ArgumentCaptor.forClass(AllDevicesOfTenantDeletedNotification.class);
         deviceManagementService
                 .createDevice(DEFAULT_TENANT_ID, Optional.of(DEFAULT_DEVICE_ID), new Device(), SPAN)
                 .compose(result -> deviceManagementService.deleteDevicesOfTenant(DEFAULT_TENANT_ID, SPAN))
-                .onComplete(context.succeeding(result -> context.verify(() -> {
-                    verify(notificationSender, times(2)).publish(notificationArgumentCaptor.capture());
+                .onComplete(context.succeeding(result -> {
+                    context.verify(() -> {
+                        verify(eventBus).publish(
+                                eq(NotificationEventBusSupport.getEventBusAddress(AllDevicesOfTenantDeletedNotification.TYPE)),
+                                notificationArgumentCaptor.capture(),
+                                any());
 
-                    final var notification = (AllDevicesOfTenantDeletedNotification) notificationArgumentCaptor.getValue();
-                    assertThat(notification.getTenantId()).isEqualTo(DEFAULT_TENANT_ID);
-                    assertThat(notification.getCreationTime()).isNotNull();
+                        assertThat(notificationArgumentCaptor.getAllValues().size()).isEqualTo(1);
+                        final var notification = notificationArgumentCaptor.getValue();
+                        assertThat(notification).isNotNull();
+                        assertThat(notification.getTenantId()).isEqualTo(DEFAULT_TENANT_ID);
+                        assertThat(notification.getCreationTime()).isNotNull();
+                    });
                     context.completeNow();
-                })));
+                }));
     }
 
     private static class TestDeviceManagementService extends AbstractDeviceManagementService {
+
+        TestDeviceManagementService(final Vertx vertx) {
+            super(vertx);
+        }
 
         @Override
         protected Future<OperationResult<Id>> processCreateDevice(final DeviceKey key, final Device device,

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantService.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -64,7 +64,6 @@ public final class FileBasedTenantService extends AbstractTenantManagementServic
 
     // <ID, tenant>
     private final ConcurrentMap<String, Versioned<Tenant>> tenants = new ConcurrentHashMap<>();
-    private final Vertx vertx;
 
     private AtomicBoolean running = new AtomicBoolean(false);
     private AtomicBoolean dirty = new AtomicBoolean(false);
@@ -78,7 +77,7 @@ public final class FileBasedTenantService extends AbstractTenantManagementServic
      */
     @Autowired
     public FileBasedTenantService(final Vertx vertx) {
-        this.vertx = Objects.requireNonNull(vertx);
+        super(vertx);
     }
 
     /**
@@ -388,9 +387,6 @@ public final class FileBasedTenantService extends AbstractTenantManagementServic
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Future<OperationResult<Id>> processCreateTenant(
             final String tenantId,
@@ -440,9 +436,6 @@ public final class FileBasedTenantService extends AbstractTenantManagementServic
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Future<OperationResult<Void>> processUpdateTenant(
             final String tenantId,

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/DeviceManagementServiceImpl.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/DeviceManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -30,6 +30,7 @@ import org.eclipse.hono.util.CacheDirective;
 
 import io.opentracing.Span;
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 
 /**
  * Implementation of the <em>device management service</em>.
@@ -43,10 +44,12 @@ public class DeviceManagementServiceImpl extends AbstractDeviceManagementService
     /**
      * Create a new instance.
      *
+     * @param vertx The vert.x instance to use.
      * @param store The backing store to use.
      * @param properties The service properties.
      */
-    public DeviceManagementServiceImpl(final TableManagementStore store, final DeviceServiceProperties properties) {
+    public DeviceManagementServiceImpl(final Vertx vertx, final TableManagementStore store, final DeviceServiceProperties properties) {
+        super(vertx);
         this.store = store;
         this.ttl = Optional.of(CacheDirective.maxAgeDirective(properties.getRegistrationTtl()));
         this.config = properties;

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/TenantManagementServiceImpl.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/TenantManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -26,6 +26,7 @@ import org.eclipse.hono.service.management.tenant.Tenant;
 
 import io.opentracing.Span;
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 
 /**
  * Implementation of a <em>Tenant management service</em>.
@@ -37,15 +38,14 @@ public class TenantManagementServiceImpl extends AbstractTenantManagementService
     /**
      * Create a new instance.
      *
+     * @param vertx The vert.x instance to use.
      * @param store The backing store to use.
      */
-    public TenantManagementServiceImpl(final ManagementStore store) {
+    public TenantManagementServiceImpl(final Vertx vertx, final ManagementStore store) {
+        super(vertx);
         this.store = store;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Future<OperationResult<Id>> processCreateTenant(
             final String tenantId,
@@ -87,9 +87,6 @@ public class TenantManagementServiceImpl extends AbstractTenantManagementService
 
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Future<OperationResult<Void>> processUpdateTenant(final String tenantId, final Tenant tenantObj,
             final Optional<String> resourceVersion, final Span span) {

--- a/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/AbstractJdbcRegistryTest.java
+++ b/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/AbstractJdbcRegistryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -127,6 +127,7 @@ abstract class AbstractJdbcRegistryTest {
                 properties
         );
         this.registrationManagement = new DeviceManagementServiceImpl(
+                vertx,
                 DeviceStores.managementStoreFactory().createTable(vertx, TRACER, jdbc, Optional.empty(), Optional.empty(), Optional.empty()),
                 properties
         );
@@ -229,7 +230,7 @@ abstract class AbstractJdbcRegistryTest {
         );
 
         this.tenantManagement = new TenantManagementServiceImpl(
-                Stores.managementStore(vertx, TRACER, jdbc)
+                vertx, Stores.managementStore(vertx, TRACER, jdbc)
         );
     }
 

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/Application.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/Application.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,16 +15,19 @@ package org.eclipse.hono.deviceregistry.mongodb;
 
 import java.util.Objects;
 
+import org.eclipse.hono.notification.NotificationSender;
 import org.eclipse.hono.service.AbstractServiceBase;
 import org.eclipse.hono.service.HealthCheckProvider;
 import org.eclipse.hono.service.auth.AuthenticationService;
 import org.eclipse.hono.service.spring.AbstractApplication;
+import org.eclipse.hono.util.WrappedLifecycleComponentVerticle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Verticle;
@@ -42,6 +45,7 @@ import io.vertx.core.Verticle;
 public class Application extends AbstractApplication {
 
     private AuthenticationService authService;
+    private NotificationSender notificationSender;
 
     /**
      * Starts the Device Registry Server.
@@ -69,14 +73,26 @@ public class Application extends AbstractApplication {
     }
 
     /**
+     * Sets the notification sender to use.
+     *
+     * @param notificationSender The notification sender.
+     * @throws NullPointerException if notificationSender is {@code null}.
+     */
+    @Autowired
+    public void setNotificationSender(final NotificationSender notificationSender) {
+        this.notificationSender = Objects.requireNonNull(notificationSender);
+    }
+
+    /**
      * {@inheritDoc}
      * <p>
-     * Deploys a single instance of the authentication service.
+     * Deploys a single instance of the authentication service and the notification sender verticle.
      */
     @Override
     protected Future<Void> deployRequiredVerticles(final int maxInstances) {
-
-        return deployVerticle(authService)
+        return CompositeFuture
+                .all(deployVerticle(authService),
+                        deployVerticle(new WrappedLifecycleComponentVerticle(notificationSender)))
                 .onSuccess(id -> registerHealthCheckProvider(authService))
                 .mapEmpty();
     }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedDeviceManagementService.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedDeviceManagementService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -38,6 +38,7 @@ import org.eclipse.hono.tracing.TracingHelper;
 
 import io.opentracing.Span;
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 
 /**
  * A device management service that uses a Mongo DB for persisting data.
@@ -57,16 +58,18 @@ public final class MongoDbBasedDeviceManagementService extends AbstractDeviceMan
     /**
      * Creates a new service for configuration properties.
      *
+     * @param vertx The vert.x instance to use.
      * @param deviceDao The data access object to use for accessing device data in the MongoDB.
      * @param credentialsDao The data access object to use for accessing credentials data in the MongoDB.
      * @param config The properties for configuring this service.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     public MongoDbBasedDeviceManagementService(
+            final Vertx vertx,
             final DeviceDao deviceDao,
             final CredentialsDao credentialsDao,
             final MongoDbBasedRegistrationConfigProperties config) {
-
+        super(vertx);
         Objects.requireNonNull(deviceDao);
         Objects.requireNonNull(credentialsDao);
         Objects.requireNonNull(config);
@@ -76,9 +79,6 @@ public final class MongoDbBasedDeviceManagementService extends AbstractDeviceMan
         this.config = config;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Future<OperationResult<Id>> processCreateDevice(
             final DeviceKey key,
@@ -121,9 +121,6 @@ public final class MongoDbBasedDeviceManagementService extends AbstractDeviceMan
                             Optional.of(deviceResourceVersion)));
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Future<OperationResult<Device>> processReadDevice(final DeviceKey key, final Span span) {
 
@@ -158,9 +155,6 @@ public final class MongoDbBasedDeviceManagementService extends AbstractDeviceMan
                         Optional.empty()));
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Future<OperationResult<Id>> processUpdateDevice(
             final DeviceKey key,

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedTenantManagementService.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedTenantManagementService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -34,6 +34,7 @@ import org.eclipse.hono.service.management.tenant.TenantWithId;
 
 import io.opentracing.Span;
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 
 /**
  * A tenant management service that persists data in a MongoDB collection.
@@ -48,14 +49,16 @@ public final class MongoDbBasedTenantManagementService extends AbstractTenantMan
     /**
      * Creates a new service for configuration properties.
      *
+     * @param vertx The vert.x instance to use.
      * @param tenantDao The data access object to use for accessing data in the MongoDB.
      * @param config The properties for configuring this service.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     public MongoDbBasedTenantManagementService(
+            final Vertx vertx,
             final TenantDao tenantDao,
             final MongoDbBasedTenantsConfigProperties config) {
-
+        super(vertx);
         Objects.requireNonNull(tenantDao);
         Objects.requireNonNull(config);
 
@@ -63,9 +66,6 @@ public final class MongoDbBasedTenantManagementService extends AbstractTenantMan
         this.config = config;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Future<OperationResult<Id>> processCreateTenant(
             final String tenantId,
@@ -101,9 +101,6 @@ public final class MongoDbBasedTenantManagementService extends AbstractTenantMan
                         Optional.ofNullable(dto.getVersion())));
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Future<OperationResult<Void>> processUpdateTenant(
             final String tenantId,

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDBBasedDeviceManagementSearchDevicesTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDBBasedDeviceManagementSearchDevicesTest.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -64,7 +64,7 @@ public final class MongoDBBasedDeviceManagementSearchDevicesTest implements Abst
         vertx = Vertx.vertx();
         dao = MongoDbTestUtils.getDeviceDao(vertx, DB_NAME);
         credentialsDao = MongoDbTestUtils.getCredentialsDao(vertx, DB_NAME);
-        service = new MongoDbBasedDeviceManagementService(dao, credentialsDao, config);
+        service = new MongoDbBasedDeviceManagementService(vertx, dao, credentialsDao, config);
         CompositeFuture.all(dao.createIndices(), credentialsDao.createIndices()).onComplete(testContext.succeedingThenComplete());
     }
 

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDBBasedTenantManagementSearchTenantsTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDBBasedTenantManagementSearchTenantsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -58,7 +58,7 @@ public class MongoDBBasedTenantManagementSearchTenantsTest implements AbstractTe
     public void setup(final VertxTestContext testContext) {
         vertx = Vertx.vertx();
         dao = MongoDbTestUtils.getTenantDao(vertx, "hono-search-tenants-test");
-        tenantManagementService = new MongoDbBasedTenantManagementService(dao, config);
+        tenantManagementService = new MongoDbBasedTenantManagementService(vertx, dao, config);
         dao.createIndices().onComplete(testContext.succeedingThenComplete());
     }
 

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialServiceTest.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -110,6 +110,7 @@ public class MongoDbBasedCredentialServiceTest implements CredentialsServiceTest
 
         deviceDao = MongoDbTestUtils.getDeviceDao(vertx, DB_NAME);
         deviceManagementService = new MongoDbBasedDeviceManagementService(
+                vertx,
                 deviceDao,
                 credentialsDao,
                 registrationServiceConfig);

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationServiceTest.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -94,7 +94,7 @@ public class MongoDbBasedRegistrationServiceTest implements AbstractRegistration
         vertx = Vertx.vertx();
         deviceDao = MongoDbTestUtils.getDeviceDao(vertx, DB_NAME);
         credentialsDao = MongoDbTestUtils.getCredentialsDao(vertx, DB_NAME);
-        deviceManagementService = new MongoDbBasedDeviceManagementService(deviceDao, credentialsDao, config);
+        deviceManagementService = new MongoDbBasedDeviceManagementService(vertx, deviceDao, credentialsDao, config);
 
         final EdgeDeviceAutoProvisioner edgeDeviceAutoProvisioner = new EdgeDeviceAutoProvisioner(
                 vertx,

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedTenantServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedTenantServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -62,7 +62,7 @@ public class MongoDbBasedTenantServiceTest implements AbstractTenantServiceTest 
         vertx = Vertx.vertx();
         dao = MongoDbTestUtils.getTenantDao(vertx, "hono-tenants-test");
         tenantService = new MongoDbBasedTenantService(dao, config);
-        tenantManagementService = new MongoDbBasedTenantManagementService(dao, config);
+        tenantManagementService = new MongoDbBasedTenantManagementService(vertx, dao, config);
         dao.createIndices().onComplete(testContext.succeedingThenComplete());
     }
 


### PR DESCRIPTION
2nd refactoring in preparation for #3017, following #3033:
Device Registry notifications are first sent on the vert.x event bus in the device registry, to be then handled by the NotificationSender, publishing them to Kafka or the AMQP messaging system.

Having the notifications on the event bus makes it easier to let them be handled in other places in the device registry, e.g. in the Kafka producers for sending auto-provisioning events (#3017).