### PR TITLE
[#2888] Adapt Kafka producer default timeout values

### DIFF
--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/MessagingKafkaProducerConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/MessagingKafkaProducerConfigProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -23,10 +23,10 @@ import io.vertx.kafka.client.serialization.BufferSerializer;
 
 /**
  * Configuration properties for Kafka producers used for Hono's messaging.
- *
+ * <p>
  * Record keys will be serialized with {@link StringSerializer}, the values with {@link BufferSerializer}.
- *
- * The properties that are required by Hono's messaging APIs are will be set in
+ * <p>
+ * The properties that are required by Hono's messaging APIs are set in
  * {@link MessagingKafkaProducerConfigProperties#adaptConfiguration(Map)}.
  *
  * @see <a href="https://kafka.apache.org/documentation/#producerconfigs">Kafka Producer Configs</a>
@@ -36,6 +36,19 @@ import io.vertx.kafka.client.serialization.BufferSerializer;
  */
 // When renaming or moving this class, please update it in the documentation
 public class MessagingKafkaProducerConfigProperties extends KafkaProducerConfigProperties {
+
+    /**
+     * Default value for the {@value ProducerConfig#DELIVERY_TIMEOUT_MS_CONFIG} config property.
+     */
+    public static final String DEFAULT_DELIVERY_TIMEOUT_MS = "2500";
+    /**
+     * Default value for the {@value ProducerConfig#REQUEST_TIMEOUT_MS_CONFIG} config property.
+     */
+    public static final String DEFAULT_REQUEST_TIMEOUT_MS = "750";
+    /**
+     * Default value for the {@value ProducerConfig#MAX_BLOCK_MS_CONFIG} config property.
+     */
+    public static final String DEFAULT_MAX_BLOCK_MS = "500";
 
     /**
      * Creates an instance.
@@ -56,19 +69,20 @@ public class MessagingKafkaProducerConfigProperties extends KafkaProducerConfigP
     }
 
     /**
-     * Sets the required properties.
-     *
-     * The following properties are set here to the given configuration:
-     * <ul>
-     * <li>{@code enable.idempotence=true}: enables idempotent producer behavior</li>
-     * </ul>
-     *
-     * @see <a href="https://kafka.apache.org/documentation/#enable.idempotence">The Kafka documentation -
-     *      "Producer Configs" - enable.idempotence</a>
+     * Adapts the given configuration, setting required and default values.
+     * <p>
+     * {@value ProducerConfig#ENABLE_IDEMPOTENCE_CONFIG} is always set to {@code true}, default values
+     * are applied for selected timeout properties.
      */
     @Override
     protected final void adaptConfiguration(final Map<String, String> config) {
+        // set properties with required values
         overrideConfigProperty(config, ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
+
+        // set default values
+        config.putIfAbsent(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, DEFAULT_DELIVERY_TIMEOUT_MS);
+        config.putIfAbsent(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, DEFAULT_REQUEST_TIMEOUT_MS);
+        config.putIfAbsent(ProducerConfig.MAX_BLOCK_MS_CONFIG, DEFAULT_MAX_BLOCK_MS);
     }
 
 }

--- a/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/kafka/NotificationKafkaProducerConfigProperties.java
+++ b/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/kafka/NotificationKafkaProducerConfigProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -25,10 +25,23 @@ import io.vertx.kafka.client.serialization.JsonObjectSerializer;
 
 /**
  * Configuration properties for Kafka producers used for Hono's notifications.
- *
+ * <p>
  * Record keys will be serialized with {@link StringSerializer}, the values with {@link JsonObjectSerializer}.
  */
 public class NotificationKafkaProducerConfigProperties extends KafkaProducerConfigProperties {
+
+    /**
+     * Default value for the {@value ProducerConfig#DELIVERY_TIMEOUT_MS_CONFIG} config property.
+     */
+    public static final String DEFAULT_DELIVERY_TIMEOUT_MS = "2500";
+    /**
+     * Default value for the {@value ProducerConfig#REQUEST_TIMEOUT_MS_CONFIG} config property.
+     */
+    public static final String DEFAULT_REQUEST_TIMEOUT_MS = "750";
+    /**
+     * Default value for the {@value ProducerConfig#MAX_BLOCK_MS_CONFIG} config property.
+     */
+    public static final String DEFAULT_MAX_BLOCK_MS = "500";
 
     /**
      * Creates an instance.
@@ -49,19 +62,20 @@ public class NotificationKafkaProducerConfigProperties extends KafkaProducerConf
     }
 
     /**
-     * Sets the required properties.
-     *
-     * The following properties are set here to the given configuration:
-     * <ul>
-     * <li>{@code enable.idempotence=true}: enables idempotent producer behavior</li>
-     * </ul>
-     *
-     * @see <a href="https://kafka.apache.org/documentation/#enable.idempotence">The Kafka documentation -
-     *      "Producer Configs" - enable.idempotence</a>
+     * Adapts the given configuration, setting required and default values.
+     * <p>
+     * {@value ProducerConfig#ENABLE_IDEMPOTENCE_CONFIG} is always set to {@code true}, default values
+     * are applied for selected timeout properties.
      */
     @Override
     protected final void adaptConfiguration(final Map<String, String> config) {
+        // set properties with required values
         overrideConfigProperty(config, ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
+
+        // set default values
+        config.putIfAbsent(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, DEFAULT_DELIVERY_TIMEOUT_MS);
+        config.putIfAbsent(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, DEFAULT_REQUEST_TIMEOUT_MS);
+        config.putIfAbsent(ProducerConfig.MAX_BLOCK_MS_CONFIG, DEFAULT_MAX_BLOCK_MS);
     }
 
 }

--- a/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
+++ b/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
@@ -65,6 +65,14 @@ where `${PROPERTY}` respectively `${property}` is any of the Kafka client's
 and `${CLIENTNAME}` respectively `${clientName}` is the name of the client to be configured, as documented in the
 component's admin guide.
 
+The following default properties are used, differing from the Kafka client defaults:
+
+| Property Name         | Value  |
+|:----------------------|:-------|
+| `delivery.timeout.ms` | `2500` |
+| `request.timeout.ms`  | `750`  |
+| `max.block.ms`        | `500`  |
+
 The following properties can _not_ be set because
 `org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties` uses fixed values instead in order to
 implement the message delivery semantics defined by Hono's Telemetry and Event APIs.


### PR DESCRIPTION
This fixes #2888:

Setting these Kafka producer defaults:
```
      delivery.timeout.ms: 2500
      request.timeout.ms: 750
      max.block.ms: 500
```
This means the overall timeout for sending messages (e.g. telemetry/event) is 3s (max.block.ms + delivery.timeout.ms).
Each request has a timeout of 750ms, allowing for 3 retries.
See [KIP-91](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=66851583).