### PR TITLE
[#3017] Remove producer metrics when tenant is deleted

### DIFF
--- a/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
+++ b/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
@@ -331,11 +331,12 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
             final KafkaProducerFactory<String, Buffer> factory = CachingKafkaProducerFactory.sharedFactory(vertx);
             factory.setMetricsSupport(kafkaClientMetricsSupport);
 
-            telemetrySenderProvider.setClient(new KafkaBasedTelemetrySender(factory, kafkaTelemetryConfig,
+            telemetrySenderProvider.setClient(new KafkaBasedTelemetrySender(vertx, factory, kafkaTelemetryConfig,
                     protocolAdapterProperties.isDefaultsEnabled(), tracer));
-            eventSenderProvider.setClient(new KafkaBasedEventSender(factory, kafkaEventConfig,
+            eventSenderProvider.setClient(new KafkaBasedEventSender(vertx, factory, kafkaEventConfig,
                     protocolAdapterProperties.isDefaultsEnabled(), tracer));
             commandResponseSenderProvider.setClient(new KafkaBasedCommandResponseSender(
+                    vertx,
                     factory,
                     kafkaCommandResponseConfig,
                     tracer));

--- a/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractMessagingClientConfig.java
+++ b/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractMessagingClientConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -87,14 +87,20 @@ public abstract class AbstractMessagingClientConfig implements ComponentNameProv
             final KafkaProducerFactory<String, Buffer> factory = CachingKafkaProducerFactory.sharedFactory(vertx);
             factory.setMetricsSupport(kafkaClientMetricsSupport);
 
-            telemetrySenderProvider.setClient(new KafkaBasedTelemetrySender(factory, kafkaTelemetryConfig(),
-                    adapterProperties.isDefaultsEnabled(), tracer));
+            telemetrySenderProvider.setClient(new KafkaBasedTelemetrySender(
+                    vertx,
+                    factory,
+                    kafkaTelemetryConfig(),
+                    adapterProperties.isDefaultsEnabled(),
+                    tracer));
             eventSenderProvider.setClient(new KafkaBasedEventSender(
+                    vertx,
                     factory,
                     kafkaEventConfig(),
                     adapterProperties.isDefaultsEnabled(),
                     tracer));
             commandResponseSenderProvider.setClient(new KafkaBasedCommandResponseSender(
+                    vertx,
                     factory,
                     kafkaCommandResponseConfig(),
                     tracer));

--- a/clients/command-kafka/pom.xml
+++ b/clients/command-kafka/pom.xml
@@ -44,6 +44,10 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-notification</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-client-registry</artifactId>
     </dependency>
     <dependency>

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSender.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSender.java
@@ -14,14 +14,19 @@ package org.eclipse.hono.client.command.kafka;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import org.eclipse.hono.client.command.CommandResponse;
 import org.eclipse.hono.client.command.CommandResponseSender;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.producer.AbstractKafkaBasedMessageSender;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.KafkaProducerHelper;
 import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.client.util.DownstreamMessageProperties;
+import org.eclipse.hono.notification.NotificationEventBusSupport;
+import org.eclipse.hono.notification.deviceregistry.LifecycleChange;
+import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistrationAssertion;
@@ -31,7 +36,9 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.kafka.client.producer.KafkaProducer;
 
 /**
  * A Kafka based client for sending command response messages downstream via a Kafka cluster.
@@ -43,16 +50,31 @@ public class KafkaBasedCommandResponseSender extends AbstractKafkaBasedMessageSe
     /**
      * Creates a new Kafka-based command response sender.
      *
+     * @param vertx The vert.x instance to use.
      * @param producerFactory The factory to use for creating Kafka producers.
      * @param producerConfig The Kafka producer configuration properties to use.
      * @param tracer The OpenTracing tracer.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     public KafkaBasedCommandResponseSender(
+            final Vertx vertx,
             final KafkaProducerFactory<String, Buffer> producerFactory,
             final MessagingKafkaProducerConfigProperties producerConfig,
             final Tracer tracer) {
         super(producerFactory, CommandConstants.COMMAND_RESPONSE_ENDPOINT, producerConfig, tracer);
+
+        NotificationEventBusSupport.registerConsumer(vertx, TenantChangeNotification.TYPE,
+                notification -> {
+                    if (LifecycleChange.DELETE.equals(notification.getChange())) {
+                        producerFactory.getProducer(CommandConstants.COMMAND_RESPONSE_ENDPOINT)
+                                .ifPresent(producer -> removeTenantTopicBasedProducerMetrics(producer, notification.getTenantId()));
+                    }
+                });
+    }
+
+    private void removeTenantTopicBasedProducerMetrics(final KafkaProducer<String, Buffer> producer, final String tenantId) {
+        final HonoTopic topic = new HonoTopic(HonoTopic.Type.COMMAND_RESPONSE, tenantId);
+        KafkaProducerHelper.removeTopicMetrics(producer, Stream.of(topic.toString()));
     }
 
     @Override

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/CachingKafkaProducerFactory.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/CachingKafkaProducerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -207,12 +207,7 @@ public class CachingKafkaProducerFactory<K, V> implements KafkaProducerFactory<K
         };
     }
 
-    /**
-     * Gets an existing producer.
-     *
-     * @param producerName The name to look up the producer.
-     * @return The producer or {@code null} if the cache does not contain the name.
-     */
+    @Override
     public Optional<KafkaProducer<K, V>> getProducer(final String producerName) {
         return Optional.ofNullable(activeProducers.get(producerName));
     }

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/KafkaProducerFactory.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/KafkaProducerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,6 +14,7 @@
 package org.eclipse.hono.client.kafka.producer;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.eclipse.hono.client.kafka.metrics.KafkaClientMetricsSupport;
@@ -32,6 +33,14 @@ import io.vertx.kafka.client.producer.KafkaProducer;
  * @param <V> The type for the record value serialization.
  */
 public interface KafkaProducerFactory<K, V> {
+
+    /**
+     * Gets an existing producer for sending data to Kafka, if one was already created with the given producer name.
+     *
+     * @param producerName The name to identify the producer.
+     * @return An existing producer or an empty Optional if no such producer exists.
+     */
+    Optional<KafkaProducer<K, V>> getProducer(String producerName);
 
     /**
      * Gets a producer for sending data to Kafka.

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/KafkaProducerHelper.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/KafkaProducerHelper.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka.producer;
+
+import java.lang.reflect.Field;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.metrics.Metrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.kafka.client.producer.KafkaProducer;
+
+/**
+ * Utility methods for working with Kafka Producers.
+ */
+public final class KafkaProducerHelper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaProducerHelper.class);
+
+    private KafkaProducerHelper() {
+    }
+
+    /**
+     * Removes topic-related metrics in the given Kafka producer.
+     *
+     * @param kafkaProducer The Kafka producer to use.
+     * @param topics The topics for which to remove the metrics.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public static void removeTopicMetrics(final KafkaProducer<?, ?> kafkaProducer, final Stream<String> topics) {
+        Objects.requireNonNull(kafkaProducer);
+        Objects.requireNonNull(topics);
+        final Metrics metrics = getInternalMetricsObject(kafkaProducer.unwrap());
+        if (metrics != null) {
+            topics.forEach(topic -> {
+                metrics.removeSensor("topic." + topic + ".records-per-batch");
+                metrics.removeSensor("topic." + topic + ".bytes");
+                metrics.removeSensor("topic." + topic + ".compression-rate");
+                metrics.removeSensor("topic." + topic + ".record-retries");
+                metrics.removeSensor("topic." + topic + ".record-errors");
+            });
+        }
+    }
+
+    private static Metrics getInternalMetricsObject(final Producer<?, ?> producer) {
+        if (producer instanceof org.apache.kafka.clients.producer.KafkaProducer) {
+            try {
+                final Field field = org.apache.kafka.clients.producer.KafkaProducer.class.getDeclaredField("metrics");
+                field.setAccessible(true);
+                return (Metrics) field.get(producer);
+            } catch (final Exception e) {
+                LOG.warn("failed to get metrics object", e);
+            }
+        }
+        return null;
+    }
+}

--- a/clients/telemetry-kafka/pom.xml
+++ b/clients/telemetry-kafka/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021 Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -32,6 +32,10 @@
     <dependency>
       <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-client-telemetry</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-notification</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>

--- a/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/KafkaBasedEventSender.java
+++ b/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/KafkaBasedEventSender.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -29,6 +29,7 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 
 /**
@@ -39,6 +40,7 @@ public class KafkaBasedEventSender extends AbstractKafkaBasedDownstreamSender im
     /**
      * Creates a new Kafka-based event sender.
      *
+     * @param vertx The vert.x instance to use.
      * @param producerFactory The factory to use for creating Kafka producers.
      * @param kafkaProducerConfig The Kafka producer configuration properties to use.
      * @param includeDefaults {@code true} if a device's default properties should be included in messages being sent.
@@ -46,12 +48,18 @@ public class KafkaBasedEventSender extends AbstractKafkaBasedDownstreamSender im
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     public KafkaBasedEventSender(
+            final Vertx vertx,
             final KafkaProducerFactory<String, Buffer> producerFactory,
             final MessagingKafkaProducerConfigProperties kafkaProducerConfig,
             final boolean includeDefaults,
             final Tracer tracer) {
 
-        super(producerFactory, EventConstants.EVENT_ENDPOINT, kafkaProducerConfig, includeDefaults, tracer);
+        super(vertx, producerFactory, EventConstants.EVENT_ENDPOINT, kafkaProducerConfig, includeDefaults, tracer);
+    }
+
+    @Override
+    protected HonoTopic.Type getTopicType() {
+        return HonoTopic.Type.EVENT;
     }
 
     @Override

--- a/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/KafkaBasedTelemetrySender.java
+++ b/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/KafkaBasedTelemetrySender.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -30,6 +30,7 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 
 /**
@@ -40,6 +41,7 @@ public class KafkaBasedTelemetrySender extends AbstractKafkaBasedDownstreamSende
     /**
      * Creates a new Kafka-based telemetry sender.
      *
+     * @param vertx The vert.x instance to use.
      * @param producerFactory The factory to use for creating Kafka producers.
      * @param kafkaProducerConfig The Kafka producer configuration properties to use.
      * @param includeDefaults {@code true} if a device's default properties should be included in messages being sent.
@@ -47,12 +49,18 @@ public class KafkaBasedTelemetrySender extends AbstractKafkaBasedDownstreamSende
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     public KafkaBasedTelemetrySender(
+            final Vertx vertx,
             final KafkaProducerFactory<String, Buffer> producerFactory,
             final MessagingKafkaProducerConfigProperties kafkaProducerConfig,
             final boolean includeDefaults,
             final Tracer tracer) {
 
-        super(producerFactory, TelemetryConstants.TELEMETRY_ENDPOINT, kafkaProducerConfig, includeDefaults, tracer);
+        super(vertx, producerFactory, TelemetryConstants.TELEMETRY_ENDPOINT, kafkaProducerConfig, includeDefaults, tracer);
+    }
+
+    @Override
+    protected HonoTopic.Type getTopicType() {
+        return HonoTopic.Type.TELEMETRY;
     }
 
     @Override

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -128,6 +128,7 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
                 internalCommandProducerConfig,
                 tracer);
         kafkaBasedCommandResponseSender = new KafkaBasedCommandResponseSender(
+                vertx,
                 kafkaProducerFactory,
                 commandResponseProducerConfig,
                 tracer);

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -188,7 +188,7 @@ public class FileBasedServiceConfig {
 
         if (kafkaEventConfig().isConfigured()) {
             final KafkaProducerFactory<String, Buffer> factory = CachingKafkaProducerFactory.sharedFactory(vertx);
-            result.setClient(new KafkaBasedEventSender(factory, kafkaEventConfig(), true, tracer));
+            result.setClient(new KafkaBasedEventSender(vertx, factory, kafkaEventConfig(), true, tracer));
         }
 
         healthCheckServer.registerHealthCheckResources(ServiceClientAdapter.forClient(result));

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
@@ -468,7 +468,7 @@ public class ApplicationConfig {
 
         if (kafkaEventConfig().isConfigured()) {
             final KafkaProducerFactory<String, Buffer> factory = CachingKafkaProducerFactory.sharedFactory(vertx());
-            result.setClient(new KafkaBasedEventSender(factory, kafkaEventConfig(), true, tracer()));
+            result.setClient(new KafkaBasedEventSender(vertx(), factory, kafkaEventConfig(), true, tracer()));
         }
 
         healthCheckServer().registerHealthCheckResources(ServiceClientAdapter.forClient(result));

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
@@ -454,7 +454,7 @@ public class ApplicationConfig {
 
         if (kafkaEventConfig().isConfigured()) {
             final KafkaProducerFactory<String, Buffer> factory = CachingKafkaProducerFactory.sharedFactory(vertx());
-            result.setClient(new KafkaBasedEventSender(factory, kafkaEventConfig(), true, tracer()));
+            result.setClient(new KafkaBasedEventSender(vertx(), factory, kafkaEventConfig(), true, tracer()));
         }
 
         healthCheckServer().registerHealthCheckResources(ServiceClientAdapter.forClient(result));

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -318,6 +318,11 @@
       <artifactId>hono-client-notification-amqp</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-telemetry-kafka</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tests/src/test/java/org/eclipse/hono/tests/client/KafkaBasedEventSenderIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/client/KafkaBasedEventSenderIT.java
@@ -1,0 +1,212 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.tests.client;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.MetricName;
+import org.eclipse.hono.client.kafka.HonoTopic;
+import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
+import org.eclipse.hono.client.telemetry.kafka.KafkaBasedEventSender;
+import org.eclipse.hono.notification.NotificationEventBusSupport;
+import org.eclipse.hono.notification.deviceregistry.LifecycleChange;
+import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
+import org.eclipse.hono.tests.AssumeMessagingSystem;
+import org.eclipse.hono.tests.IntegrationTestSupport;
+import org.eclipse.hono.util.EventConstants;
+import org.eclipse.hono.util.MessagingType;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.noop.NoopTracerFactory;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.kafka.admin.KafkaAdminClient;
+import io.vertx.kafka.admin.NewTopic;
+import io.vertx.kafka.client.producer.KafkaProducer;
+
+/**
+ * Test cases verifying the behavior of {@link KafkaBasedEventSender}.
+ * <p>
+ * To run this on a specific Kafka cluster instance, set the
+ * {@value IntegrationTestSupport#PROPERTY_DOWNSTREAM_BOOTSTRAP_SERVERS} system property,
+ * e.g. <code>-Ddownstream.bootstrap.servers="PLAINTEXT://localhost:9092"</code>.
+ */
+@ExtendWith(VertxExtension.class)
+@AssumeMessagingSystem(type = MessagingType.kafka)
+public class KafkaBasedEventSenderIT {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaBasedEventSenderIT.class);
+
+    private static final short REPLICATION_FACTOR = 1;
+
+    private static Vertx vertx;
+    private static KafkaAdminClient adminClient;
+    private static List<String> topicsToDeleteAfterTests;
+
+    private KafkaBasedEventSender KafkaBasedEventSender;
+    private CachingKafkaProducerFactory<String, Buffer> producerFactory;
+
+    /**
+     * Sets up fixture.
+     */
+    @BeforeAll
+    public static void init() {
+        vertx = Vertx.vertx();
+        topicsToDeleteAfterTests = new ArrayList<>();
+
+        final Map<String, String> adminClientConfig = IntegrationTestSupport.getKafkaAdminClientConfig()
+                .getAdminClientConfig("test");
+        adminClient = KafkaAdminClient.create(vertx, adminClientConfig);
+    }
+
+    /**
+     * Creates the event sender.
+     */
+    @BeforeEach
+    void initProducer() {
+        producerFactory = CachingKafkaProducerFactory.nonSharedFactory(vertx);
+        KafkaBasedEventSender = new KafkaBasedEventSender(vertx, producerFactory,
+                IntegrationTestSupport.getKafkaProducerConfig(), false, NoopTracerFactory.create());
+    }
+
+    /**
+     * Cleans up fixture.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @AfterAll
+    public static void shutDown(final VertxTestContext ctx) {
+        final Promise<Void> topicsDeletedPromise = Promise.promise();
+        adminClient.deleteTopics(topicsToDeleteAfterTests, topicsDeletedPromise);
+        topicsDeletedPromise.future()
+                .recover(thr -> {
+                    LOG.info("error deleting topics", thr);
+                    return Future.succeededFuture();
+                })
+                .onComplete(ar -> {
+                    topicsToDeleteAfterTests.clear();
+                    topicsToDeleteAfterTests = null;
+                    adminClient.close();
+                    adminClient = null;
+                    vertx.close();
+                    vertx = null;
+                })
+                .onComplete(ctx.succeedingThenComplete());
+    }
+
+    /**
+     * Stops the event sender created during the test.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @AfterEach
+    void closeProducer(final VertxTestContext ctx) {
+        if (KafkaBasedEventSender != null) {
+            KafkaBasedEventSender.stop().onComplete(ctx.succeedingThenComplete());
+        }
+    }
+
+    /**
+     * Verifies that the event sender causes topic-specific metrics in its underlying Kafka producer to be removed
+     * when a tenant-deletion notification is sent via the vert.x event bus.
+     *
+     * @param ctx The vert.x text context.
+     * @throws InterruptedException if test execution gets interrupted.
+     */
+    @Test
+    @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+    public void testProducerTopicMetricsGetRemovedOnTenantDeletion(final VertxTestContext ctx) throws InterruptedException {
+
+        final String tenantId = "MetricsRemovalTestTenant";
+        final String tenantTopicName = new HonoTopic(HonoTopic.Type.EVENT, tenantId).toString();
+
+        final VertxTestContext setup = new VertxTestContext();
+        createTopic(tenantTopicName)
+                .compose(v -> KafkaBasedEventSender.start())
+                .compose(v -> sendEvent(tenantId, "myDeviceId", "test"))
+                .onComplete(setup.succeedingThenComplete());
+
+        assertThat(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS)).isTrue();
+        if (setup.failed()) {
+            ctx.failNow(setup.causeOfFailure());
+            return;
+        }
+        // GIVEN a started event sender that has already sent an event message
+        // and the underlying Kafka producer having filled corresponding topic-specific metrics
+        final var producerOptional = producerFactory.getProducer(EventConstants.EVENT_ENDPOINT);
+        ctx.verify(() -> {
+            assertThat(producerOptional.isPresent()).isTrue();
+            assertThat(getTopicRelatedMetrics(producerOptional.get(), tenantTopicName)).isNotEmpty();
+        });
+
+        // WHEN sending a tenant-deleted notification for that tenant
+        NotificationEventBusSupport.sendNotification(vertx,
+                new TenantChangeNotification(LifecycleChange.DELETE, tenantId, Instant.now(), false));
+
+        vertx.runOnContext(v -> {
+            // THEN the metrics of the underlying producer don't contain any metrics regarding that topic
+            ctx.verify(() -> assertThat(getTopicRelatedMetrics(producerOptional.get(), tenantTopicName)).isEmpty());
+            ctx.completeNow();
+        });
+    }
+
+    private List<MetricName> getTopicRelatedMetrics(final KafkaProducer<String, Buffer> kafkaProducer,
+            final String topicName) {
+        return kafkaProducer.unwrap().metrics().keySet().stream()
+                .filter(metricName -> metricName.tags().containsValue(topicName))
+                .collect(Collectors.toList());
+    }
+
+    private Future<Void> sendEvent(final String tenantId, final String deviceId, final String messagePayload) {
+        return KafkaBasedEventSender.sendEvent(TenantObject.from(tenantId), new RegistrationAssertion(deviceId),
+                "text/plain", Buffer.buffer(messagePayload), Map.of(), null);
+    }
+
+    private static Future<Void> createTopic(final String topicName) {
+        return createTopics(List.of(topicName), 1, Map.of());
+    }
+
+    private static Future<Void> createTopics(final Collection<String> topicNames, final int numPartitions,
+            final Map<String, String> topicConfig) {
+        topicsToDeleteAfterTests.addAll(topicNames);
+        final Promise<Void> resultPromise = Promise.promise();
+        final List<NewTopic> topics = topicNames.stream()
+                .map(t -> new NewTopic(t, numPartitions, REPLICATION_FACTOR).setConfig(topicConfig))
+                .collect(Collectors.toList());
+        adminClient.createTopics(topics, resultPromise);
+        return resultPromise.future();
+    }
+}
+


### PR DESCRIPTION
This fixes #3017:
Kafka producer metrics regarding the telemetry, event and command-response topics of a tenant are removed when that
tenant got deleted.