### PR TITLE
Improve documentation of device authentication

### DIFF
--- a/site/documentation/content/user-guide/amqp-adapter.md
+++ b/site/documentation/content/user-guide/amqp-adapter.md
@@ -31,7 +31,7 @@ The username provided in the *authcid* field must match the pattern *auth-id@ten
 The adapter then verifies the provided username and password against the credentials that the
 [configured Credentials service]({{< relref "/admin-guide/common-config#credentials-service-connection-configuration" >}})
 has on record for the client as described in
-[Username/Password based Authentication]({{< relref "/concepts/device-identity#username-password-based-authentication" >}}).
+[Username/Password based Authentication]({{< relref "/concepts/device-identity#usernamepassword-based-authentication" >}}).
 If the credentials match, the client has been authenticated successfully and the SASL handshake is completed.
 
 The examples below refer to devices `4711` and `gw-1` of tenant `DEFAULT_TENANT` using *auth-ids* `sensor1` and `gw1` and
@@ -538,7 +538,7 @@ default value.
 
 ### Event Message Time-to-live
 
-Events published by devices will usually be persisted by the messing infrastructure in order to support deferred
+Events published by devices will usually be persisted by the messaging infrastructure in order to support deferred
 delivery to downstream consumers.
 
 In most cases, the messaging infrastructure can be configured with a maximum *time-to-live* to apply to the events so

--- a/site/documentation/content/user-guide/amqp-adapter.md
+++ b/site/documentation/content/user-guide/amqp-adapter.md
@@ -9,54 +9,51 @@ messages to Eclipse Hono&trade;'s Telemetry, Event and Command & Control endpoin
 
 ## Device Authentication
 
-By default, all Hono protocol adapters require clients (devices or gateway components) to authenticate during connection establishment.
+By default, all Hono protocol adapters require clients (devices or gateway components) to authenticate during
+connection establishment.
 This is the preferred way for devices to publish data via protocol adapters. The AMQP adapter supports both the
-[SASL PLAIN](https://tools.ietf.org/html/rfc4616) and [SASL EXTERNAL](https://tools.ietf.org/html/rfc4422) authentication mechanisms.
-The former uses a *username* and *password* to authenticate to the adapter while the latter uses an X.509 client certificate.
+[SASL PLAIN](https://tools.ietf.org/html/rfc4616) and [SASL EXTERNAL](https://tools.ietf.org/html/rfc4422)
+authentication mechanisms.
 
-This guide provides examples for publishing telemetry and events for *authenticated* (using SASL PLAIN) and *unauthenticated* clients.
+This guide provides examples for publishing telemetry and events for *authenticated* (using SASL PLAIN) and
+*unauthenticated* clients.
 
 **NB** The AMQP adapter can be configured to *allow* unauthenticated devices to connect by setting configuration variable
-`HONO_AMQP_AUTHENTICATION_REQUIRED` to `false`.
+*HONO_AMQP_AUTHENTICATION_REQUIRED* to `false`.
 
 ### SASL PLAIN Authentication
 
-The AMQP adapter supports authenticating clients using a *username* and *password*. This means that clients need to provide a *username* and a *password*
-when connecting to the AMQP adapter. The *username* must match the pattern [*auth-id@tenant*], e.g. `sensor1@DEFAULT_TENANT`.
+The AMQP adapter supports authenticating clients using the SASL PLAIN mechanism. This means that clients need to
+provide a username and a password in the *authcid* and *passwd* fields of their SASL response as defined in
+[RFC 4616, Section 2](https://datatracker.ietf.org/doc/html/rfc4616#section-2) when connecting to the AMQP adapter.
+The username provided in the *authcid* field must match the pattern *auth-id@tenant*, e.g. `sensor1@DEFAULT_TENANT`.
 
-The adapter verifies the credentials provided by the client against the credentials that the
-[configured Credentials service]({{< relref "/admin-guide/common-config#credentials-service-connection-configuration" >}}) has on record for the client.
-If the credentials match, the client device can proceed to publish messages to Hono.
+The adapter then verifies the provided username and password against the credentials that the
+[configured Credentials service]({{< relref "/admin-guide/common-config#credentials-service-connection-configuration" >}})
+has on record for the client as described in
+[Username/Password based Authentication]({{< relref "/concepts/device-identity#username-password-based-authentication" >}}).
+If the credentials match, the client has been authenticated successfully and the SASL handshake is completed.
 
-The examples below refer to devices `4711` and `gw-1` of tenant `DEFAULT_TENANT` using *auth-ids* `sensor1` and `gw1` and corresponding passwords.
-The example deployment as described in the [Deployment Guide]({{< relref "deployment" >}}) comes pre-configured with the corresponding entities in its
-device registry component.
+The examples below refer to devices `4711` and `gw-1` of tenant `DEFAULT_TENANT` using *auth-ids* `sensor1` and `gw1` and
+corresponding passwords. The example deployment as described in the [Deployment Guide]({{< relref "deployment" >}})
+comes pre-configured with the corresponding entities in its device registry component.
 
-**NB** There is a subtle difference between the *device identifier* (*device-id*) and the *auth-id* a device uses for authentication.
-See [Device Identity]({{< relref "/concepts/device-identity.md" >}}) for a discussion of the concepts.
+**NB** There is a subtle difference between the *device identifier* (*device-id*) and the *auth-id* a device uses
+for authentication. See [Device Identity]({{< relref "/concepts/device-identity.md" >}}) for a discussion of the
+concepts.
 
 ### SASL EXTERNAL Authentication
 
-When a device uses a client certificate for authentication, the TLS handshake is initiated during TCP connection establishment.
-If no trust anchor is configured for the AMQP adapter, the TLS handshake will succeed only if the certificate has not yet expired.
-Once the TLS handshake completes and a secure connection is established, the certificate's signature is checked during the SASL handshake.
-To complete the SASL handshake and authenticate the client, the adapter performs the following steps:
-
-1. The adapter extracts the client certificate's *Issuer DN* from the client certificate
-1. The adapter invokes the Tenant service to look up the tenant matching the DN.
-   In order for the lookup to succeed, the tenant’s trust anchor needs to be configured by means of registering the
-   [trusted certificate authority]({{< relref "/api/tenant#trusted-ca-format" >}}).
-1. If the lookup succeeds, the tenant returned by the Tenant service is the tenant that the device belongs to.
-1. The adapter verifies the device’s client certificate's signature using the trust anchor registered for the tenant.
-1. Finally, the adapter authenticates the client certificate using Hono's credentials API. In this step, the adapter
-   uses the client certificate’s *Subject DN* (as authentication identifier) and `x509-cert` (for the credentials type)
-   in order to determine the device ID.
+The AMQP adapter supports authenticating clients using the SASL EXTERNAL mechanism. This mechanism builds on top of
+a successful validation of an X.509 (client) certificate presented by the client during a TLS handshake as described in
+[Client Certificate based Authentication]({{< relref "/concepts/device-identity#client-certificate-based-authentication" >}}).
 
 **NB** The AMQP adapter needs to be configured for TLS in order to support this mechanism.
 
 ## Resource Limit Checks
 
-The adapter performs additional checks regarding resource limits when a client tries to connect and/or send a message to the adapter.
+The adapter performs additional checks regarding resource limits when a client tries to connect and/or send a message
+to the adapter.
 
 ### Connection Limits
 
@@ -70,8 +67,8 @@ Please refer to [resource-limits]({{< ref "/concepts/resource-limits.md" >}}) fo
 ### Connection Duration Limits
 
 The adapter immediately closes a newly established connection with an `amqp:unauthorized-access` error if the
-[connection duration limit]({{< relref "/concepts/resource-limits#connection-duration-limit" >}}) that has been configured for
-the client's tenant is exceeded.
+[connection duration limit]({{< relref "/concepts/resource-limits#connection-duration-limit" >}}) that has been
+configured for the client's tenant is exceeded.
 
 ### Message Limits
 
@@ -82,35 +79,51 @@ The adapter
   * telemetry data or an event uploaded by a client
   * a command sent by a north bound application
 
-if the [message limit]({{< relref "/concepts/resource-limits.md" >}}) that has been configured for the device's tenant is exceeded.
+if the [message limit]({{< relref "/concepts/resource-limits.md" >}}) that has been configured for the device's tenant
+is exceeded.
 
 ## Connection Events
 
-The adapter can emit [Connection Events]({{< relref "/api/event#connection-event" >}}) for client connections being established and/or terminated.
-Please refer to the [common configuration options]({{< relref "/admin-guide/common-config#connection-event-producer-configuration" >}})
+The adapter can emit [Connection Events]({{< relref "/api/event#connection-event" >}}) for client connections being
+established and/or terminated. Please refer to the
+[common configuration options]({{< relref "/admin-guide/common-config#connection-event-producer-configuration" >}})
 for details regarding how to enable this behavior.
 
 The adapter includes the client's AMQP *container-id* as the Connection Event's *remote-id*.
 
 ## Link Establishment
 
-The AMQP adapter supports the [Anonymous Terminus for Message Routing](http://docs.oasis-open.org/amqp/anonterm/v1.0/anonterm-v1.0.html) specification
-and requires clients to create a single sender link using the `null` target address for publishing all types of messages to the AMQP adapter.
+The AMQP adapter supports the
+[Anonymous Terminus for Message Routing](http://docs.oasis-open.org/amqp/anonterm/v1.0/anonterm-v1.0.html) specification
+and requires clients to create a single sender link using the `null` target address for publishing all types of messages
+to the AMQP adapter.
 
-Using *AT MOST ONCE* delivery semantics, the client will not wait for the message to be accepted and settled by the downstream consumer. However, with *AT LEAST ONCE*, the client sends the message and waits for the message to be delivered to and accepted by the downstream consumer. If the message cannot be delivered due to a failure, the client will be notified.
+Using *AT MOST ONCE* delivery semantics, the client will not wait for the message to be accepted and settled by the
+downstream consumer. However, with *AT LEAST ONCE*, the client sends the message and waits for the message to be
+delivered to and accepted by the downstream consumer. If the message cannot be delivered due to a failure, the client
+will be notified.
 
-The client indicates its preferred message delivery mode by means of the *snd-settle-mode* and *rcv-settle-mode* fields of its *attach* frame during link establishment. Clients should use `mixed` as the *snd-settle-mode* and `first` as the *rcv-settle-mode* in order to be able to use the same link for sending all types of messages using different delivery semantics as described in the following sections.
+The client indicates its preferred message delivery mode by means of the *snd-settle-mode* and *rcv-settle-mode*
+fields of its *attach* frame during link establishment. Clients should use `mixed` as the *snd-settle-mode* and `first`
+as the *rcv-settle-mode* in order to be able to use the same link for sending all types of messages using different
+delivery semantics as described in the following sections.
 
 ## Error Handling
 
-The AMQP adapter distinguishes between two types of errors when a message is published using *AT LEAST ONCE* delivery semantics:
+The AMQP adapter distinguishes between two types of errors when a message is published using *AT LEAST ONCE* delivery
+semantics:
 
 * An error caused by the client side, e.g invalid message address, content-type, adapter disabled for tenant etc.
 * An error caused by the server side, e.g no downstream consumers registered, downstream connection loss etc.
 
-For a client side error, the adapter settles the message transfer with the *rejected* outcome and provides an error description in the corresponding disposition frame. In the case of a server-side error, the adapter settles the message with the *released* outcome, indicating to the client that the message itself was OK but it cannot be delivered due to a failure beyond the control of the client. In the latter case, a client may attempt to re-send the message unaltered.
+For a client side error, the adapter settles the message transfer with the *rejected* outcome and provides an error
+description in the corresponding disposition frame. In the case of a server-side error, the adapter settles the
+message with the *released* outcome, indicating to the client that the message itself was OK but it cannot be
+delivered due to a failure beyond the control of the client. In the latter case, a client may attempt to re-send
+the message unaltered.
 
-In case of terminal errors the AMQP connection to the device is closed. The errors that are classified as terminal are listed below.
+In case of terminal errors the AMQP connection to the device is closed. The errors that are classified as terminal
+are listed below.
 
 * The adapter is disabled for the tenant that the client belongs to.
 * The authenticated device or gateway is disabled or not registered.
@@ -118,7 +131,9 @@ In case of terminal errors the AMQP connection to the device is closed. The erro
 
 ## AMQP Command-line Client
 
-For purposes of demonstrating the usage of the AMQP adapter, the **Hono CLI Module** contains an AMQP command-line client for interacting with the AMQP adapter. The client can be used to send telemetry or events and to receive/respond to command request messages.
+For purposes of demonstrating the usage of the AMQP adapter, the **Hono CLI Module** contains an AMQP command-line
+client for interacting with the AMQP adapter. The client can be used to send telemetry or events and to
+receive/respond to command request messages.
 
 The command-line client supports the following parameters (with default values):
 
@@ -126,7 +141,8 @@ The command-line client supports the following parameters (with default values):
 * `--spring.profiles.active=amqp-command`: Profile for receiving and responding to command request messages.
 * `--message.address`: The AMQP 1.0 message address (default: `telemetry`)
 * `--message.payload`: The message payload body (default: `'{"temp": 5}'`)
-* `--hono.client.host`: The host name that the AMQP adapter is running on (default: the address of [Hono Sandbox]({{% homelink "sandbox/" %}}))
+* `--hono.client.host`: The host name that the AMQP adapter is running on (default: the address of
+  [Hono Sandbox]({{% homelink "sandbox/" %}}))
 * `--hono.client.port`: The port that the adapter is listening for incoming connections (default: `5672`)
 
 To run the client to send a telemetry message to Hono, open a terminal and execute the following:
@@ -138,36 +154,41 @@ java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-send --hono.client.u
 Accepted{}
 ~~~
 
-The client prints the outcome of the operation to standard out. The outcome above (`Accepted`) indicates that the request to upload the data has succeeded.
+The client prints the outcome of the operation to standard out. The outcome above (`Accepted`) indicates that the request
+to upload the data has succeeded.
 
 **NB**
-There are two JAR files in the hono/cli/target directory. The JAR to use for the client is the `hono-cli-$VERSION-exec.jar` and not the `hono-cli-$VERSION.jar` file. Running the latter will not work and will output the message: `no main manifest attribute, in hono-cli-$VERSION.jar`
+There are two JAR files in the hono/cli/target directory. The JAR to use for the client is the `hono-cli-$VERSION-exec.jar`
+and not the `hono-cli-$VERSION.jar` file. Running the latter will not work and will output the message:
+`no main manifest attribute, in hono-cli-$VERSION.jar`
 
 ## Publishing Telemetry Data
 
 The client indicates the delivery mode to use when uploading telemetry messages by means of the *settled* and
-*rcv-settle-mode* properties of the AMQP *transfer* frame(s) it uses for uploading the message.
+*rcv-settle-mode* properties of the AMQP *transfer* frame(s) it uses for uploading a message.
 The AMQP adapter will accept messages using a delivery mode according to the following table:
 
 | settled | rcv-settle-mode | Delivery semantics |
 | :------ | :-------------- | :----------------- |
-| `false` | `first`          | The adapter will forward the message to the downstream AMQP 1.0 Messaging Network and will forward any AMQP *disposition* frame received from the AMQP 1.0 Messaging Network to the client *as is*. It is up to the client's discretion if and how it processes the disposition frame. The adapter will accept any re-delivered message. Sending *unsettled* messages allows for clients to implement either *AT LEAST ONCE* or *AT MOST ONCE* delivery semantics, depending on whether a client actually waits for and considers the disposition frames it receives from the adapter or not. This is the recommended mode for uploading telemetry data. |
-| `true`  | `first`          | The adapter will acknowledge and settle any received message spontaneously before forwarding it to the downstream AMQP 1.0 Messaging Network. The adapter will ignore any AMQP *disposition* frames it receives from the AMQP 1.0 Messaging Network. Sending *pre-settled* messages allows for clients to implement *AT MOST ONCE* delivery semantics only. This is the fastest mode of delivery but has the drawback of less reliable end-to-end flow control and potential loss of messages without notice. |
+| `false`  | `first`          | The adapter will forward the message to the downstream messaging infrastructure configured for the device's tenant.<br>In case of an AMQP 1.0 Messaging Network, the transfer will be settled with the outcome of transferring the message to the Messaging Network.<br>In case of Kafka, the transfer will be settled with outcome `accepted` once the message has been successfully transferred to the Kafka broker. Otherwise, the transfer will be settled with outcome `released`.<br>The adapter will accept any re-delivered message. Sending *unsettled* messages allows for clients to implement either *AT LEAST ONCE* or *AT MOST ONCE* delivery semantics, depending on whether a client actually waits for and considers the disposition frames it receives from the adapter or not. This is the recommended mode for uploading telemetry data. |
+| `true`  | `first`          | The adapter will settle the transfer of the message with the `accepted` outcome before forwarding it to the downstream messaging infrastructure configured for the device's tenant. Sending *pre-settled* messages allows for clients to implement *AT MOST ONCE* delivery semantics only. This is the fastest mode of delivery but has the drawback of less reliable end-to-end flow control and potential loss of messages without notice. |
 
-All other combinations are not supported by the adapter and will result in the message being ignored (pre-settled) or rejected (unsettled).
+All other combinations are not supported by the adapter and will result in the message being ignored (pre-settled)
+or rejected (unsettled).
 
 ## Publish Telemetry Data (authenticated Device)
 
 * Authentication: SASL PLAIN or SASL EXTERNAL
 * Message *properties*:
-  * (required) `to`: either `telemetry` or `t`
-  * (optional) `content-type`: The type of payload contained in the message body. The given content type will be used
+  * (required) *to*: either `telemetry` or `t`
+  * (optional) *content-type*: The type of payload contained in the message body. The given content type will be used
     in the AMQP message being forwarded downstream if not empty. Otherwise, the content type of the downstream
     message will be set to `application/octet-stream` if the payload is not empty and no default content type has been
     defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}}).
 * Message Body:
   * (optional) Arbitrary payload contained in either a single AMQP *Data* or *AmqpValue* section. Note that the adapter
-    only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will be ignored.
+    only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will
+    be ignored.
 * Outcomes:
   * `accepted`: The message has been successfully forwarded downstream.
   * `released`: The message could not be processed by the adapter due to a (temporary) problem that has not been caused
@@ -177,8 +198,8 @@ All other combinations are not supported by the adapter and will result in the m
     be processed. Possible error conditions include:
     * `hono:bad-request`: The message does not meet all formal requirements, e.g. a required property is missing.
     * `amqp:unauthorized-access`: The adapter is not enabled for the tenant that the client belongs to.
-    * `amqp:resource-limit-exceeded`: One of the [Resource Limit Checks]({{< relref "#resource-limit-checks" >}}) has failed for the
-       tenant that the client belongs to.
+    * `amqp:resource-limit-exceeded`: One of the [Resource Limit Checks]({{< relref "#resource-limit-checks" >}}) has
+       failed for the tenant that the client belongs to.
     * `amqp:precondition-failed`: The message does not fulfill certain requirements, e.g adapter cannot assert device registration etc.
 
 When a device publishes data to the `telemetry` address, the AMQP adapter automatically determines the device's identity
@@ -204,14 +225,15 @@ java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-send --hono.client.p
 
 * Authentication: SASL PLAIN or SASL EXTERNAL
 * Message *properties*:
-  * (required) `to`: either `telemetry/${tenant-id}/${device-id}` or `t/${tenant-id}/${device-id}`
-  * (optional) `content-type`: The type of payload contained in the message body. The given content type will be used
+  * (required) *to*: either `telemetry/${tenant-id}/${device-id}` or `t/${tenant-id}/${device-id}`
+  * (optional) *content-type*: The type of payload contained in the message body. The given content type will be used
     in the AMQP message being forwarded downstream if not empty. Otherwise, the content type of the downstream
     message will be set to `application/octet-stream` if the payload is not empty and no default content type has been
     defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}}).
 * Message Body:
   * (optional) Arbitrary payload contained in either a single AMQP *Data* or *AmqpValue* section. Note that the adapter
-    only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will be ignored.
+    only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will
+    be ignored.
 * Outcomes:
   * `accepted`: The message has been successfully forwarded downstream.
   * `released`: The message could not be processed by the adapter due to a (temporary) problem that has not been caused
@@ -221,8 +243,8 @@ java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-send --hono.client.p
     be processed. Possible error conditions include:
     * `hono:bad-request`: The message does not meet all formal requirements, e.g. a required property is missing.
     * `amqp:unauthorized-access`: The adapter is not enabled for the tenant that the client belongs to.
-    * `amqp:resource-limit-exceeded`: One of the [Resource Limit Checks]({{< relref "#resource-limit-checks" >}}) has failed for the
-       tenant that the client belongs to.
+    * `amqp:resource-limit-exceeded`: One of the [Resource Limit Checks]({{< relref "#resource-limit-checks" >}}) has
+       failed for the tenant that the client belongs to.
     * `amqp:precondition-failed`: The message does not fulfill certain requirements, e.g adapter cannot assert device registration etc.
 
 This address format is used by devices that have not authenticated to the protocol adapter. Note that this requires the
@@ -239,18 +261,25 @@ java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-send --message.addre
 
 ## Publish Telemetry Data (authenticated Gateway)
 
-A device that publishes data on behalf of another device is called a gateway device. The message address is used by *gateway* components to publish data *on behalf of* other devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the message address is used to identify the device that the gateway publishes data for.
+A device that publishes data on behalf of another device is called a gateway device. The message address is used by
+*gateway* components to publish data *on behalf of* other devices which do not connect to a protocol adapter directly
+but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like
+[SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the credentials provided by the
+gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the
+message address is used to identify the device that the gateway publishes data for.
 
 **Examples**
 
-A gateway connecting to the adapter using `gw@DEFAULT_TENANT` as username and `gw-secret` as password and then publishing some JSON data for device `4712`:
+A gateway connecting to the adapter using `gw@DEFAULT_TENANT` as username and `gw-secret` as password and then publishing
+some JSON data for device `4712`:
 
 ~~~sh
 # in directory: hono/cli/target/
 java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-send --hono.client.username=gw@DEFAULT_TENANT --hono.client.password=gw-secret --message.address=t/DEFAULT_TENANT/4712
 ~~~
 
-In this example, we are using message address `t/DEFAULT_TENANT/4712` which contains the device that the gateway is publishing the message for.
+In this example, we are using message address `t/DEFAULT_TENANT/4712` which contains the device that the gateway is
+publishing the message for.
 
 ## Publishing Events
 
@@ -262,14 +291,15 @@ All other combinations are not supported by the adapter and result in the messag
 
 * Authentication: SASL PLAIN or SASL EXTERNAL
 * Message *properties*:
-  * (required) `to`: either `event` or `e`
-  * (optional) `content-type`: The type of payload contained in the message body. The given content type will be used
+  * (required) *to*: either `event` or `e`
+  * (optional) *content-type*: The type of payload contained in the message body. The given content type will be used
     in the AMQP message being forwarded downstream if not empty. Otherwise, the content type of the downstream
     message will be set to `application/octet-stream` if the payload is not empty and no default content type has been
     defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}}).
 * Message Body:
   * (optional) Arbitrary payload contained in either a single AMQP *Data* or *AmqpValue* section. Note that the adapter
-    only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will be ignored.
+    only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will
+    be ignored.
 * Outcomes:
   * `accepted`: The message has been successfully forwarded downstream.
   * `released`: The message could not be processed by the adapter due to a (temporary) problem that has not been caused
@@ -279,8 +309,8 @@ All other combinations are not supported by the adapter and result in the messag
     be processed. Possible error conditions include:
     * `hono:bad-request`: The message does not meet all formal requirements, e.g. a required property is missing.
     * `amqp:unauthorized-access`: The adapter is not enabled for the tenant that the client belongs to.
-    * `amqp:resource-limit-exceeded`: One of the [Resource Limit Checks]({{< relref "#resource-limit-checks" >}}) has failed for the
-       tenant that the client belongs to.
+    * `amqp:resource-limit-exceeded`: One of the [Resource Limit Checks]({{< relref "#resource-limit-checks" >}}) has
+       failed for the tenant that the client belongs to.
     * `amqp:precondition-failed`: The message does not fulfill certain requirements, e.g adapter cannot assert device registration etc.
 
 This is the preferred way for devices to publish events. It is available only if the protocol adapter has been
@@ -299,14 +329,15 @@ java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-send --hono.client.u
 
 * Authentication: SASL PLAIN or SASL EXTERNAL
 * Message *properties*:
-  * (required) `to`: either `event/${tenant-id}/${device-id}` or `e/${tenant-id}/${device-id}`
-  * (optional) `content-type`: The type of payload contained in the message body. The given content type will be used
+  * (required) *to*: either `event/${tenant-id}/${device-id}` or `e/${tenant-id}/${device-id}`
+  * (optional) *content-type*: The type of payload contained in the message body. The given content type will be used
     in the AMQP message being forwarded downstream if not empty. Otherwise, the content type of the downstream
     message will be set to `application/octet-stream` if the payload is not empty and no default content type has been
     defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}}).
 * Message Body:
   * (optional) Arbitrary payload contained in either a single AMQP *Data* or *AmqpValue* section. Note that the adapter
-    only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will be ignored.
+    only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will
+    be ignored.
 * Outcomes:
   * `accepted`: The message has been successfully forwarded downstream.
   * `released`: The message could not be processed by the adapter due to a (temporary) problem that has not been caused
@@ -316,8 +347,8 @@ java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-send --hono.client.u
     be processed. Possible error conditions include:
     * `hono:bad-request`: The message does not meet all formal requirements, e.g. a required property is missing.
     * `amqp:unauthorized-access`: The adapter is not enabled for the tenant that the client belongs to.
-    * `amqp:resource-limit-exceeded`: One of the [Resource Limit Checks]({{< relref "#resource-limit-checks" >}}) has failed for the
-       tenant that the client belongs to.
+    * `amqp:resource-limit-exceeded`: One of the [Resource Limit Checks]({{< relref "#resource-limit-checks" >}}) has
+       failed for the tenant that the client belongs to.
     * `amqp:precondition-failed`: The message does not fulfill certain requirements, e.g adapter cannot assert device registration etc.
 
 This address format is used by devices that have not authenticated to the protocol adapter. Note that this requires the
@@ -336,24 +367,38 @@ java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-send --message.addre
 
 **Example**
 
-A gateway connecting to the adapter using `gw@DEFAULT_TENANT` as username and `gw-secret` as password and then publishing some JSON data for device `4712`:
+A gateway connecting to the adapter using `gw@DEFAULT_TENANT` as username and `gw-secret` as password and then publishing
+some JSON data for device `4712`:
 
 ~~~sh
 # in directory: hono/cli/target/
 java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-send --hono.client.username=gw@DEFAULT_TENANT --hono.client.password=gw-secret --message.address=e/DEFAULT_TENANT/4712
 ~~~
 
-In this example, we are using message address `e/DEFAULT_TENANT/4712` which contains the device that the gateway is publishing the message for.
+In this example, we are using message address `e/DEFAULT_TENANT/4712` which contains the device that the gateway is
+publishing the message for.
 
 ## Command & Control
 
-The AMQP adapter enables devices to receive commands that have been sent by business applications by means of opening a receiver link using a device specific *source address* as described below. When a device no longer wants to receive commands anymore, it can simply close the link.
+The AMQP adapter enables devices to receive commands that have been sent by business applications by means of opening
+a receiver link using a device specific *source address* as described below. When a device no longer wants to receive
+commands anymore, it can simply close the link.
 
-When a device has successfully opened a receiver link for commands, the adapter sends an [empty notification]({{< relref "/api/event#empty-notification" >}}) on behalf of the device to the downstream AMQP 1.0 Messaging Network with the *ttd* header set to `-1`, indicating that the device will be ready to receive commands until further notice. Analogously, the adapter sends an empty notification with the *ttd* header set to `0` when a device closes the link or disconnects.
+When a device has successfully opened a receiver link for commands, the adapter sends an
+[empty notification]({{< relref "/api/event#empty-notification" >}}) on behalf of the device to the downstream
+AMQP 1.0 Messaging Network with the *ttd* header set to `-1`, indicating that the device will be ready to receive
+commands until further notice. Analogously, the adapter sends an empty notification with the *ttd* header set to `0`
+when a device closes the link or disconnects.
 
-Devices send their responses to commands by means of sending an AMQP message with properties specific to the command that has been executed. The AMQP adapter accepts responses being published using either *at most once* (QoS 0) or *at least once* (QoS 1) delivery semantics. The device must send the command response messages using the same (sender) link that it uses for sending telemetry data and events.
+Devices send their responses to commands by means of sending an AMQP message with properties specific to the command
+that has been executed. The AMQP adapter accepts responses being published using either *at most once* (QoS 0) or
+*at least once* (QoS 1) delivery semantics. The device must send the command response messages using the same (sender)
+link that it uses for sending telemetry data and events.
 
-The AMQP adapter checks the configured [message limit]({{< relref "/concepts/resource-limits.md" >}}) before accepting any command requests and responses. In case of incoming command requests from business applications or the command responses from devices, if the message limit is exceeded, the Adapter rejects the message with the reason `amqp:resource-limit-exceeded`. 
+The AMQP adapter checks the configured [message limit]({{< relref "/concepts/resource-limits.md" >}}) before accepting
+any command requests and responses. In case of incoming command requests from business applications or the command
+responses from devices, if the message limit is exceeded, the Adapter rejects the message with the reason
+`amqp:resource-limit-exceeded`. 
 
 ### Receiving Commands
 
@@ -377,16 +422,29 @@ Once the link has been established, the adapter will send command messages havin
 | *correlation-id*  | no        | *properties*             | *string*    | This property will be empty for *one-way* commands, otherwise it will contain the identifier used to correlate the response with the command request. |
 | *device_id*       | no        | *application-properties* | *string*    | This property will only be set if an authenticated gateway has connected to the adapter. It will contain the id of the device (connected to the gateway) that the command is targeted at. |
 
-Authenticated gateways will receive commands for devices which do not connect to a protocol adapter directly but instead are connected to the gateway. Corresponding devices have to be configured so that they can be used with a gateway. See [Configuring Gateway Devices]({{< relref "/admin-guide/file-based-device-registry-config#configuring-gateway-devices" >}}) for details.
+Authenticated gateways will receive commands for devices which do not connect to a protocol adapter directly but
+instead are connected to the gateway. Corresponding devices have to be configured so that they can be used with a
+gateway. See [Configuring Gateway Devices]({{< relref "/admin-guide/file-based-device-registry-config#configuring-gateway-devices" >}})
+for details.
 
-A gateway can open a link to receive commands for *all* devices it acts on behalf of. An authenticated gateway can also open a receiver link for commands targeted at a *specific* device.
+A gateway can open a link to receive commands for *all* devices it acts on behalf of. An authenticated gateway can also
+open a receiver link for commands targeted at a *specific* device.
 
-When processing an incoming command message, the protocol adapter will give precedence to a device-specific command consumer matching the command target device, whether it was created by a gateway or by the device itself. If multiple such consumer links have been created, by multiple gateways and/or from the device itself, the gateway or device that last created the consumer link will get the command messages.
+When processing an incoming command message, the protocol adapter will give precedence to a device-specific command
+consumer matching the command target device, whether it was created by a gateway or by the device itself. If multiple
+such consumer links have been created, by multiple gateways and/or from the device itself, the gateway or device that
+last created the consumer link will get the command messages.
 
-If no device-specific command consumer exists for a command target device, but *one* gateway, that may act on behalf of the device, has opened a generic, device-unspecific command consumer link, then the command message is sent to that gateway. 
+If no device-specific command consumer exists for a command target device, but *one* gateway, that may act on behalf
+of the device, has opened a generic, device-unspecific command consumer link, then the command message is sent to
+that gateway. 
 
-If *multiple* gateways have opened a generic command consumer link, the protocol adapter may have to decide to which gateway a particular command message will be sent to.
-In case the command target device has already sent a telemetry, event or command response message via a gateway and if that gateway has opened a command consumer link, that gateway will be chosen. Otherwise one gateway that may act on behalf of the command target device and that has opened a command consumer link will be chosen randomly to receive the command message.
+If *multiple* gateways have opened a generic command consumer link, the protocol adapter may have to decide to which
+gateway a particular command message will be sent to.
+In case the command target device has already sent a telemetry, event or command response message via a gateway and
+if that gateway has opened a command consumer link, that gateway will be chosen. Otherwise one gateway that may act
+on behalf of the command target device and that has opened a command consumer link will be chosen randomly to receive
+the command message.
 
 Clients MUST settle command messages using one of the following outcomes:
 
@@ -403,19 +461,21 @@ Devices may use the same anonymous sender link for this purpose that they also u
 
 The adapter supports *AT LEAST ONCE* delivery of command response messages only. A client therefore MUST set the
 *settled* property to `false` and the *rcv-settle-mode* property to `first` in all *transfer* frame(s) it uses
-for uploading command responses. All other combinations are not supported by the adapter and result in the message being rejected.
+for uploading command responses. All other combinations are not supported by the adapter and result in the message
+being rejected.
 
 * Authentication: SASL PLAIN or SASL EXTERNAL
 * Message *properties*:
-  * (required) `to`: MUST contain the value of the *reply-to* property of the command request message.
-  * (required) `correlation-id`: MUST contain the value of the *correlation-id* property of the command request message.
-  * (optional) `content-type`: The type of payload contained in the message body.
+  * (required) *to*: MUST contain the value of the *reply-to* property of the command request message.
+  * (required) *correlation-id*: MUST contain the value of the *correlation-id* property of the command request message.
+  * (optional) *content-type*: The type of payload contained in the message body.
 * Message *application-properties*:
-  * (required) `status`: MUST contain an AMQP 1.0 *int* typed status code indicating the outcome of processing the command at the
-    device (see [Command & Control API]({{< relref "/api/command-and-control" >}}) for details).
+  * (required) *status*: MUST contain an AMQP 1.0 *int* typed status code indicating the outcome of processing the
+    command at the device (see [Command & Control API]({{< relref "/api/command-and-control" >}}) for details).
 * Message Body:
   * (optional) Arbitrary payload contained in either a single AMQP *Data* or *AmqpValue* section. Note that the adapter
-    only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will be ignored.
+    only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will
+    be ignored.
 * Outcomes:
   * `accepted`: The message has been successfully forwarded downstream.
   * `released`: The message could not be processed by the adapter due to a (temporary) problem that has not been caused
@@ -425,13 +485,14 @@ for uploading command responses. All other combinations are not supported by the
     be processed. Possible error conditions include:
     * `hono:bad-request`: The message does not meet all formal requirements, e.g. a required property is missing.
     * `amqp:unauthorized-access`: The adapter is not enabled for the tenant that the client belongs to.
-    * `amqp:resource-limit-exceeded`: One of the [Resource Limit Checks]({{< relref "#resource-limit-checks" >}}) has failed for the
-       tenant that the client belongs to.
+    * `amqp:resource-limit-exceeded`: One of the [Resource Limit Checks]({{< relref "#resource-limit-checks" >}}) has
+       failed for the tenant that the client belongs to.
     * `amqp:precondition-failed`: The message does not fulfill certain requirements, e.g adapter cannot assert device registration etc.
 
 ### Examples
 
-The AMQP adapter client can be used to simulate a device which receives commands and sends responses back to the application. 
+The AMQP adapter client can be used to simulate a device which receives commands and sends responses back to the
+application.
 
 A subscription to commands for a specific device can be done like this:
 
@@ -440,9 +501,11 @@ A subscription to commands for a specific device can be done like this:
 java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-command --hono.client.username=sensor1@DEFAULT_TENANT --hono.client.password=hono-secret
 ~~~
 
-After successfully starting the client, a message indicating that the device is ready to receive commands will be printed to standard output. The device is now waiting to receive commands from applications. 
+After successfully starting the client, a message indicating that the device is ready to receive commands will be
+printed to standard output. The device is now waiting to receive commands from applications. 
 
-After a command has arrived, the AMQP adapter client will print out the command name and payload that it receives and automatically send a command response to the application.
+After a command has arrived, the AMQP adapter client will print out the command name and payload that it receives and
+automatically send a command response to the application.
 
 ~~~plaintext
 Received Command Message : [Command name: setBrightness, Command payload: some-payload]
@@ -451,7 +514,7 @@ Command response sent [outcome: Accepted{}]
 
 ## Downstream Meta Data
 
-The adapter includes the following meta data in the application properties of messages being sent downstream:
+The adapter includes the following meta data in messages being sent downstream:
 
 | Name               | Type      | Description                                                     |
 | :----------------- | :-------- | :-------------------------------------------------------------- |
@@ -459,32 +522,38 @@ The adapter includes the following meta data in the application properties of me
 | *orig_adapter*     | *string*  | Contains the adapter's *type name* which can be used by downstream consumers to determine the protocol adapter that the message has been received over. The AMQP adapter's type name is `hono-amqp`. |
 | *orig_address*     | *string*  | Contains the AMQP *target address* that the device has used to send the data. |
 
-The adapter also considers *defaults* registered for the device at either the [tenant]({{< relref "/api/tenant#tenant-information-format" >}})
-or the [device level]({{< relref "/api/device-registration#assert-device-registration" >}}).
+The adapter also considers *defaults* registered for the device at either the
+[tenant]({{< relref "/api/tenant#tenant-information-format" >}}) or the
+[device level]({{< relref "/api/device-registration#assert-device-registration" >}}).
 The values of the default properties are determined as follows:
 
 1. If the message already contains a non-empty property of the same name, the value if unchanged.
-2. Otherwise, if a default property of the same name is defined in the device's registration information, that value is used.
-3. Otherwise, if a default property of the same name is defined for the tenant that the device belongs to, that value is used.
+2. Otherwise, if a default property of the same name is defined in the device's registration information,
+   that value is used.
+3. Otherwise, if a default property of the same name is defined for the tenant that the device belongs to,
+   that value is used.
 
-Note that of the standard AMQP 1.0 message properties only the *content-type* and *ttl* can be set this way to a default value.
+Note that of the standard AMQP 1.0 message properties only the *content-type* and *ttl* can be set this way to a
+default value.
 
 ### Event Message Time-to-live
 
-Events published by devices will usually be persisted by the AMQP Messaging Network in order to support deferred delivery to downstream consumers.
-In most cases the AMQP Messaging Network can be configured with a maximum *time-to-live* to apply to the events so that the events will be removed
-from the persistent store if no consumer has attached to receive the event before the message expires.
+Events published by devices will usually be persisted by the messing infrastructure in order to support deferred
+delivery to downstream consumers.
 
-In order to support environments where the AMQP Messaging Network cannot be configured accordingly, the protocol adapter supports setting a
-downstream event message's *ttl* property based on the default *ttl* and *max-ttl* values configured for a tenant/device as described in the
-[Tenant API]({{< relref "/api/tenant#resource-limits-configuration-format" >}}).
+In most cases, the messaging infrastructure can be configured with a maximum *time-to-live* to apply to the events so
+that the events will be removed from the persistent store if no consumer has attached to receive the event before
+the message expires.
 
+In order to support environments where the messaging infrastructure cannot be configured accordingly, the protocol
+adapter supports setting a downstream event message's *ttl* property based on the default *ttl* and *max-ttl* values
+configured for a tenant/device as described in the [Tenant API]({{< relref "/api/tenant#resource-limits-configuration-format" >}}).
 
 ## Tenant specific Configuration
 
-The adapter uses the [Tenant API]({{< ref "/api/tenant#get-tenant-information" >}}) to retrieve *tenant specific configuration* for adapter type `hono-amqp`.
-The following properties are (currently) supported:
+The adapter uses the [Tenant API]({{< ref "/api/tenant#get-tenant-information" >}}) to retrieve *tenant specific
+configuration* for adapter type `hono-amqp`. The following properties are (currently) supported:
 
 | Name               | Type       | Default Value | Description                                                     |
 | :----------------- | :--------- | :------------ | :-------------------------------------------------------------- |
-| *enabled*          | *boolean*  | `true`        | If set to `false` the adapter will reject all data from devices belonging to the tenant and respond with a `amqp:unauthorized-access` as the error condition value for rejecting the message. |
+| *enabled*          | *boolean*  | `true`         | If set to `false` the adapter will reject all data from devices belonging to the tenant and respond with a `amqp:unauthorized-access` as the error condition value for rejecting the message. |

--- a/site/documentation/content/user-guide/coap-adapter.md
+++ b/site/documentation/content/user-guide/coap-adapter.md
@@ -754,7 +754,7 @@ default value.
 
 ### Event Message Time-to-live
 
-Events published by devices will usually be persisted by the messing infrastructure in order to support deferred
+Events published by devices will usually be persisted by the messaging infrastructure in order to support deferred
 delivery to downstream consumers.
 
 In most cases, the messaging infrastructure can be configured with a maximum *time-to-live* to apply to the events so

--- a/site/documentation/content/user-guide/coap-adapter.md
+++ b/site/documentation/content/user-guide/coap-adapter.md
@@ -3,47 +3,43 @@ title = "CoAP Adapter"
 weight = 225
 +++
 
-The CoAP protocol adapter exposes [CoAP](https://tools.ietf.org/html/rfc7252) based endpoints for Eclipse Hono&trade;'s south bound Telemetry, Event and Command & Control APIs.
+The CoAP protocol adapter exposes [CoAP](https://tools.ietf.org/html/rfc7252) based endpoints for Eclipse Hono&trade;'s
+south bound Telemetry, Event and Command & Control APIs.
 <!--more-->
 
 ## Device Authentication
 
-The CoAP adapter by default requires clients (devices or gateway components) to authenticate during connection establishment.
-The adapter (currently) supports the use of pre-shared keys (PSK) and X.509 certificates as part of a DTLS handshake for that purpose.
-Additional variants mentioned in [Securing CoAP](https://tools.ietf.org/html/rfc7252#section-9) might be added in the future.
+The CoAP adapter by default requires clients (devices or gateway components) to authenticate during connection
+establishment. The adapter (currently) supports the use of pre-shared keys (PSK) and X.509 certificates as part of a
+DTLS handshake for that purpose. Additional variants mentioned in
+[Securing CoAP](https://tools.ietf.org/html/rfc7252#section-9) might be added in the future.
 
-### PSK
+### Pre-Shared Key
 
-The *identity* provided in the ClientKeyExchange must have the form *auth-id@tenant*, e.g. `sensor1@DEFAULT_TENANT`.
-The adapter performs the handshake using the credentials which the
-[configured Credentials service]({{< relref "/admin-guide/common-config#credentials-service-connection-configuration" >}})
-has on record for the client. The adapter uses the Credentials API's *get* operation to retrieve the credentials on record
-with the *tenant* and *auth-id* provided by the device in the *identity* and `psk` as the *type* of secret as query parameters.
+The CoAP adapter supports authenticating clients using PSK based cipher suites as part of the DTLS handshake.
+This requires a client to provide a *psk_identity* in its *ClientKeyExchange* message as defined in
+[RFC 4279, Section 2](https://datatracker.ietf.org/doc/html/rfc4279#section-2) during the DTLS handshake with
+the CoAP adapter. The adapter uses the provided information to verify the client's identity as described in
+[Pre-Shared Key based Authentication]({{< relref "/concepts/device-identity#pre-shared-key-based-authentication" >}}).
 
 The examples below refer to devices `4711` and `gw-1` of tenant `DEFAULT_TENANT` using *auth-ids* `sensor1` and `gw1` and
-corresponding secrets. The example deployment as described in the [Deployment Guides]({{< relref "deployment" >}}) comes pre-configured
-with the corresponding entities in its device registry component.
-Please refer to the [Credentials API]({{< relref "/api/credentials#standard-credential-types" >}}) for details regarding the different
-types of secrets.
+corresponding secrets. The example deployment as described in the [Deployment Guides]({{< relref "deployment" >}})
+comes pre-configured with the corresponding entities in its device registry component.
 
-**NB** There is a subtle difference between the *device identifier* (*device-id*) and the *auth-id* a device uses for authentication.
-See [Device Identity]({{< relref "/concepts/device-identity.md" >}}) for a discussion of the concepts.
+**NB** There is a subtle difference between the *device identifier* (*device-id*) and the *auth-id* a device uses
+for authentication. See [Device Identity]({{< relref "/concepts/device-identity.md" >}}) for a discussion of the
+concepts.
 
 ### X.509
 
-When a device uses a client certificate for authentication during the DTLS handshake, the adapter tries to determine the
-tenant that the device belongs to, based on the *issuer DN* contained in the certificate.
-In order for the lookup to succeed, the tenant's trust anchor needs to be configured by means of
-[registering the trusted certificate authority]({{< relref "/api/tenant#tenant-information-format" >}}).
-The device's client certificate will then be validated using the registered trust anchor, thus implicitly establishing
-the tenant that the device belongs to.
-
-In a second step, the adapter then determines the device identifier using the Credentials API's *get* operation with the
-client certificate's *subject DN* as the *auth-id* and `x509-cert` as the *type* of secret as query parameters.
+The CoAP adapter supports authenticating clients based on TLS cipher suites using the `ECDHE_ECDSA` key exchange algorithm
+as described in [RFC 4492](https://datatracker.ietf.org/doc/html/rfc4492). This requires a client to provide an
+X.509 client certificate containing an ECDSA-capable public key. The adapter uses the information in the client
+certificate to verify the device's identity as described in
+[Client Certificate based Authentication]({{< relref "/concepts/device-identity#client-certificate-based-authentication" >}}).
 
 **NB** The CoAP adapter needs to be [configured for DTLS]({{< relref "/admin-guide/secure_communication#coap-adapter" >}})
-in order to support this mechanism. X.509 based authentication of clients is only supported with *elliptic curve cryptography*
-(ECC) based keys.
+in order to support this mechanism.
 
 ## Message Limits
 
@@ -52,17 +48,17 @@ The adapter rejects
 * a client's request to upload data with status code `429 Too Many Requests` and
 * any AMQP 1.0 message containing a command sent by a north bound application
 
-if the [message limit]({{< relref "/concepts/resource-limits.md" >}}) that has been configured for the device's tenant is exceeded.
+if the [message limit]({{< relref "/concepts/resource-limits.md" >}}) that has been configured for the device's tenant
+is exceeded.
 
 ## CoAP Content Format Codes
 
-CoAP doesn't use a textual identifier for content types. Instead, numbers are used, which are maintained by the [IANA](https://www.iana.org/).
-The [IANA - CoAP Content Formats](https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats) page lists all
-(currently) registered codes and the corresponding media types.
+CoAP doesn't use a textual identifier for content types. Instead, numbers are used which are maintained by the
+[IANA](https://www.iana.org/).
+The [IANA - CoAP Content Formats](https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats)
+page lists all (currently) registered codes and the corresponding media types.
 
 ## Publish Telemetry Data (authenticated Device)
-
-The device is authenticated using PSK.
 
 * URI: `/telemetry`
 * Method: `POST`
@@ -70,53 +66,57 @@ The device is authenticated using PSK.
   * `CON`: *at least once* delivery semantics
   * `NON`: *at most once* delivery semantics
 * Request Options:
-  * (optional) `content-format`: The type of payload contained in the request body. Required, if request contains payload.
+  * (optional) *content-format*: The type of payload contained in the request body. Required, if request contains payload.
 * Query Parameters:
-  * (optional) `hono-ttd`: The number of seconds the device will wait for the response.
-  * (optional) `empty`: Marks the request as an [empty notification]({{< relref "/api/event#empty-notification" >}}).
+  * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
+  * (optional) *empty*: Marks the request as an [empty notification]({{< relref "/api/event#empty-notification" >}}).
 * Request Body:
   * (optional) Arbitrary payload encoded according to the given content type. Maybe empty, if `URI-query: empty` is provided.
 * Response Options:
-  * (optional) `content-format`: A media type describing the semantics and format of payload contained in the response body.
-    This option will only be present if the response contains a command to be executed by the device which requires input data.
-    Note that this option will be empty if the media type contained in the command (AMQP) message's *content-type* property cannot
-    be mapped to one of the registered CoAP *content-format* codes.
-  * (optional) `location-query`: The `hono-command` query parameter contains the name of the command to execute.
+  * (optional) *content-format*: A media type describing the semantics and format of payload contained in the response body.
+    This option will only be present if the response contains a command to be executed by the device which requires input
+    data. Note that this option will be empty if the media type contained in the command (AMQP) message's *content-type*
+    property cannot be mapped to one of the registered CoAP *content-format* codes.
+  * (optional) *location-query*: The *hono-command* query parameter contains the name of the command to execute.
     This option will only be present if the response contains a command to be executed by the device.
-  * (optional) `location-path`: The location path is `command` for one-way-commands and
+  * (optional) *location-path*: The location path is `command` for one-way-commands and
     `command_response/<command-request-id>` for commands expecting  a response.
-    In the latter case, the *location-path* option contains exactly the URI-path that the device must use when sending its
-    response to the command.
-    This option will only be present if the response contains a command to be executed by the device.
+    In the latter case, the *location-path* option contains exactly the URI-path that the device must use when sending
+    its response to the command. This option will only be present if the response contains a command to be executed
+    by the device.
 * Response Body:
   * (optional) Arbitrary data serving as input to a command to be executed by the device.
   * (optional) Error details, if status code is >= 4.00.
 * Response Codes:
-  * 2.04 (Changed): The data in the request body has been accepted for processing. The response may contain a command for the device to execute.
-    Note that if the message type is `NON` (*at most once* semantics), this status code does **not** mean that the message has been
-    delivered to any potential consumer (yet). However, if the message type is `CON` (*at least once* semantics), then the adapter waits
-    for the message to be delivered and accepted by a downstream consumer before responding with this status code.
+  * 2.04 (Changed): The data in the request body has been accepted for processing. The response may contain a command
+    for the device to execute. Note that if the message type is `NON` (*at most once* semantics), this status code does
+    **not** mean that the message has been delivered to any potential consumer (yet). However, if the message type is
+    `CON` (*at least once* semantics), then the adapter waits for the message to be delivered and accepted by a
+    downstream consumer before responding with this status code.
   * 4.00 (Bad Request): The request cannot be processed. Possible reasons include:
-    * the request body is empty, and the *URI-query* option doesn't contain the `empty` parameter.
+    * the request body is empty, and the *URI-query* option doesn't contain the *empty* parameter.
   * 4.03 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
     * The given tenant is not allowed to use this protocol adapter.
   * 4.04 (Not Found): The request cannot be processed because the device is disabled or does not exist.
-  * 4.13 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum supported size.
-  * 4.29 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
+  * 4.13 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum
+    supported size.
+  * 4.29 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period
+    is exceeded.
   * 5.03 (Service Unavailable): The request cannot be processed. Possible reasons for this include:
-    * There is no consumer of telemetry data for the given tenant connected to Hono, or the consumer has not indicated that it may receive further messages (not giving credits).
+    * There is no consumer of telemetry data for the given tenant connected to Hono, or the consumer has not indicated
+      that it may receive further messages (not giving credits).
     * If the message type is `CON` (*at least once* semantics), the reason may be:
       * The consumer has indicated that it didn't process the telemetry data.
       * The consumer failed to indicate in time whether it has processed the telemetry data. 
 
-This is the preferred way for devices to publish telemetry data. It is available only if the protocol adapter is configured to require
-devices to authenticate (which is the default).
+This is the preferred way for devices to publish telemetry data. It is available only if the protocol adapter is
+configured to require devices to authenticate (which is the default).
 
 **Examples**
 
-The examples provided below make use of the *coap-client* command line tool which is part of the [libcoap project](https://libcoap.net/).
-Precompiled packages should be available for different Linux variants.
+The examples provided below make use of the *coap-client* command line tool which is part of the
+[libcoap project](https://libcoap.net/). Precompiled packages should be available for different Linux variants.
 
 Publish some JSON data for device `4711` using default message type `CON` (*at least once*):
 
@@ -158,49 +158,53 @@ downstream application attached which could send any commands to the device.
   * `CON`: *at least once* delivery semantics
   * `NON`: *at most once* delivery semantics
 * Request Options:
-  * (optional) `content-format`: The type of payload contained in the request body. Required, if request contains payload.
+  * (optional) *content-format*: The type of payload contained in the request body. Required, if request contains payload.
 * Query Parameters:
-  * (optional) `hono-ttd`: The number of seconds the device will wait for the response.
-  * (optional) `empty`: Marks the request as an [empty notification]({{< relref "/api/event#empty-notification" >}}).
+  * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
+  * (optional) *empty*: Marks the request as an [empty notification]({{< relref "/api/event#empty-notification" >}}).
 * Request Body:
   * (optional) Arbitrary payload encoded according to the given content type. Maybe empty, if `URI-query: empty` is provided.
 * Response Options:
-  * (optional) `content-format`: A media type describing the semantics and format of payload contained in the response body.
-    This option will only be present if the response contains a command to be executed by the device which requires input data.
-    Note that this option will be empty if the media type contained in the command (AMQP) message's *content-type* property cannot
-    be mapped to one of the registered CoAP *content-format* codes.
-  * (optional) `location-query`: The `hono-command` query parameter contains the name of the command to execute.
+  * (optional) *content-format*: A media type describing the semantics and format of payload contained in the response body.
+    This option will only be present if the response contains a command to be executed by the device which requires input
+    data. Note that this option will be empty if the media type contained in the command (AMQP) message's *content-type*
+    property cannot be mapped to one of the registered CoAP *content-format* codes.
+  * (optional) *location-query*: The *hono-command* query parameter contains the name of the command to execute.
     This option will only be present if the response contains a command to be executed by the device.
-  * (optional) `location-path`: The location path is `command` for one-way-commands and
+  * (optional) *location-path*: The location path is `command` for one-way-commands and
     `command_response/<command-request-id>` for commands expecting  a response.
-    In the latter case, the *location-path* option contains exactly the URI-path that the device must use when sending its
-    response to the command.
-    This option will only be present if the response contains a command to be executed by the device.
+    In the latter case, the *location-path* option contains exactly the URI-path that the device must use when sending
+    its response to the command. This option will only be present if the response contains a command to be executed by
+    the device.
 * Response Body:
   * (optional) Arbitrary data serving as input to a command to be executed by the device, if status code is 2.05 (Content).
   * (optional) Error details, if status code is >= 4.00.
 * Response Codes:
-  * 2.04 (Changed): The data in the request body has been accepted for processing. The response may contain a command for the device to execute.
-    Note that if the message type is `NON` (*at most once* semantics), this status code does **not** mean that the message has been
-    delivered to any potential consumer (yet). However, if the message type is `CON` (*at least once* semantics), then the adapter waits
-    for the message to be delivered and accepted by a downstream consumer before responding with this status code.
+  * 2.04 (Changed): The data in the request body has been accepted for processing. The response may contain a command
+    for the device to execute. Note that if the message type is `NON` (*at most once* semantics), this status code does
+    **not** mean that the message has been delivered to any potential consumer (yet). However, if the message type is
+    `CON` (*at least once* semantics), then the adapter waits for the message to be delivered and accepted by a
+    downstream consumer before responding with this status code.
   * 4.00 (Bad Request): The request cannot be processed. Possible reasons include:
-    * the request body is empty, and the *URI-query* option doesn't contain the `empty` parameter.
+    * the request body is empty, and the *URI-query* option doesn't contain the *empty* parameter.
   * 4.03 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
     * The given tenant is not allowed to use this protocol adapter.
     * The given device does not belong to the given tenant.
   * 4.04 (Not Found): The request cannot be processed because the device is disabled or does not exist.
-  * 4.13 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum supported size.
-  * 4.29 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
+  * 4.13 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum
+    supported size.
+  * 4.29 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period
+    is exceeded.
   * 5.03 (Service Unavailable): The request cannot be processed. Possible reasons for this include:
-    * There is no consumer of telemetry data for the given tenant connected to Hono, or the consumer has not indicated that it may receive further messages (not giving credits).
+    * There is no consumer of telemetry data for the given tenant connected to Hono, or the consumer has not indicated
+      that it may receive further messages (not giving credits).
     * If the message type is `CON` (*at least once* semantics), the reason may be:
       * The consumer has indicated that it didn't process the telemetry data.
       * The consumer failed to indicate in time whether it has processed the telemetry data.
 
 This resource MUST be used by devices that have not authenticated to the protocol adapter. Note that this requires the
-`HONO_COAP_AUTHENTICATION_REQUIRED` configuration property to be explicitly set to `false`.
+*HONO_COAP_AUTHENTICATION_REQUIRED* configuration property to be explicitly set to `false`.
 
 **Examples**
 
@@ -234,35 +238,36 @@ coap-client -m PUT coap://hono.eclipseprojects.io/telemetry/DEFAULT_TENANT/4711?
   * `CON`: *at least once* delivery semantics
   * `NON`: *at most once* delivery semantics
 * Request Options:
-  * (optional) `content-format`: The type of payload contained in the request body. Required, if request contains payload.
+  * (optional) *content-format*: The type of payload contained in the request body. Required, if request contains payload.
 * Query Parameters:
-  * (optional) `hono-ttd`: The number of seconds the device will wait for the response.
-  * (optional) `empty`: Marks the request as an [empty notification]({{< relref "/api/event#empty-notification" >}}).
+  * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
+  * (optional) *empty*: Marks the request as an [empty notification]({{< relref "/api/event#empty-notification" >}}).
 * Request Body:
   * (optional) Arbitrary payload encoded according to the given content type. Maybe empty, if `URI-query: empty` is provided.
 * Response Options:
-  * (optional) `content-format`: A media type describing the semantics and format of payload contained in the response body.
-    This option will only be present if the response contains a command to be executed by the device which requires input data.
-    Note that this option will be empty if the media type contained in the command (AMQP) message's *content-type* property cannot
-    be mapped to one of the registered CoAP *content-format* codes.
-  * (optional) `location-query`: The `hono-command` query parameter contains the name of the command to execute.
+  * (optional) *content-format*: A media type describing the semantics and format of payload contained in the response body.
+    This option will only be present if the response contains a command to be executed by the device which requires input
+    data. Note that this option will be empty if the media type contained in the command (AMQP) message's *content-type*
+    property cannot be mapped to one of the registered CoAP *content-format* codes.
+  * (optional) *location-query*: The *hono-command* query parameter contains the name of the command to execute.
     This option will only be present if the response contains a command to be executed by the device.
-  * (optional) `location-path`: The location path is `command/${tenantId}/${deviceId}` for one-way-commands and
+  * (optional) *location-path*: The location path is `command/${tenantId}/${deviceId}` for one-way-commands and
     `command_response/${tenantId}/${deviceId}/<command-request-id>` for commands expecting  a response.
-    In the latter case, the *location-path* option contains exactly the URI-path that the device must use when sending its
-    response to the command. Note that in both cases the `${tenantId}/${deviceId}` path segments indicate the device that
-    the command is targeted at.
-    This option will only be present if the response contains a command to be executed by the device.
+    In the latter case, the *location-path* option contains exactly the URI-path that the device must use when sending
+    its response to the command. Note that in both cases the `${tenantId}/${deviceId}` path segments indicate the device
+    that the command is targeted at. This option will only be present if the response contains a command to be executed
+    by the device.
 * Response Body:
   * (optional) Arbitrary data serving as input to a command to be executed by the device, if status code is 2.05 (Content).
   * (optional) Error details, if status code is >= 4.00.
 * Response Codes:
-  * 2.04 (Changed): The data in the request body has been accepted for processing. The response may contain a command for a device to execute.
-    Note that if the message type is `NON` (*at most once* semantics), this status code does **not** mean that the message has been
-    delivered to any potential consumer (yet). However, if the message type is `CON` (*at least once* semantics), then the adapter waits
-    for the message to be delivered and accepted by a downstream consumer before responding with this status code.
+  * 2.04 (Changed): The data in the request body has been accepted for processing. The response may contain a command
+    for a device to execute. Note that if the message type is `NON` (*at most once* semantics), this status code does
+    **not** mean that the message has been delivered to any potential consumer (yet). However, if the message type is
+    `CON` (*at least once* semantics), then the adapter waits for the message to be delivered and accepted by a
+    downstream consumer before responding with this status code.
   * 4.00 (Bad Request): The request cannot be processed. Possible reasons include:
-    * the request body is empty, and the *URI-query* option doesn't contain the `empty` parameter.
+    * the request body is empty, and the *URI-query* option doesn't contain the *empty* parameter.
   * 4.03 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
     * The tenant that the gateway belongs to is not allowed to use this protocol adapter.
@@ -270,22 +275,26 @@ coap-client -m PUT coap://hono.eclipseprojects.io/telemetry/DEFAULT_TENANT/4711?
     * The gateway is not authorized to act *on behalf of* the device.
     * The gateway associated with the device is not registered or disabled.
   * 4.04 (Not Found): The request cannot be processed because the device is disabled or does not exist.
-  * 4.13 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum supported size.
-  * 4.29 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
+  * 4.13 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum
+    supported size.
+  * 4.29 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period
+    is exceeded.
   * 5.03 (Service Unavailable): The request cannot be processed. Possible reasons for this include:
-    * There is no consumer of telemetry data for the given tenant connected to Hono, or the consumer has not indicated that it may receive further messages (not giving credits).
+    * There is no consumer of telemetry data for the given tenant connected to Hono, or the consumer has not indicated
+      that it may receive further messages (not giving credits).
     * If the message type is `CON` (*at least once* semantics), the reason may be:
       * The consumer has indicated that it didn't process the telemetry data.
       * The consumer failed to indicate in time whether it has processed the telemetry data. 
 
-This resource can be used by *gateway* components to publish data *on behalf of* other devices which do not connect to a protocol adapter
-directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com)
-or [LoRa](https://lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the
-protocol adapter are used to authenticate the gateway whereas the parameters from the URI are used to identify the device that the gateway
-publishes data for.
+This resource can be used by *gateway* components to publish data *on behalf of* other devices which do not connect to
+a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based
+technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the credentials
+provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway
+whereas the parameters from the URI are used to identify the device that the gateway publishes data for.
 
-The protocol adapter checks the gateway's authority to publish data on behalf of the device implicitly by means of retrieving a *registration assertion*
-for the device from the [configured Device Registration service]({{< relref "/admin-guide/common-config#device-registration-service-connection-configuration" >}}).
+The protocol adapter checks the gateway's authority to publish data on behalf of the device implicitly by means of
+retrieving a *registration assertion* for the device from the configured
+[Device Registration service]({{< relref "/admin-guide/common-config#device-registration-service-connection-configuration" >}}).
 
 **Examples**
 
@@ -311,60 +320,62 @@ coap-client -u gw@DEFAULT_TENANT -k gw-secret -m PUT coaps://hono.eclipseproject
 }
 ~~~
 
-**NB** The examples above assume that a gateway device has been registered with `psk` credentials with *auth-id* `gw` and secret `gw-secret`
-which is authorized to publish data *on behalf of* device `4712`.
+**NB** The examples above assume that a gateway device has been registered with `psk` credentials with *auth-id* `gw` and
+secret `gw-secret` which is authorized to publish data *on behalf of* device `4712`.
 
 ## Publish an Event (authenticated Device)
-
-The device is authenticated using PSK.
 
 * URI: `/event`
 * Method: `POST`
 * Type:`CON`
 * Request Options:
-  * (optional) `content-format`: The type of payload contained in the request body. Required, if request contains payload.
+  * (optional) *content-format*: The type of payload contained in the request body. Required, if request contains payload.
 * Query Parameters:
-  * (optional) `hono-ttd`: The number of seconds the device will wait for the response.
-  * (optional) `empty`: Marks the request as an [empty notification]({{< relref "/api/event#empty-notification" >}}).
+  * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
+  * (optional) *empty*: Marks the request as an [empty notification]({{< relref "/api/event#empty-notification" >}}).
 * Request Body:
   * (optional) Arbitrary payload encoded according to the given content type. Maybe empty, if `URI-query: empty` is provided.
 * Response Options:
-  * (optional) `content-format`: A media type describing the semantics and format of payload contained in the response body.
-    This option will only be present if the response contains a command to be executed by the device which requires input data.
-    Note that this option will be empty if the media type contained in the command (AMQP) message's *content-type* property cannot
-    be mapped to one of the registered CoAP *content-format* codes.
-  * (optional) `location-query`: The `hono-command` query parameter contains the name of the command to execute.
+  * (optional) *content-format*: A media type describing the semantics and format of payload contained in the response body.
+    This option will only be present if the response contains a command to be executed by the device which requires input
+    data. Note that this option will be empty if the media type contained in the command (AMQP) message's *content-type*
+    property cannot be mapped to one of the registered CoAP *content-format* codes.
+  * (optional) *location-query*: The *hono-command* query parameter contains the name of the command to execute.
     This option will only be present if the response contains a command to be executed by the device.
-  * (optional) `location-path`: The location path is `command` for one-way-commands and
+  * (optional) *location-path*: The location path is `command` for one-way-commands and
     `command_response/<command-request-id>` for commands expecting  a response.
-    In the latter case, the *location-path* option contains exactly the URI-path that the device must use when sending its
-    response to the command.
+    In the latter case, the *location-path* option contains exactly the URI-path that the device must use when sending
+    its response to the command.
     This option will only be present if the response contains a command to be executed by the device.
 * Response Body:
   * (optional) Arbitrary data serving as input to a command to be executed by the device, if status code is 2.05 (Content).
   * (optional) Error details, if status code is >= 4.00.
 * Response Codes:
-  * 2.04 (Changed): The data in the request body has been accepted for processing. The response may contain a command for the device to execute.
-    Note that if the message type is `NON` (*at most once* semantics), this status code does **not** mean that the message has been
-    delivered to any potential consumer (yet). However, if the message type is `CON` (*at least once* semantics), then the adapter waits
-    for the message to be delivered and accepted by a downstream consumer before responding with this status code.
+  * 2.04 (Changed): The data in the request body has been accepted for processing. The response may contain a command
+    for the device to execute. Note that if the message type is `NON` (*at most once* semantics), this status code does
+    **not** mean that the message has been delivered to any potential consumer (yet). However, if the message type is
+    `CON` (*at least once* semantics), then the adapter waits for the message to be delivered and accepted by a
+    downstream consumer before responding with this status code.
   * 4.00 (Bad Request): The request cannot be processed. Possible reasons include:
-    * the request body is empty, and the *URI-query* option doesn't contain the `empty` parameter.
+    * the request body is empty, and the *URI-query* option doesn't contain the *empty* parameter.
   * 4.03 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
     * The given tenant is not allowed to use this protocol adapter.
   * 4.04 (Not Found): The request cannot be processed because the device is disabled or does not exist.
-  * 4.13 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum supported size.
-  * 4.29 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
-  * 5.03 (Service Unavailable): The request cannot be processed because there is no consumer of events for the given tenant connected to Hono, or the consumer didn't process the event.
+  * 4.13 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum
+    supported size.
+  * 4.29 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period
+    is exceeded.
+  * 5.03 (Service Unavailable): The request cannot be processed because there is no consumer of events for the given
+    tenant connected to Hono, or the consumer didn't process the event.
 
-This is the preferred way for devices to publish events. It is available only if the protocol adapter is configured to require
-devices to authenticate (which is the default).
+This is the preferred way for devices to publish events. It is available only if the protocol adapter is configured to
+require devices to authenticate (which is the default).
 
 **Examples**
 
-The examples provided below make use of the *coap-client* command line tool which is part of the [libcoap project](https://libcoap.net/).
-Precompiled packages should be available for different Linux variants.
+The examples provided below make use of the *coap-client* command line tool which is part of the
+[libcoap project](https://libcoap.net/). Precompiled packages should be available for different Linux variants.
 
 Publish some JSON data for device `4711` using default message type `CON` (*at least once*):
 
@@ -398,45 +409,49 @@ downstream application attached which could send any commands to the device.
 * Method: `PUT`
 * Type:`CON`
 * Request Options:
-  * (optional) `content-format`: The type of payload contained in the request body. Required, if request contains payload.
+  * (optional) *content-format*: The type of payload contained in the request body. Required, if request contains payload.
 * Query Parameters:
-  * (optional) `hono-ttd`: The number of seconds the device will wait for the response.
-  * (optional) `empty`: Marks the request as an [empty notification]({{< relref "/api/event#empty-notification" >}}).
+  * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
+  * (optional) *empty*: Marks the request as an [empty notification]({{< relref "/api/event#empty-notification" >}}).
 * Request Body:
   * (optional) Arbitrary payload encoded according to the given content type. Maybe empty, if `URI-query: empty` is provided.
 * Response Options:
-  * (optional) `content-format`: A media type describing the semantics and format of payload contained in the response body.
-    This option will only be present if the response contains a command to be executed by the device which requires input data.
-    Note that this option will be empty if the media type contained in the command (AMQP) message's *content-type* property cannot
-    be mapped to one of the registered CoAP *content-format* codes.
-  * (optional) `location-query`: The `hono-command` query parameter contains the name of the command to execute.
+  * (optional) *content-format*: A media type describing the semantics and format of payload contained in the response body.
+    This option will only be present if the response contains a command to be executed by the device which requires input
+    data. Note that this option will be empty if the media type contained in the command (AMQP) message's *content-type*
+    property cannot be mapped to one of the registered CoAP *content-format* codes.
+  * (optional) *location-query*: The *hono-command* query parameter contains the name of the command to execute.
     This option will only be present if the response contains a command to be executed by the device.
-  * (optional) `location-path`: The location path is `command` for one-way-commands and
+  * (optional) *location-path*: The location path is `command` for one-way-commands and
     `command_response/<command-request-id>` for commands expecting  a response.
-    In the latter case, the *location-path* option contains exactly the URI-path that the device must use when sending its
-    response to the command.
+    In the latter case, the *location-path* option contains exactly the URI-path that the device must use when sending
+    its response to the command.
     This option will only be present if the response contains a command to be executed by the device.
 * Response Body:
   * (optional) Arbitrary data serving as input to a command to be executed by the device, if status code is 2.05 (Content).
   * (optional) Error details, if status code is >= 4.00.
 * Response Codes:
-  * 2.04 (Changed): The data in the request body has been accepted for processing. The response may contain a command for the device to execute.
-    Note that if the message type is `NON` (*at most once* semantics), this status code does **not** mean that the message has been
-    delivered to any potential consumer (yet). However, if the message type is `CON` (*at least once* semantics), then the adapter waits
-    for the message to be delivered and accepted by a downstream consumer before responding with this status code.
+  * 2.04 (Changed): The data in the request body has been accepted for processing. The response may contain a command
+    for the device to execute. Note that if the message type is `NON` (*at most once* semantics), this status code does
+    **not** mean that the message has been delivered to any potential consumer (yet). However, if the message type is
+    `CON` (*at least once* semantics), then the adapter waits for the message to be delivered and accepted by a
+    downstream consumer before responding with this status code.
   * 4.00 (Bad Request): The request cannot be processed. Possible reasons include:
-    * the request body is empty, and the *URI-query* option doesn't contain the `empty` parameter.
+    * the request body is empty, and the *URI-query* option doesn't contain the *empty* parameter.
   * 4.03 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
     * The given tenant is not allowed to use this protocol adapter.
     * The given device does not belong to the given tenant.
   * 4.04 (Not Found): The request cannot be processed because the device is disabled or does not exist.
-  * 4.13 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum supported size.
-  * 4.29 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
-  * 5.03 (Service Unavailable): The request cannot be processed because there is no consumer of events for the given tenant connected to Hono, or the consumer didn't process the event.
+  * 4.13 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum
+    supported size.
+  * 4.29 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period
+    is exceeded.
+  * 5.03 (Service Unavailable): The request cannot be processed because there is no consumer of events for the given
+    tenant connected to Hono, or the consumer didn't process the event.
 
 This resource MUST be used by devices that have not authenticated to the protocol adapter. Note that this requires the
-`HONO_COAP_AUTHENTICATION_REQUIRED` configuration property to be explicitly set to `false`.
+*HONO_COAP_AUTHENTICATION_REQUIRED* configuration property to be explicitly set to `false`.
 
 **Examples**
 
@@ -462,35 +477,36 @@ coap-client -m PUT coap://hono.eclipseprojects.io/event/DEFAULT_TENANT/4711?hono
 * Method: `PUT`
 * Type:`CON`
 * Request Options:
-  * (optional) `content-format`: The type of payload contained in the request body. Required, if request contains payload.
+  * (optional) *content-format*: The type of payload contained in the request body. Required, if request contains payload.
 * Query Parameters:
-  * (optional) `hono-ttd`: The number of seconds the device will wait for the response.
-  * (optional) `empty`: Marks the request as an [empty notification]({{< relref "/api/event#empty-notification" >}}).
+  * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
+  * (optional) *empty*: Marks the request as an [empty notification]({{< relref "/api/event#empty-notification" >}}).
 * Request Body:
   * (optional) Arbitrary payload encoded according to the given content type. Maybe empty, if `URI-query: empty` is provided.
 * Response Options:
-  * (optional) `content-format`: A media type describing the semantics and format of payload contained in the response body.
-    This option will only be present if the response contains a command to be executed by the device which requires input data.
-    Note that this option will be empty if the media type contained in the command (AMQP) message's *content-type* property cannot
-    be mapped to one of the registered CoAP *content-format* codes.
-  * (optional) `location-query`: The `hono-command` query parameter contains the name of the command to execute.
+  * (optional) *content-format*: A media type describing the semantics and format of payload contained in the response body.
+    This option will only be present if the response contains a command to be executed by the device which requires input
+    data. Note that this option will be empty if the media type contained in the command (AMQP) message's *content-type*
+    property cannot be mapped to one of the registered CoAP *content-format* codes.
+  * (optional) *location-query*: The *hono-command* query parameter contains the name of the command to execute.
     This option will only be present if the response contains a command to be executed by the device.
-  * (optional) `location-path`: The location path is `command/${tenantId}/${deviceId}` for one-way-commands and
+  * (optional) *location-path*: The location path is `command/${tenantId}/${deviceId}` for one-way-commands and
     `command_response/${tenantId}/${deviceId}/<command-request-id>` for commands expecting  a response.
-    In the latter case, the *location-path* option contains exactly the URI-path that the device must use when sending its
-    response to the command. Note that in both cases the `${tenantId}/${deviceId}` path segments indicate the device that
+    In the latter case, the *location-path* option contains exactly the URI-path that the device must use when sending
+    its response to the command. Note that in both cases the `${tenantId}/${deviceId}` path segments indicate the device that
     the command is targeted at.
     This option will only be present if the response contains a command to be executed by the device.
 * Response Body:
   * (optional) Arbitrary data serving as input to a command to be executed by the device, if status code is 2.05 (Content).
   * (optional) Error details, if status code is >= 4.00.
 * Response Codes:
-  * 2.04 (Changed): The data in the request body has been accepted for processing. The response may contain a command for a device to execute.
-    Note that if the message type is `NON` (*at most once* semantics), this status code does **not** mean that the message has been
-    delivered to any potential consumer (yet). However, if the message type is `CON` (*at least once* semantics), then the adapter waits
-    for the message to be delivered and accepted by a downstream consumer before responding with this status code.
+  * 2.04 (Changed): The data in the request body has been accepted for processing. The response may contain a command
+    for a device to execute. Note that if the message type is `NON` (*at most once* semantics), this status code does
+    **not** mean that the message has been delivered to any potential consumer (yet). However, if the message type is
+    `CON` (*at least once* semantics), then the adapter waits for the message to be delivered and accepted by a
+    downstream consumer before responding with this status code.
   * 4.00 (Bad Request): The request cannot be processed. Possible reasons include:
-    * the request body is empty, and the *URI-query* option doesn't contain the `empty` parameter.
+    * the request body is empty, and the *URI-query* option doesn't contain the *empty* parameter.
   * 4.03 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
     * The tenant that the gateway belongs to is not allowed to use this protocol adapter.
@@ -498,18 +514,22 @@ coap-client -m PUT coap://hono.eclipseprojects.io/event/DEFAULT_TENANT/4711?hono
     * The gateway is not authorized to act *on behalf of* the device.
     * The gateway associated with the device is not registered or disabled.
   * 4.04 (Not Found): The request cannot be processed because the device is disabled or does not exist.
-  * 4.13 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum supported size.
-  * 4.29 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
-  * 5.03 (Service Unavailable): The request cannot be processed because there is no consumer of events for the given tenant connected to Hono, or the consumer didn't process the event.
+  * 4.13 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum
+    supported size.
+  * 4.29 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period
+    is exceeded.
+  * 5.03 (Service Unavailable): The request cannot be processed because there is no consumer of events for the given
+    tenant connected to Hono, or the consumer didn't process the event.
 
-This resource can be used by *gateway* components to publish data *on behalf of* other devices which do not connect to a protocol adapter
-directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com)
-or [LoRa](https://lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the
-protocol adapter are used to authenticate the gateway whereas the parameters from the URI are used to identify the device that the gateway
-publishes data for.
+This resource can be used by *gateway* components to publish data *on behalf of* other devices which do not connect to
+a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based
+technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the credentials
+provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway
+whereas the parameters from the URI are used to identify the device that the gateway publishes data for.
 
-The protocol adapter checks the gateway's authority to publish data on behalf of the device implicitly by means of retrieving a *registration assertion*
-for the device from the [configured Device Registration service]({{< relref "/admin-guide/common-config#device-registration-service-connection-configuration" >}}).
+The protocol adapter checks the gateway's authority to publish data on behalf of the device implicitly by means of
+retrieving a *registration assertion* for the device from the configured
+[Device Registration service]({{< relref "/admin-guide/common-config#device-registration-service-connection-configuration" >}}).
 
 **Examples**
 
@@ -529,57 +549,79 @@ coap-client -u gw@DEFAULT_TENANT -k gw-secret -m PUT coaps://hono.eclipseproject
 }
 ~~~
 
-**NB** The examples above assume that a gateway device has been registered with `psk` credentials with *auth-id* `gw` and secret `gw-secret`
-which is authorized to publish data *on behalf of* device `4712`.
+**NB** The examples above assume that a gateway device has been registered with `psk` credentials with *auth-id* `gw` and
+secret `gw-secret` which is authorized to publish data *on behalf of* device `4712`.
 
 ## Command & Control
 
-The CoAP adapter enables devices to receive commands that have been sent by business applications. Commands are delivered to the device by means of a response message. That means a device first has to send a request, indicating how long it will wait for the response. That request can either be a telemetry or event message, with a `hono-ttd` query parameter (`ttd` for `time till disconnect`) specifying the number of seconds the device will wait for the response. The business application can react on that message by sending a command message, targeted at the device. The CoAP adapter will then send the command message as part of the response message to the device.
+The CoAP adapter enables devices to receive commands that have been sent by business applications. Commands are
+delivered to the device by means of a response message. That means a device first has to send a request, indicating
+how long it will wait for the response. That request can either be a telemetry or event message, with a *hono-ttd*
+query parameter (`ttd` for `time till disconnect`) specifying the number of seconds the device will wait for the response.
+The business application can react on that message by sending a command message, targeted at the device. The CoAP
+adapter will then send the command message as part of the response message to the device.
 
 ### Commands handled by gateways
 
-Authenticated gateways will receive commands for devices which do not connect to a protocol adapter directly but instead are connected to the gateway. Corresponding devices have to be configured so that they can be used with a gateway. See [Configuring Gateway Devices]({{< relref "/admin-guide/file-based-device-registry-config#configuring-gateway-devices" >}}) for details.
+Authenticated gateways will receive commands for devices which do not connect to a protocol adapter directly but
+instead are connected to the gateway. Corresponding devices have to be configured so that they can be used with a
+gateway.
+See [Configuring Gateway Devices]({{< relref "/admin-guide/file-based-device-registry-config#configuring-gateway-devices" >}})
+for details.
 
-A gateway can send a request with the `hono-ttd` query parameter on the `/event` or `/telemetry` URI, indicating its readiness to receive a command for *any* device it acts on behalf of. Note that in this case, the business application will be notified with the gateway id in the `device_id` property of the downstream message.
+A gateway can send a request with the *hono-ttd* query parameter on the `/event` or `/telemetry` URI, indicating its readiness
+to receive a command for *any* device it acts on behalf of. Note that in this case, the business application will be
+notified with the gateway id in the `device_id` property of the downstream message.
 
-An authenticated gateway can also indicate its readiness to receive a command targeted at a *specific* device. For that, the `/event/${tenantId}/${deviceId}` or `/telemetry/${tenantId}/${deviceId}` URI is to be used, containing the id of the device to receive a command for. The business application will receive a notification with that device id.
+An authenticated gateway can also indicate its readiness to receive a command targeted at a *specific* device. For that,
+the `/event/${tenantId}/${deviceId}` or `/telemetry/${tenantId}/${deviceId}` URI is to be used, containing the id of the device to
+receive a command for. The business application will receive a notification with that device id.
 
-If there are multiple concurrent requests with a `hono-ttd` query parameter, sent by the command target device and/or one or more of its potential gateways, the CoAP adapter will choose the device or gateway to send the command to as follows:
+If there are multiple concurrent requests with a *hono-ttd* query parameter, sent by the command target device and/or one
+or more of its potential gateways, the CoAP adapter will choose the device or gateway to send the command to as follows:
 
-- A request done by the command target device or by a gateway specifically done for that device, has precedence. If there are multiple, concurrent such requests, the last one will get the command message (if received) in its response. Note that the other requests won't be answered with a command message in their response event if the business application sent multiple command messages. That means commands for a single device can only be requested sequentially, not in parallel.
-- If the above doesn't apply, a single `hono-ttd` request on the `/event` or `/telemetry` URI, sent by a gateway that the command target device is configured for, will get the command message in its response.
-- If there are multiple, concurrent such requests by different gateways, all configured for the command target device, the request by the gateway will be chosen, through which the target device has last sent a telemetry or event message. If the target device hasn't sent a message yet and it is thereby unknown via which gateway the device communicates, then one of the requests will be chosen randomly to set the command in its response. 
+* A request done by the command target device or by a gateway specifically done for that device, has precedence. If
+  there are multiple, concurrent such requests, the last one will get the command message (if received) in its response.
+  Note that the other requests won't be answered with a command message in their response event if the business application
+  sent multiple command messages. That means commands for a single device can only be requested sequentially, not in parallel.
+* If the above doesn't apply, a single *hono-ttd* request on the `/event` or `/telemetry` URI, sent by a gateway that the
+  command target device is configured for, will get the command message in its response.
+* If there are multiple, concurrent such requests by different gateways, all configured for the command target device,
+  the request by the gateway will be chosen, through which the target device has last sent a telemetry or event message.
+  If the target device hasn't sent a message yet and it is thereby unknown via which gateway the device communicates,
+  then one of the requests will be chosen randomly to set the command in its response. 
 
 ### Sending a Response to a Command (authenticated Device)
-
-The device is authenticated using PSK.
 
 * URI: `/command_response/${commandRequestId}`
 * Method: `POST`
 * Type: `CON`
 * Request Options:
   * (optional) `content-type`: A media type describing the semantics and format of the payload contained in the request body.
-    This option must be set if the result of processing the command on the device is non-empty. In this case the result data is
-    contained in the request body.
+    This option must be set if the result of processing the command on the device is non-empty. In this case the result
+    data is contained in the request body.
 * Query Parameters:
   * (required) `hono-cmd-status`: An HTTP status code indicating the outcome of processing the command.
 * Request Body:
   * (optional) Arbitrary data representing the result of processing the command on the device.
 * Response Codes:
   * 2.04 (Changed): The response has been successfully delivered to the application that has sent the command.
-  * 4.00 (Bad Request): The request cannot be processed because the command status or command request ID are missing/malformed.
+  * 4.00 (Bad Request): The request cannot be processed because the command status or command request ID are
+    missing/malformed.
   * 4.03 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
     * The given tenant is not allowed to use this protocol adapter.
   * 4.04 (Not Found): The request cannot be processed because the device is disabled or does not exist.
-  * 4.13 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum supported size.
-  * 4.29 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
+  * 4.13 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum
+    supported size.
+  * 4.29 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period
+    is exceeded.
   * 5.03 (Service Unavailable): The request cannot be processed. Possible reasons for this include:
     * There is no application listening for a reply to the given *commandRequestId*.
     * The application has already given up on waiting for a response.
 
-This is the preferred way for devices to respond to commands. It is available only if the protocol adapter is configured to require devices to
-authenticate (which is the default).
+This is the preferred way for devices to respond to commands. It is available only if the protocol adapter is configured
+to require devices to authenticate (which is the default).
 
 **Example**
 
@@ -596,32 +638,36 @@ coap-client -u sensor1@DEFAULT_TENANT -k hono-secret coaps://hono.eclipseproject
 * Type: `CON`
 * Request Options:
   * (optional) `content-type`: A media type describing the semantics and format of the payload contained in the request body.
-    This option must be set if the result of processing the command on the device is non-empty. In this case the result data is
-    contained in the request body.
+    This option must be set if the result of processing the command on the device is non-empty. In this case the result
+    data is contained in the request body.
 * Query Parameters:
   * (required) `hono-cmd-status`: An HTTP status code indicating the outcome of processing the command.
 * Request Body:
   * (optional) Arbitrary data representing the result of processing the command on the device.
 * Response Codes:
   * 2.04 (Changed): The response has been successfully delivered to the application that has sent the command.
-  * 4.00 (Bad Request): The request cannot be processed because the command status or command request ID are missing/malformed.
+  * 4.00 (Bad Request): The request cannot be processed because the command status or command request ID are
+    missing/malformed.
   * 4.03 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
     * The given tenant is not allowed to use this protocol adapter.
     * The given device does not belong to the given tenant.
   * 4.04 (Not Found): The request cannot be processed because the device is disabled or does not exist.
-  * 4.13 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum supported size.
-  * 4.29 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
+  * 4.13 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum
+    supported size.
+  * 4.29 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period
+    is exceeded.
   * 5.03 (Service Unavailable): The request cannot be processed. Possible reasons for this include:
     * There is no application listening for a reply to the given *commandRequestId*.
     * The application has already given up on waiting for a response.
 
 This resource MUST be used by devices that have not authenticated to the protocol adapter. Note that this requires the
-`HONO_HTTP_AUTHENTICATION_REQUIRED` configuration property to be explicitly set to `false`.
+*HONO_COAP_AUTHENTICATION_REQUIRED* configuration property to be explicitly set to `false`.
 
 **Examples**
 
-Send a response to a previously received command with the command-request-id `req-id-uuid` for the unauthenticated device `4711`:
+Send a response to a previously received command with the command-request-id `req-id-uuid` for the unauthenticated
+device `4711`:
 
 ~~~sh
 coap-client -u sensor1@DEFAULT_TENANT -k hono-secret coaps://hono.eclipseprojects.io/command_response/DEFAULT_TENANT/4711/req-id-uuid?hono-cmd-status=200 -e '{"brightness-changed": true}'
@@ -634,15 +680,16 @@ coap-client -u sensor1@DEFAULT_TENANT -k hono-secret coaps://hono.eclipseproject
 * Type: `CON`
 * Request Options:
   * (optional) `content-type`: A media type describing the semantics and format of the payload contained in the request body.
-    This option must be set if the result of processing the command on the device is non-empty. In this case the result data is
-    contained in the request body.
+    This option must be set if the result of processing the command on the device is non-empty. In this case the result
+    data is contained in the request body.
 * Query Parameters:
   * (required) `hono-cmd-status`: An HTTP status code indicating the outcome of processing the command.
 * Request Body:
   * (optional) Arbitrary data representing the result of processing the command on the device.
 * Response Codes:
   * 2.04 (Changed): The response has been successfully delivered to the application that has sent the command.
-  * 4.00 (Bad Request): The request cannot be processed because the command status or command request ID are missing/malformed.
+  * 4.00 (Bad Request): The request cannot be processed because the command status or command request ID are
+    missing/malformed.
   * 4.03 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
     * The given tenant is not allowed to use this protocol adapter.
@@ -650,20 +697,23 @@ coap-client -u sensor1@DEFAULT_TENANT -k hono-secret coaps://hono.eclipseproject
     * The gateway is not authorized to act *on behalf of* the device.
     * The gateway associated with the device is not registered or disabled.
   * 4.04 (Not Found): The request cannot be processed because the device is disabled or does not exist.
-  * 4.13 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum supported size.
-  * 4.29 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
+  * 4.13 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum
+    supported size.
+  * 4.29 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period
+    is exceeded.
   * 5.03 (Service Unavailable): The request cannot be processed. Possible reasons for this include:
     * There is no application listening for a reply to the given *commandRequestId*.
     * The application has already given up on waiting for a response.
 
-This resource can be used by *gateway* components to send the response to a command *on behalf of* other devices which do not connect
-to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like
-[SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the credentials provided by the gateway during
-connection establishment with the protocol adapter are used to authenticate the gateway whereas the parameters from the URI are used
-to identify the device that the gateway publishes data for.
+This resource can be used by *gateway* components to send the response to a command *on behalf of* other devices which
+do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth
+radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the
+credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate
+the gateway whereas the parameters from the URI are used to identify the device that the gateway publishes data for.
 
-The protocol adapter checks the gateway's authority to send responses to a command on behalf of the device implicitly by means of
-retrieving a *registration assertion* for the device from the [configured Device Registration service]({{< relref "/admin-guide/common-config#device-registration-service-connection-configuration" >}}).
+The protocol adapter checks the gateway's authority to send responses to a command on behalf of the device implicitly
+by means of retrieving a *registration assertion* for the device from the configured
+[Device Registration service]({{< relref "/admin-guide/common-config#device-registration-service-connection-configuration" >}}).
 
 **Examples**
 
@@ -673,39 +723,47 @@ Send a response to a previously received command with the command-request-id `re
 coap-client -u gw@DEFAULT_TENANT -k gw-secret coaps://hono.eclipseprojects.io/command_response/DEFAULT_TENANT/4712/req-id-uuid?hono-cmd-status=200 -e '{"brightness-changed": true}'
 ~~~
 
-**NB** The example above assumes that a gateway device has been registered with `psk` credentials with *auth-id* `gw` and secret `gw-secret` which is
-authorized to publish data *on behalf of* device `4712`.
+**NB** The example above assumes that a gateway device has been registered with `psk` credentials with *auth-id* `gw` and
+secret `gw-secret` which is authorized to publish data *on behalf of* device `4712`.
 
 
 ## Downstream Meta Data
 
-The adapter includes the following meta data in the application properties of messages being sent downstream:
+The adapter includes the following meta data in messages being sent downstream:
 
 | Name               | Type      | Description                                                     |
 | :----------------- | :-------- | :-------------------------------------------------------------- |
 | *device_id*        | *string*  | The identifier of the device that the message originates from.  |
 | *orig_adapter*     | *string*  | Contains the adapter's *type name* which can be used by downstream consumers to determine the protocol adapter that the message has been received over. The CoAP adapter's type name is `hono-coap`. |
 | *orig_address*     | *string*  | Contains the (relative) URI that the device has originally posted the data to. |
-| *ttd*              | *integer* | Contains the effective number of seconds that the device will wait for a response. This property is only set if the request contains the `hono-ttd` *URI-query* option. |
+| *ttd*              | *integer* | Contains the effective number of seconds that the device will wait for a response. This property is only set if the request contains the *hono-ttd* *URI-query* option. |
 
-The adapter also considers *defaults* registered for the device at either the [tenant]({{< relref "/api/tenant#tenant-information-format" >}}) or the [device level]({{< relref "/api/device-registration#assert-device-registration" >}}). The values of the default properties are determined as follows:
+The adapter also considers *defaults* registered for the device at either the
+[tenant]({{< relref "/api/tenant#tenant-information-format" >}}) or the
+[device level]({{< relref "/api/device-registration#assert-device-registration" >}}).
+The values of the default properties are determined as follows:
 
 1. If the message already contains a non-empty property of the same name, the value if unchanged.
-2. Otherwise, if a default property of the same name is defined in the device's registration information, that value is used.
-3. Otherwise, if a default property of the same name is defined for the tenant that the device belongs to, that value is used.
+2. Otherwise, if a default property of the same name is defined in the device's registration information,
+   that value is used.
+3. Otherwise, if a default property of the same name is defined for the tenant that the device belongs to,
+   that value is used.
 
-Note that of the standard AMQP 1.0 message properties only the *content-type* and *ttl* can be set this way to a default value.
+Note that of the standard AMQP 1.0 message properties only the *content-type* and *ttl* can be set this way to a
+default value.
 
 ### Event Message Time-to-live
 
-Events published by devices will usually be persisted by the AMQP Messaging Network in order to support deferred delivery to downstream consumers.
-In most cases the AMQP Messaging Network can be configured with a maximum *time-to-live* to apply to the events so that the events will be removed
-from the persistent store if no consumer has attached to receive the event before the message expires.
+Events published by devices will usually be persisted by the messing infrastructure in order to support deferred
+delivery to downstream consumers.
 
-In order to support environments where the AMQP Messaging Network cannot be configured accordingly, the protocol adapter supports setting a
-downstream event message's *ttl* property based on the *hono-ttl* property set as a query parameter in the event requests by the devices.
-Also the default *ttl* and *max-ttl* values can be configured for a tenant/device as described in the [Tenant API]({{< relref "/api/tenant#resource-limits-configuration-format" >}}).
+In most cases, the messaging infrastructure can be configured with a maximum *time-to-live* to apply to the events so
+that the events will be removed from the persistent store if no consumer has attached to receive the event before
+the message expires.
 
+In order to support environments where the messaging infrastructure cannot be configured accordingly, the protocol
+adapter supports setting a downstream event message's *ttl* property based on the default *ttl* and *max-ttl* values
+configured for a tenant/device as described in the [Tenant API]({{< relref "/api/tenant#resource-limits-configuration-format" >}}).
 
 ## Tenant specific Configuration
 

--- a/site/documentation/content/user-guide/http-adapter.md
+++ b/site/documentation/content/user-guide/http-adapter.md
@@ -3,29 +3,48 @@ title = "HTTP Adapter"
 weight = 210
 +++
 
-The HTTP protocol adapter exposes HTTP based endpoints for Eclipse Hono&trade;'s south bound Telemetry, Event and Command & Control APIs.
+The HTTP protocol adapter exposes HTTP based endpoints for Eclipse Hono&trade;'s south bound Telemetry, Event and
+Command & Control APIs.
 <!--more-->
 
 ## Device Authentication
 
-The HTTP adapter by default requires clients (devices or gateway components) to authenticate during connection establishment. The adapter supports both the [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617) as well as client certificate based authentication as part of a TLS handshake for that purpose.
+The HTTP adapter by default requires clients (devices or gateway components) to authenticate during connection
+establishment. The adapter supports both the
+[Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617) as well as client certificate based
+authentication as part of a TLS handshake for that purpose.
 
 The adapter tries to authenticate the device using these mechanisms in the following order
 
 ### Client Certificate
 
-When a device uses a client certificate for authentication during the TLS handshake, the adapter tries to determine the tenant that the device belongs to, based on the *issuer DN* contained in the certificate. In order for the lookup to succeed, the tenant's trust anchor needs to be configured by means of [registering the trusted certificate authority]({{< relref "/api/tenant#tenant-information-format" >}}). The device's client certificate will then be validated using the registered trust anchor, thus implicitly establishing the tenant that the device belongs to. In a second step, the adapter then uses the Credentials API's *get* operation with the client certificate's *subject DN* as the *auth-id* and `x509-cert` as the *type* of secret as query parameters.
+The HTTP adapter supports authenticating clients based on TLS cipher suites using a digital signature based key
+exchange algorithm as described in [RFC 5246 (TLS 1.2)](https://datatracker.ietf.org/doc/html/rfc5246) and
+[RFC 8446 (TLS 1.3)](https://datatracker.ietf.org/doc/html/rfc8446). This requires a client to provide an X.509
+certificate containing a public key that can be used for digital signature. The adapter uses the information in the
+client certificate to verify the device's identity as described in
+[Client Certificate based Authentication]({{< relref "/concepts/device-identity#client-certificate-based-authentication" >}}).
 
-**NB** The HTTP adapter needs to be [configured for TLS]({{< relref "/admin-guide/secure_communication#http-adapter" >}}) in order to support this mechanism.
+**NB** The HTTP adapter needs to be [configured for TLS]({{< relref "/admin-guide/secure_communication#http-adapter" >}})
+in order to support this mechanism.
 
 ### HTTP Basic Auth
 
-The *username* provided in the header must have the form *auth-id@tenant*, e.g. `sensor1@DEFAULT_TENANT`. The adapter verifies the credentials provided by the client against the credentials that the [configured Credentials service]({{< relref "/admin-guide/common-config#credentials-service-connection-configuration" >}}) has on record for the client. The adapter uses the Credentials API's *get* operation to retrieve the credentials on record with the *tenant* and *auth-id* provided by the device in the *username* and `hashed-password` as the *type* of secret as query parameters.
+The HTTP adapter supports authenticating clients using the *Basic* HTTP authentication scheme. This means that clients
+need to provide a *user-id* and a *password* encoded in the *authorization* HTTP request header as defined in
+[RFC 7617, Section 2](https://datatracker.ietf.org/doc/html/rfc7617#section-2) when connecting to the HTTP adapter.
+The *user-id* component of the header value must match the pattern *auth-id@tenant*, e.g. `sensor1@DEFAULT_TENANT`.
 
-The examples below refer to devices `4711` and `gw-1` of tenant `DEFAULT_TENANT` using *auth-ids* `sensor1` and `gw1` and corresponding passwords. The example deployment as described in the [Deployment Guides]({{< relref "deployment" >}}) comes pre-configured with the corresponding entities in its device registry component.
-Please refer to the [Credentials API]({{< relref "/api/credentials#standard-credential-types" >}}) for details regarding the different types of secrets.
+The adapter extracts the *auth-id*, *tenant* and password from the request header and verifies them using the
+credentials that the
+[configured Credentials service]({{< relref "/admin-guide/common-config#credentials-service-connection-configuration" >}})
+has on record for the client as described in
+[Username/Password based Authentication]({{< relref "/concepts/device-identity#username-password-based-authentication" >}}).
+If the credentials match, the client has been authenticated successfully and the request is being processed.
 
-**NB** There is a subtle difference between the *device identifier* (*device-id*) and the *auth-id* a device uses for authentication. See [Device Identity]({{< relref "/concepts/device-identity.md" >}}) for a discussion of the concepts.
+**NB** There is a subtle difference between the *device identifier* (*device-id*) and the *auth-id* a device uses
+for authentication. See [Device Identity]({{< relref "/concepts/device-identity.md" >}}) for a discussion of the
+concepts.
 
 ## Message Limits
 
@@ -34,52 +53,66 @@ The adapter rejects
 * a client's request to upload data with status code `429 Too Many Requests` and
 * any AMQP 1.0 message containing a command sent by a north bound application
 
-if the [message limit]({{< relref "/concepts/resource-limits.md" >}}) that has been configured for the device's tenant is exceeded.
+if the [message limit]({{< relref "/concepts/resource-limits.md" >}}) that has been configured for the device's tenant
+is exceeded.
 
 ## Publish Telemetry Data (authenticated Device)
 
 * URI: `/telemetry`
 * Method: `POST`
 * Request Headers:
-  * (optional) `authorization`: The device's *auth-id* and plain text password encoded according to the [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the device to present a client certificate as part of the TLS handshake during connection establishment.
-  * (required) `content-type`: The type of payload contained in the request body.
-  * (optional) `hono-ttd`: The number of seconds the device will wait for the response.
-  * (optional) `qos-level`: The QoS level for publishing telemetry messages. The adapter supports *at most once* (`0`) and *at least once* (`1`) QoS levels. The default value of `0` is assumed if this header is omitted.
+  * (optional) *authorization*: The device's *auth-id* and plain text password encoded according to the
+    [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the device
+    to present a client certificate as part of the TLS handshake during connection establishment.
+  * (required) *content-type*: The type of payload contained in the request body.
+  * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
+  * (optional) *qos-level*: The QoS level for publishing telemetry messages. The adapter supports *at most once* (`0`)
+    and *at least once* (`1`) QoS levels. The default value of `0` is assumed if this header is omitted.
 * Request Body:
   * (required) Arbitrary payload encoded according to the given content type.
 * Response Headers:
-  * (optional) `content-type`: A media type describing the semantics and format of payload contained in the response body.
+  * (optional) *content-type*: A media type describing the semantics and format of payload contained in the response body.
     This header will only be present if the response contains a command to be executed by the device which requires input
     data or if the request failed and the response body contains error details.
-  * (optional) `hono-command`: The name of the command to execute. This header will only be present if the response contains a command to be executed by the device.
-  * (optional) `hono-cmd-req-id`: An identifier that the device must include in its response to a command. This header will only be present if the response contains a command to be executed by the device.
-  * (optional) `hono-cmd-target-device`: The id of the device that shall execute the command. This header will only be present if the response contains a command to be executed by the device and if the response goes to a gateway that acts on behalf of the target device.
+  * (optional) *hono-command*: The name of the command to execute. This header will only be present if the response
+    contains a command to be executed by the device.
+  * (optional) *hono-cmd-req-id*: An identifier that the device must include in its response to a command. This header
+    will only be present if the response contains a command to be executed by the device.
+  * (optional) *hono-cmd-target-device*: The id of the device that shall execute the command. This header will only be
+    present if the response contains a command to be executed by the device and if the response goes to a gateway that
+    acts on behalf of the target device.
 * Response Body:
   * (optional) Arbitrary data serving as input to a command to be executed by the device, if status code is 200.
   * (optional) Error details, if status code is >= 400.
 * Status Codes:
-  * 200 (OK): The telemetry data has been accepted for processing. The response contains a command for the device to execute.
-  * 202 (Accepted): The telemetry data has been accepted for processing. Note that if the `qos-level` request header is omitted (*at most once* semantics),
-    this status code does **not** mean that the message has been delivered to any potential consumer. However, if the QoS level header is set to `1`
-    (*at least once* semantics), then the adapter waits for the message to be delivered and accepted by a downstream consumer before responding with
-    this status code.
+  * 200 (OK): The telemetry data has been accepted for processing. The response contains a command for the device to
+    execute.
+  * 202 (Accepted): The telemetry data has been accepted for processing. Note that if the *qos-level* request header is
+    omitted (*at most once* semantics), this status code does **not** mean that the message has been delivered to any
+    potential consumer. However, if the QoS level header is set to `1` (*at least once* semantics), then the adapter
+    waits for the message to be delivered and accepted by a downstream consumer before responding with this status code.
   * 400 (Bad Request): The request cannot be processed. Possible reasons for this include:
     * The content type header is missing.
     * The request body is empty.
     * The QoS header value is invalid.
   * 401 (Unauthorized): The request cannot be processed because the request does not contain valid credentials.
-  * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted. Possible reasons for this include:
+  * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
+    Possible reasons for this include:
     * The given tenant is not allowed to use this protocol adapter.
   * 404 (Not Found): The request cannot be processed because the device is disabled or does not exist.
-  * 413 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum supported size.
-  * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
+  * 413 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum
+    supported size.
+  * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period
+    is exceeded.
   * 503 (Service Unavailable): The request cannot be processed. Possible reasons for this include:
-    * There is no consumer of telemetry data for the given tenant connected to Hono, or the consumer has not indicated that it may receive further messages (not giving credits).
+    * There is no consumer of telemetry data for the given tenant connected to Hono, or the consumer has not indicated
+      that it may receive further messages (not giving credits).
     * If the QoS level header is set to `1` (*at least once* semantics), the reason may be:
       * The consumer has indicated that it didn't process the telemetry data.
       * The consumer failed to indicate in time whether it has processed the telemetry data. 
 
-This is the preferred way for devices to publish telemetry data. It is available only if the protocol adapter is configured to require devices to authenticate (which is the default).
+This is the preferred way for devices to publish telemetry data. It is available only if the protocol adapter is
+configured to require devices to authenticate (which is the default).
 
 **Examples**
 
@@ -126,50 +159,60 @@ HTTP/1.1 202 Accepted
 content-length: 0
 ~~~
 
-**NB** The example above assumes that the HTTP adapter is [configured for TLS]({{< relref "/admin-guide/secure_communication#http-adapter" >}}) and the secure port is used.
+**NB** The example above assumes that the HTTP adapter is
+[configured for TLS]({{< relref "/admin-guide/secure_communication#http-adapter" >}}) and the secure port is used.
 
 ## Publish Telemetry Data (unauthenticated Device)
 
 * URI: `/telemetry/${tenantId}/${deviceId}`
 * Method: `PUT`
 * Request Headers:
-  * (required) `content-type`: The type of payload contained in the request body.
-  * (optional) `hono-ttd`: The number of seconds the device will wait for the response.
-  * (optional) `qos-level`: The QoS level for publishing telemetry messages. The adapter supports *at most once* (`0`) and *at least once* (`1`) QoS levels. The default value of `0` is assumed if this header is omitted.
+  * (required) *content-type*: The type of payload contained in the request body.
+  * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
+  * (optional) *qos-level*: The QoS level for publishing telemetry messages. The adapter supports *at most once* (`0`)
+    and *at least once* (`1`) QoS levels. The default value of `0` is assumed if this header is omitted.
 * Request Body:
   * (required) Arbitrary payload encoded according to the given content type.
 * Response Headers:
-  * (optional) `content-type`: A media type describing the semantics and format of payload contained in the response body.
+  * (optional) *content-type*: A media type describing the semantics and format of payload contained in the response body.
     This header will only be present if the response contains a command to be executed by the device which requires input
     data or if the request failed and the response body contains error details.
-  * (optional) `hono-command`: The name of the command to execute. This header will only be present if the response contains a command to be executed by the device.
-  * (optional) `hono-cmd-req-id`: An identifier that the device must include in its response to a command. This header will only be present if the response contains a command to be executed by the device.
+  * (optional) *hono-command*: The name of the command to execute. This header will only be present if the response
+    contains a command to be executed by the device.
+  * (optional) *hono-cmd-req-id*: An identifier that the device must include in its response to a command. This header
+    will only be present if the response contains a command to be executed by the device.
 * Response Body:
   * (optional) Arbitrary data serving as input to a command to be executed by the device, if status code is 200.
   * (optional) Error details, if status code is >= 400.
 * Status Codes:
-  * 200 (OK): The telemetry data has been accepted for processing. The response contains a command for the device to execute.
-  * 202 (Accepted): The telemetry data has been accepted for processing. Note that if the `qos-level` request header is omitted (*at most once* semantics),
-    this status code does **not** mean that the message has been delivered to any potential consumer. However, if the QoS level header is set to `1`
-    (*at least once* semantics), then the adapter waits for the message to be delivered and accepted by a downstream consumer before responding with
-    this status code.
+  * 200 (OK): The telemetry data has been accepted for processing. The response contains a command for the device to
+    execute.
+  * 202 (Accepted): The telemetry data has been accepted for processing. Note that if the *qos-level* request header is
+    omitted (*at most once* semantics), this status code does **not** mean that the message has been delivered to any
+    potential consumer. However, if the QoS level header is set to `1` (*at least once* semantics), then the adapter
+    waits for the message to be delivered and accepted by a downstream consumer before responding with this status code.
   * 400 (Bad Request): The request cannot be processed. Possible reasons for this include:
     * The content type header is missing.
     * The request body is empty.
     * The QoS header value is invalid.
-  * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted. Possible reasons for this include:
+  * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
+    Possible reasons for this include:
     * The given tenant is not allowed to use this protocol adapter.
     * The given device does not belong to the given tenant.
   * 404 (Not Found): The request cannot be processed because the device is disabled or does not exist.
-  * 413 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum supported size.
-  * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
+  * 413 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum
+    supported size.
+  * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period
+    is exceeded.
   * 503 (Service Unavailable): The request cannot be processed. Possible reasons for this include:
-    * There is no consumer of telemetry data for the given tenant connected to Hono, or the consumer has not indicated that it may receive further messages (not giving credits).
+    * There is no consumer of telemetry data for the given tenant connected to Hono, or the consumer has not indicated
+      that it may receive further messages (not giving credits).
     * If the QoS level header is set to `1` (*at least once* semantics), the reason may be:
       * The consumer has indicated that it didn't process the telemetry data.
       * The consumer failed to indicate in time whether it has processed the telemetry data. 
 
-This resource MUST be used by devices that have not authenticated to the protocol adapter. Note that this requires the `HONO_HTTP_AUTHENTICATION_REQUIRED` configuration property to be explicitly set to `false`.
+This resource MUST be used by devices that have not authenticated to the protocol adapter. Note that this requires the
+*HONO_HTTP_AUTHENTICATION_REQUIRED* configuration property to be explicitly set to `false`.
 
 **Examples**
 
@@ -211,50 +254,67 @@ content-length: 23
 * URI: `/telemetry/${tenantId}/${deviceId}`
 * Method: `PUT`
 * Request Headers:
-  * (optional) `authorization`: The gateway's *auth-id* and plain text password encoded according to the [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the gateway to present a client certificate as part of the TLS handshake during connection establishment.
-  * (required) `content-type`: The type of payload contained in the request body.
-  * (optional) `hono-ttd`: The number of seconds the device will wait for the response.
-  * (optional) `qos-level`: The QoS level for publishing telemetry messages. The adapter supports *at most once* (`0`) and *at least once* (`1`) QoS levels. The default value of `0` is assumed if this header is omitted.
+  * (optional) *authorization*: The gateway's *auth-id* and plain text password encoded according to the
+    [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the gateway
+    to present a client certificate as part of the TLS handshake during connection establishment.
+  * (required) *content-type*: The type of payload contained in the request body.
+  * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
+  * (optional) *qos-level*: The QoS level for publishing telemetry messages. The adapter supports *at most once* (`0`)
+    and *at least once* (`1`) QoS levels. The default value of `0` is assumed if this header is omitted.
 * Request Body:
   * (required) Arbitrary payload encoded according to the given content type.
 * Response Headers:
-  * (optional) `content-type`: A media type describing the semantics and format of payload contained in the response body.
+  * (optional) *content-type*: A media type describing the semantics and format of payload contained in the response body.
     This header will only be present if the response contains a command to be executed by the device which requires input
     data or if the request failed and the response body contains error details.
-  * (optional) `hono-command`: The name of the command to execute. This header will only be present if the response contains a command to be executed by the device.
-  * (optional) `hono-cmd-req-id`: An identifier that the device must include in its response to a command. This header will only be present if the response contains a command to be executed by the device.
-  * (optional) `hono-cmd-target-device`: The id of the device that shall execute the command. This header will only be present if the response contains a command to be executed by the device.
+  * (optional) *hono-command*: The name of the command to execute. This header will only be present if the response
+    contains a command to be executed by the device.
+  * (optional) *hono-cmd-req-id*: An identifier that the device must include in its response to a command. This header
+    will only be present if the response contains a command to be executed by the device.
+  * (optional) *hono-cmd-target-device*: The id of the device that shall execute the command. This header will only be
+    present if the response contains a command to be executed by the device.
 * Response Body:
   * (optional) Arbitrary data serving as input to a command to be executed by the device, if status code is 200.
   * (optional) Error details, if status code is >= 400.
 * Status Codes:
-  * 200 (OK): The telemetry data has been accepted for processing. The response contains a command for the device to execute.
-  * 202 (Accepted): The telemetry data has been accepted for processing. Note that if the `qos-level` request header is omitted (*at most once* semantics),
-    this status code does **not** mean that the message has been delivered to any potential consumer. However, if the QoS level header is set to `1`
-    (*at least once* semantics), then the adapter waits for the message to be delivered and accepted by a downstream consumer before responding with
-    this status code.
+  * 200 (OK): The telemetry data has been accepted for processing. The response contains a command for the device to
+    execute.
+  * 202 (Accepted): The telemetry data has been accepted for processing. Note that if the *qos-level* request header is
+    omitted (*at most once* semantics), this status code does **not** mean that the message has been delivered to any
+    potential consumer. However, if the QoS level header is set to `1` (*at least once* semantics), then the adapter
+    waits for the message to be delivered and accepted by a downstream consumer before responding with this status code.
   * 400 (Bad Request): The request cannot be processed. Possible reasons for this include:
     * The content type header is missing.
     * The request body is empty.
     * The QoS header value is invalid.
   * 401 (Unauthorized): The request cannot be processed because the request does not contain valid credentials.
-  * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted. Possible reasons for this include:
+  * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
+    Possible reasons for this include:
     * The tenant that the gateway belongs to is not allowed to use this protocol adapter.
     * The device belongs to another tenant than the gateway.
     * The gateway is not authorized to act *on behalf of* the device.
     * The gateway associated with the device is not registered or disabled.
   * 404 (Not Found): The request cannot be processed because the device is disabled or does not exist.
-  * 413 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum supported size.
-  * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
+  * 413 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum
+    supported size.
+  * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period
+    is exceeded.
   * 503 (Service Unavailable): The request cannot be processed. Possible reasons for this include:
-    * There is no consumer of telemetry data for the given tenant connected to Hono, or the consumer has not indicated that it may receive further messages (not giving credits).
+    * There is no consumer of telemetry data for the given tenant connected to Hono, or the consumer has not indicated
+      that it may receive further messages (not giving credits).
     * If the QoS level header is set to `1` (*at least once* semantics), the reason may be:
       * The consumer has indicated that it didn't process the telemetry data.
       * The consumer failed to indicate in time whether it has processed the telemetry data. 
 
-This resource can be used by *gateway* components to publish data *on behalf of* other devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the parameters from the URI are used to identify the device that the gateway publishes data for.
+This resource can be used by *gateway* components to publish data *on behalf of* other devices which do not connect to
+a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based
+technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the credentials
+provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway
+whereas the parameters from the URI are used to identify the device that the gateway publishes data for.
 
-The protocol adapter checks the gateway's authority to publish data on behalf of the device implicitly by means of retrieving a *registration assertion* for the device from the [configured Device Registration service]({{< relref "/admin-guide/common-config#device-registration-service-connection-configuration" >}}).
+The protocol adapter checks the gateway's authority to publish data on behalf of the device implicitly by means of
+retrieving a *registration assertion* for the device from the configured
+[Device Registration service]({{< relref "/admin-guide/common-config#device-registration-service-connection-configuration" >}}).
 
 **Examples**
 
@@ -291,26 +351,33 @@ content-length: 23
 }
 ~~~
 
-**NB** The example above assumes that a gateway device has been registered with `hashed-password` credentials with *auth-id* `gw` and password `gw-secret` which is authorized to publish data *on behalf of* device `4712`.
+**NB** The example above assumes that a gateway device has been registered with `hashed-password` credentials with
+*auth-id* `gw` and password `gw-secret` which is authorized to publish data *on behalf of* device `4712`.
 
 ## Publish an Event (authenticated Device)
 
 * URI: `/event`
 * Method: `POST`
 * Request Headers:
-  * (optional) `authorization`: The device's *auth-id* and plain text password encoded according to the [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the device to present a client certificate as part of the TLS handshake during connection establishment.
-  * (required) `content-type`: The type of payload contained in the request body.
-  * (optional) `hono-ttd`: The number of seconds the device will wait for the response.
-  * (optional) `hono-ttl`: The *time-to-live* in number of seconds for event messages.  
+  * (optional) *authorization*: The device's *auth-id* and plain text password encoded according to the
+    [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the
+    device to present a client certificate as part of the TLS handshake during connection establishment.
+  * (required) *content-type*: The type of payload contained in the request body.
+  * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
+  * (optional) *hono-ttl*: The *time-to-live* in number of seconds for event messages.  
 * Request Body:
   * (required) Arbitrary payload encoded according to the given content type.
 * Response Headers:
-  * (optional) `content-type`: A media type describing the semantics and format of payload contained in the response body.
+  * (optional) *content-type*: A media type describing the semantics and format of payload contained in the response body.
     This header will only be present if the response contains a command to be executed by the device which requires input
     data or if the request failed and the response body contains error details.
-  * (optional) `hono-command`: The name of the command to execute. This header will only be present if the response contains a command to be executed by the device.
-  * (optional) `hono-cmd-req-id`: An identifier that the device must include in its response to a command. This header will only be present if the response contains a command to be executed by the device.
-  * (optional) `hono-cmd-target-device`: The id of the device that shall execute the command. This header will only be present if the response contains a command to be executed by the device and if the response goes to a gateway that acts on behalf of the target device.
+  * (optional) *hono-command*: The name of the command to execute. This header will only be present if the response
+    contains a command to be executed by the device.
+  * (optional) *hono-cmd-req-id*: An identifier that the device must include in its response to a command. This header
+    will only be present if the response contains a command to be executed by the device.
+  * (optional) *hono-cmd-target-device*: The id of the device that shall execute the command. This header will only be
+    present if the response contains a command to be executed by the device and if the response goes to a gateway that
+    acts on behalf of the target device.
 * Response Body:
   * (optional) Arbitrary data serving as input to a command to be executed by the device, if status code is 200.
   * (optional) Error details, if status code is >= 400.
@@ -321,14 +388,19 @@ content-length: 23
     * The content type header is missing.
     * The request body is empty but the event is not of type [empty-notification]({{< relref "/api/event#empty-notification" >}}).
   * 401 (Unauthorized): The request cannot be processed because the request does not contain valid credentials.
-  * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted. Possible reasons for this include:
+  * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
+    Possible reasons for this include:
     * The given tenant is not allowed to use this protocol adapter.
   * 404 (Not Found): The request cannot be processed because the device is disabled or does not exist.
-  * 413 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum supported size.
-  * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
-  * 503 (Service Unavailable): The request cannot be processed because there is no consumer of events for the given tenant connected to Hono, or the consumer didn't process the event.
+  * 413 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum
+    supported size.
+  * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period
+    is exceeded.
+  * 503 (Service Unavailable): The request cannot be processed because there is no consumer of events for the given
+    tenant connected to Hono, or the consumer didn't process the event.
 
-This is the preferred way for devices to publish events. It is available only if the protocol adapter is configured to require devices to authenticate (which is the default).
+This is the preferred way for devices to publish events. It is available only if the protocol adapter is configured to
+require devices to authenticate (which is the default).
 
 **Example**
 
@@ -346,35 +418,43 @@ content-length: 0
 * URI: `/event/${tenantId}/${deviceId}`
 * Method: `PUT`
 * Request Headers:
-  * (required) `content-type`: The type of payload contained in the request body.
-  * (optional) `hono-ttd`: The number of seconds the device will wait for the response.
-  * (optional) `hono-ttl`: The *time-to-live* in number of seconds for event messages.
+  * (required) *content-type*: The type of payload contained in the request body.
+  * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
+  * (optional) *hono-ttl*: The *time-to-live* in number of seconds for event messages.
 * Request Body:
   * (required) Arbitrary payload encoded according to the given content type.
 * Response Headers:
-  * (optional) `content-type`: A media type describing the semantics and format of payload contained in the response body.
+  * (optional) *content-type*: A media type describing the semantics and format of payload contained in the response body.
     This header will only be present if the response contains a command to be executed by the device which requires input
     data or if the request failed and the response body contains error details.
-  * (optional) `hono-command`: The name of the command to execute. This header will only be present if the response contains a command to be executed by the device.
-  * (optional) `hono-cmd-req-id`: An identifier that the device must include in its response to a command. This header will only be present if the response contains a command to be executed by the device.
+  * (optional) *hono-command*: The name of the command to execute. This header will only be present if the response
+    contains a command to be executed by the device.
+  * (optional) *hono-cmd-req-id*: An identifier that the device must include in its response to a command. This header
+    will only be present if the response contains a command to be executed by the device.
 * Response Body:
   * (optional) Arbitrary data serving as input to a command to be executed by the device, if status code is 200.
   * (optional) Error details, if status code is >= 400.
 * Status Codes:
-  * 200 (OK): The event has been accepted and put to a persistent store for delivery to consumers. The response contains a command for the device to execute.
+  * 200 (OK): The event has been accepted and put to a persistent store for delivery to consumers. The response contains
+    a command for the device to execute.
   * 202 (Accepted): The event has been accepted and put to a persistent store for delivery to consumers.
   * 400 (Bad Request): The request cannot be processed. Possible reasons for this include:
     * The content type header is missing.
     * The request body is empty but the event is not of type [empty-notification]({{< relref "/api/event#empty-notification" >}}).
-  * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted. Possible reasons for this include:
+  * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
+    Possible reasons for this include:
     * The given tenant is not allowed to use this protocol adapter.
     * The given device does not belong to the given tenant.
   * 404 (Not Found): The request cannot be processed because the device is disabled or does not exist.
-  * 413 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum supported size.
-  * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
-  * 503 (Service Unavailable): The request cannot be processed because there is no consumer of events for the given tenant connected to Hono, or the consumer didn't process the event.
+  * 413 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum
+    supported size.
+  * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period
+    is exceeded.
+  * 503 (Service Unavailable): The request cannot be processed because there is no consumer of events for the given
+    tenant connected to Hono, or the consumer didn't process the event.
 
-This resource MUST be used by devices that have not authenticated to the protocol adapter. Note that this requires the `HONO_HTTP_AUTHENTICATION_REQUIRED` configuration property to be explicitly set to `false`.
+This resource MUST be used by devices that have not authenticated to the protocol adapter. Note that this requires the
+*HONO_HTTP_AUTHENTICATION_REQUIRED* configuration property to be explicitly set to `false`.
 
 **Examples**
 
@@ -392,42 +472,58 @@ content-length: 0
 * URI: `/event/${tenantId}/${deviceId}`
 * Method: `PUT`
 * Request Headers:
-  * (optional) `authorization`: The gateway's *auth-id* and plain text password encoded according to the [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the gateway to present a client certificate as part of the TLS handshake during connection establishment.
-  * (required) `content-type`: The type of payload contained in the request body.
-  * (optional) `hono-ttd`: The number of seconds the device will wait for the response.
-  * (optional) `hono-ttl`: The *time-to-live* in number of seconds for event messages.
+  * (optional) *authorization*: The gateway's *auth-id* and plain text password encoded according to the
+    [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the
+    gateway to present a client certificate as part of the TLS handshake during connection establishment.
+  * (required) *content-type*: The type of payload contained in the request body.
+  * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
+  * (optional) *hono-ttl*: The *time-to-live* in number of seconds for event messages.
 * Request Body:
   * (required) Arbitrary payload encoded according to the given content type.
 * Response Headers:
-  * (optional) `content-type`: A media type describing the semantics and format of payload contained in the response body.
+  * (optional) *content-type*: A media type describing the semantics and format of payload contained in the response body.
     This header will only be present if the response contains a command to be executed by the device which requires input
     data or if the request failed and the response body contains error details.
-  * (optional) `hono-command`: The name of the command to execute. This header will only be present if the response contains a command to be executed by the device.
-  * (optional) `hono-cmd-req-id`: An identifier that the device must include in its response to a command. This header will only be present if the response contains a command to be executed by the device.
-  * (optional) `hono-cmd-target-device`: The id of the device that shall execute the command. This header will only be present if the response contains a command to be executed by the device.
+  * (optional) *hono-command*: The name of the command to execute. This header will only be present if the response
+    contains a command to be executed by the device.
+  * (optional) *hono-cmd-req-id*: An identifier that the device must include in its response to a command. This header
+    will only be present if the response contains a command to be executed by the device.
+  * (optional) *hono-cmd-target-device*: The id of the device that shall execute the command. This header will only be
+    present if the response contains a command to be executed by the device.
 * Response Body:
   * (optional) Arbitrary data serving as input to a command to be executed by the device, if status code is 200.
   * (optional) Error details, if status code is >= 400.
 * Status Codes:
-  * 200 (OK): The event has been accepted and put to a persistent store for delivery to consumers. The response contains a command for the device to execute.
+  * 200 (OK): The event has been accepted and put to a persistent store for delivery to consumers. The response
+    contains a command for the device to execute.
   * 202 (Accepted): The event has been accepted and put to a persistent store for delivery to consumers.
   * 400 (Bad Request): The request cannot be processed. Possible reasons for this include:
     * The content type header is missing.
     * The request body is empty but the event is not of type [empty-notification]({{< relref "/api/event#empty-notification" >}}).
   * 401 (Unauthorized): The request cannot be processed because the request does not contain valid credentials.
-  * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted. Possible reasons for this include:
+  * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
+    Possible reasons for this include:
     * The tenant that the gateway belongs to is not allowed to use this protocol adapter.
     * The device belongs to another tenant than the gateway.
     * The gateway is not authorized to act *on behalf of* the device.
     * The gateway associated with the device is not registered or disabled.
   * 404 (Not Found): The request cannot be processed because the device is disabled or does not exist.
-  * 413 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum supported size.
-  * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
-  * 503 (Service Unavailable): The request cannot be processed because there is no consumer of events for the given tenant connected to Hono, or the consumer didn't process the event.
+  * 413 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum
+    supported size.
+  * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period
+    is exceeded.
+  * 503 (Service Unavailable): The request cannot be processed because there is no consumer of events for the given
+    tenant connected to Hono, or the consumer didn't process the event.
 
-This resource can be used by *gateway* components to publish data *on behalf of* other devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the parameters from the URI are used to identify the device that the gateway publishes data for.
+This resource can be used by *gateway* components to publish data *on behalf of* other devices which do not connect to
+a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based
+technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the credentials
+provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway
+whereas the parameters from the URI are used to identify the device that the gateway publishes data for.
 
-The protocol adapter checks the gateway's authority to publish data on behalf of the device implicitly by means of retrieving a *registration assertion* for the device from the [configured Device Registration service]({{< relref "/admin-guide/common-config#device-registration-service-connection-configuration" >}}).
+The protocol adapter checks the gateway's authority to publish data on behalf of the device implicitly by means of
+retrieving a *registration assertion* for the device from the configured
+[Device Registration service]({{< relref "/admin-guide/common-config#device-registration-service-connection-configuration" >}}).
 
 **Examples**
 
@@ -440,19 +536,28 @@ HTTP/1.1 202 Accepted
 content-length: 0
 ~~~
 
-**NB** The example above assumes that a gateway device has been registered with `hashed-password` credentials with *auth-id* `gw` and password `gw-secret` which is authorized to publish data *on behalf of* device `4712`.
+**NB** The example above assumes that a gateway device has been registered with `hashed-password` credentials with
+*auth-id* `gw` and password `gw-secret` which is authorized to publish data *on behalf of* device `4712`.
 
 ## Command & Control
 
-The HTTP adapter enables devices to receive commands that have been sent by business applications. Commands are delivered to the device by means of an HTTP response message. That means a device first has to send a request, indicating how long it will wait for the response. That request can either be a telemetry or event message, with a `hono-ttd` header or query parameter (`ttd` for `time till disconnect`) specifying the number of seconds the device will wait for the response. The business application can react on that message by sending a command message, targeted at the device. The HTTP adapter will then send the command message as part of the HTTP response message with status `200` (OK) to the device. If the HTTP adapter receives no command message in the given time period, a `202` (Accepted) response will be sent to the device (provided the request was valid).
+The HTTP adapter enables devices to receive commands that have been sent by business applications. Commands are
+delivered to the device by means of an HTTP response message. That means a device first has to send a request,
+indicating how long it will wait for the response. That request can either be a telemetry or event message, with a
+*hono-ttd* header or query parameter (`ttd` for `time till disconnect`) specifying the number of seconds the device will
+wait for the response. The business application can react on that message by sending a command message, targeted at
+the device. The HTTP adapter will then send the command message as part of the HTTP response message with status `200`
+(OK) to the device. If the HTTP adapter receives no command message in the given time period, a `202` (Accepted)
+response will be sent to the device (provided the request was valid).
 
 ### Specifying the Time a Device will wait for a Response
 
-The adapter lets devices indicate the number of seconds they will wait for a response by setting a header or a query parameter.
+The adapter lets devices indicate the number of seconds they will wait for a response by setting a header or a query
+parameter.
 
 #### Using an HTTP Header
 
-The (optional) `hono-ttd` header can be set in requests for publishing telemetry data or events.
+The (optional) *hono-ttd* header can be set in requests for publishing telemetry data or events.
 
 Example:
 
@@ -465,7 +570,7 @@ content-length: 0
 
 #### Using a Query Parameter
 
-Alternatively the `hono-ttd` query parameter can be used:
+Alternatively the *hono-ttd* query parameter can be used:
 
 ~~~sh
 curl -i -u sensor1@DEFAULT_TENANT:hono-secret -H 'content-type: application/json' --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry?hono-ttd=60
@@ -476,48 +581,74 @@ content-length: 0
 
 ### Commands handled by gateways
 
-Authenticated gateways will receive commands for devices which do not connect to a protocol adapter directly but instead are connected to the gateway. Corresponding devices have to be configured so that they can be used with a gateway. See [Configuring Gateway Devices]({{< relref "/admin-guide/file-based-device-registry-config#configuring-gateway-devices" >}}) for details.
+Authenticated gateways will receive commands for devices which do not connect to a protocol adapter directly but
+instead are connected to the gateway. Corresponding devices have to be configured so that they can be used with a
+gateway. See
+[Configuring Gateway Devices]({{< relref "/admin-guide/file-based-device-registry-config#configuring-gateway-devices" >}})
+for details.
 
-A gateway can send a request with the `hono-ttd` header or query parameter on the `/event` or `/telemetry` URI, indicating its readiness to receive a command for *any* device it acts on behalf of. Note that in this case, the business application will be notified with the gateway id in the `device_id` property of the downstream message.
+A gateway can send a request with the *hono-ttd* header or query parameter on the `/event` or `/telemetry` URI, indicating
+its readiness to receive a command for *any* device it acts on behalf of. Note that in this case, the business
+application will be notified with the gateway id in the `device_id` property of the downstream message.
 
-An authenticated gateway can also indicate its readiness to receive a command targeted at a *specific* device. For that, the `/event/${tenantId}/${deviceId}` or `/telemetry/${tenantId}/${deviceId}` URI is to be used, containing the id of the device to receive a command for. The business application will receive a notification with that device id.
+An authenticated gateway can also indicate its readiness to receive a command targeted at a *specific* device. For that,
+the `/event/${tenantId}/${deviceId}` or `/telemetry/${tenantId}/${deviceId}` URI is to be used, containing the id of the device
+to receive a command for. The business application will receive a notification with that device id.
 
-If there are multiple concurrent requests with a `hono-ttd` header or query parameter, sent by the command target device and/or one or more of its potential gateways, the HTTP adapter will choose the device or gateway to send the command to as follows:
+If there are multiple concurrent requests with a *hono-ttd* header or query parameter, sent by the command target device
+and/or one or more of its potential gateways, the HTTP adapter will choose the device or gateway to send the command to
+as follows:
 
-- A request done by the command target device or by a gateway specifically done for that device, has precedence. If there are multiple, concurrent such requests, the last one will get the command message (if received) in its response. Note that the other requests won't be answered with a command message in their response event if the business application sent multiple command messages. That means commands for a single device can only be requested sequentially, not in parallel.
-- If the above doesn't apply, a single `hono-ttd` request on the `/event` or `/telemetry` URI, sent by a gateway that the command target device is configured for, will get the command message in its response.
-- If there are multiple, concurrent such requests by different gateways, all configured for the command target device, the request by the gateway will be chosen, through which the target device has last sent a telemetry or event message. If the target device hasn't sent a message yet and it is thereby unknown via which gateway the device communicates, then one of the requests will be chosen randomly to set the command in its response. 
+* A request done by the command target device or by a gateway specifically done for that device, has precedence. If
+  there are multiple, concurrent such requests, the last one will get the command message (if received) in its response.
+  Note that the other requests won't be answered with a command message in their response event if the business
+  application sent multiple command messages. That means commands for a single device can only be requested sequentially,
+  not in parallel.
+* If the above doesn't apply, a single *hono-ttd* request on the `/event` or `/telemetry` URI, sent by a gateway that the
+  command target device is configured for, will get the command message in its response.
+* If there are multiple, concurrent such requests by different gateways, all configured for the command target device,
+  the request by the gateway will be chosen, through which the target device has last sent a telemetry or event message.
+  If the target device hasn't sent a message yet and it is thereby unknown via which gateway the device communicates,
+  then one of the requests will be chosen randomly to set the command in its response. 
 
 ### Sending a Response to a Command (authenticated Device)
 
 * URI: `/command/res/${commandRequestId}` or `/command/res/${commandRequestId}?hono-cmd-status=${status}`
 * Method: `POST`
 * Request Headers:
-  * (optional) `authorization`: The device's *auth-id* and plain text password encoded according to the [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the device to present a client certificate as part of the TLS handshake during connection establishment.
-  * (optional) `content-type`: A media type describing the semantics and format of the payload contained in the request body. This header may be set if the result of processing the command on the device is non-empty. In this case the result data is contained in the request body.
-  * (optional) `hono-cmd-status`: The status of the command execution. If not set, the adapter expects that the URI contains it
-    as request parameter at the end.
+  * (optional) *authorization*: The device's *auth-id* and plain text password encoded according to the
+    [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the
+    device to present a client certificate as part of the TLS handshake during connection establishment.
+  * (optional) *content-type*: A media type describing the semantics and format of the payload contained in the request
+    body. This header may be set if the result of processing the command on the device is non-empty. In this case the
+    result data is contained in the request body.
+  * (optional) *hono-cmd-status*: The status of the command execution. If not set, the adapter expects that the URI
+    contains it as a query parameter.
 * Request Body:
   * (optional) Arbitrary data representing the result of processing the command on the device.
 * Response Headers:
-  * (optional) `content-type`: A media type describing the semantics and format of payload contained in the response body.
+  * (optional) *content-type*: A media type describing the semantics and format of payload contained in the response body.
     This header will only be present if the request failed and the response body contains error details.
 * Response Body:
   * (optional) Error details, if status code is >= 400.
 * Status Codes:
   * 202 (Accepted): The response has been successfully delivered to the application that has sent the command.
   * 400 (Bad Request): The request cannot be processed because the command status is missing.
-  * 401 (Unauthorized): The request cannot be processed because the request does not contain valid credentials.  
-  * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted. Possible reasons for this include:
+  * 401 (Unauthorized): The request cannot be processed because the request does not contain valid credentials.
+  * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
+    Possible reasons for this include:
     * The given tenant is not allowed to use this protocol adapter.
   * 404 (Not Found): The request cannot be processed because the device is disabled or does not exist.
-  * 413 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum supported size.
-  * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
+  * 413 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum
+    supported size.
+  * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period
+    is exceeded.
   * 503 (Service Unavailable): The request cannot be processed. Possible reasons for this include:
     * There is no application listening for a reply to the given *commandRequestId*.
     * The application has already given up on waiting for a response.
 
-This is the preferred way for devices to respond to commands. It is available only if the protocol adapter is configured to require devices to authenticate (which is the default).
+This is the preferred way for devices to respond to commands. It is available only if the protocol adapter is
+configured to require devices to authenticate (which is the default).
 
 **Example**
 
@@ -535,34 +666,40 @@ content-length: 0
 * URI: `/command/res/${tenantId}/${deviceId}/${commandRequestId}` or `/command/res/${tenantId}/${deviceId}/${commandRequestId}?hono-cmd-status=${status}`
 * Method: `PUT`
 * Request Headers:
-  * (optional) `content-type`: A media type describing the semantics and format of the payload contained in the request body (the outcome of processing the command).
-  * (optional) `hono-cmd-status`: The status of the command execution. If not set, the adapter expects that the URI contains it
-    as request parameter at the end.
+  * (optional) *content-type*: A media type describing the semantics and format of the payload contained in the request
+    body (the outcome of processing the command).
+  * (optional) *hono-cmd-status*: The status of the command execution. If not set, the adapter expects that the URI
+    contains it as a query parameter.
 * Request Body:
   * (optional) Arbitrary data representing the result of processing the command on the device.
 * Response Headers:
-  * (optional) `content-type`: A media type describing the semantics and format of payload contained in the response body.
+  * (optional) *content-type*: A media type describing the semantics and format of payload contained in the response body.
     This header will only be present if the request failed and the response body contains error details.
 * Response Body:
   * (optional) Error details, if status code is >= 400.
 * Status Codes:
   * 202 (Accepted): The response has been successfully delivered to the application that has sent the command.
   * 400 (Bad Request): The request cannot be processed because the command status is missing.
-  * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted. Possible reasons for this might be:
+  * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
+    Possible reasons for this might be:
     * The given tenant is not allowed to use this protocol adapter.
     * The given device does not belong to the given tenant.
   * 404 (Not Found): The request cannot be processed because the device is disabled or does not exist.
-  * 413 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum supported size.
-  * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
+  * 413 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum
+    supported size.
+  * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period
+    is exceeded.
   * 503 (Service Unavailable): The request cannot be processed. Possible reasons for this include:
     * There is no application listening for a reply to the given *commandRequestId*.
     * The application has already given up on waiting for a response.
 
-This resource MUST be used by devices that have not authenticated to the protocol adapter. Note that this requires the `HONO_HTTP_AUTHENTICATION_REQUIRED` configuration property to be explicitly set to `false`.
+This resource MUST be used by devices that have not authenticated to the protocol adapter. Note that this requires the
+*HONO_HTTP_AUTHENTICATION_REQUIRED* configuration property to be explicitly set to `false`.
 
 **Examples**
 
-Send a response to a previously received command with the command-request-id `req-id-uuid` for the unauthenticated device `4711`:
+Send a response to a previously received command with the command-request-id `req-id-uuid` for the unauthenticated
+device `4711`:
 
 ~~~sh
 curl -i -X PUT -H 'content-type: application/json' --data-binary '{"brightness-changed": true}' http://127.0.0.1:8080/command/res/DEFAULT_TENANT/4711/req-id-uuid?hono-cmd-status=200
@@ -573,38 +710,51 @@ content-length: 0
 
 ### Sending a Response to a Command (authenticated Gateway)
 
-* URI: `/command/res/${tenantId}/${deviceId}/${commandRequestId}` or `/command/res/${tenantId}/${deviceId}/${commandRequestId}?hono-cmd-status=${status}`
+* URI: `/command/res/${tenantId}/${deviceId}/${commandRequestId}` or
+  `/command/res/${tenantId}/${deviceId}/${commandRequestId}?hono-cmd-status=${status}`
 * Method: `PUT`
 * Request Headers:
-  * (optional) `authorization`: The gateway's *auth-id* and plain text password encoded according to the [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the gateway to present a client certificate as part of the TLS handshake during connection establishment.
-  * (optional) `content-type`: A media type describing the semantics and format of the payload contained in the request body (the outcome of processing the command).
-  * (optional) `hono-cmd-status`: The status of the command execution. If not set, the adapter expects that the URI contains it
-    as request parameter at the end.
+  * (optional) *authorization*: The gateway's *auth-id* and plain text password encoded according to the
+    [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the
+    gateway to present a client certificate as part of the TLS handshake during connection establishment.
+  * (optional) *content-type*: A media type describing the semantics and format of the payload contained in the request
+    body (the outcome of processing the command).
+  * (optional) *hono-cmd-status*: The status of the command execution. If not set, the adapter expects that the URI
+    contains it as a query parameter.
 * Request Body:
   * (optional) Arbitrary data representing the result of processing the command on the device.
 * Response Headers:
-  * (optional) `content-type`: A media type describing the semantics and format of payload contained in the response body.
+  * (optional) *content-type*: A media type describing the semantics and format of payload contained in the response body.
     This header will only be present if the request failed and the response body contains error details.
 * Response Body:
   * (optional) Error details, if status code is >= 400.
 * Status Codes:
   * 202 (Accepted): The response has been successfully delivered to the application that has sent the command.
   * 400 (Bad Request): The request cannot be processed because the command status is missing.
-  * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted. Possible reasons for this might be:
+  * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
+    Possible reasons for this might be:
     * The given tenant is not allowed to use this protocol adapter.
     * The given device does not belong to the given tenant.
     * The gateway is not authorized to act *on behalf of* the device.
     * The gateway associated with the device is not registered or disabled.
   * 404 (Not Found): The request cannot be processed because the device is disabled or does not exist.
-  * 413 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum supported size.
-  * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
+  * 413 (Request Entity Too Large): The request cannot be processed because the request body exceeds the maximum
+    supported size.
+  * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period
+    is exceeded.
   * 503 (Service Unavailable): The request cannot be processed. Possible reasons for this include:
     * There is no application listening for a reply to the given *commandRequestId*.
     * The application has already given up on waiting for a response.
 
-This resource can be used by *gateway* components to send the response to a command *on behalf of* other devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the parameters from the URI are used to identify the device that the gateway publishes data for.
+This resource can be used by *gateway* components to send the response to a command *on behalf of* other devices which
+do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth
+radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the
+credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate
+the gateway whereas the parameters from the URI are used to identify the device that the gateway publishes data for.
 
-The protocol adapter checks the gateway's authority to send responses to a command on behalf of the device implicitly by means of retrieving a *registration assertion* for the device from the [configured Device Registration service]({{< relref "/admin-guide/common-config#device-registration-service-connection-configuration" >}}).
+The protocol adapter checks the gateway's authority to send responses to a command on behalf of the device implicitly
+by means of retrieving a *registration assertion* for the device from the configured
+[Device Registration service]({{< relref "/admin-guide/common-config#device-registration-service-connection-configuration" >}}).
 
 **Examples**
 
@@ -617,37 +767,46 @@ HTTP/1.1 202 Accepted
 content-length: 0
 ~~~
 
-**NB** The example above assumes that a gateway device has been registered with `hashed-password` credentials with *auth-id* `gw` and password `gw-secret` which is authorized to publish data *on behalf of* device `4712`.
+**NB** The example above assumes that a gateway device has been registered with `hashed-password` credentials with
+*auth-id* `gw` and password `gw-secret` which is authorized to publish data *on behalf of* device `4712`.
 
 ## Downstream Meta Data
 
-The adapter includes the following meta data in the application properties of messages being sent downstream:
+The adapter includes the following meta data in messages being sent downstream:
 
 | Name               | Type      | Description                                                     |
 | :----------------- | :-------- | :-------------------------------------------------------------- |
 | *device_id*        | *string*  | The identifier of the device that the message originates from.  |
 | *orig_adapter*     | *string*  | Contains the adapter's *type name* which can be used by downstream consumers to determine the protocol adapter that the message has been received over. The HTTP adapter's type name is `hono-http`. |
 | *orig_address*     | *string*  | Contains the (relative) URI that the device has originally posted the data to. |
-| *ttd*              | *integer* | Contains the effective number of seconds that the device will wait for a response. This property is only set if the HTTP request contains the `hono-ttd` header or request parameter. |
+| *ttd*              | *integer* | Contains the effective number of seconds that the device will wait for a response. This property is only set if the HTTP request contains the *hono-ttd* header or request parameter. |
 
-The adapter also considers *defaults* registered for the device at either the [tenant]({{< relref "/api/tenant#tenant-information-format" >}}) or the [device level]({{< relref "/api/device-registration#assert-device-registration" >}}). The values of the default properties are determined as follows:
+The adapter also considers *defaults* registered for the device at either the
+[tenant]({{< relref "/api/tenant#tenant-information-format" >}}) or the
+[device level]({{< relref "/api/device-registration#assert-device-registration" >}}).
+The values of the default properties are determined as follows:
 
 1. If the message already contains a non-empty property of the same name, the value if unchanged.
-2. Otherwise, if a default property of the same name is defined in the device's registration information, that value is used.
-3. Otherwise, if a default property of the same name is defined for the tenant that the device belongs to, that value is used.
+2. Otherwise, if a default property of the same name is defined in the device's registration information,
+   that value is used.
+3. Otherwise, if a default property of the same name is defined for the tenant that the device belongs to,
+   that value is used.
 
-Note that of the standard AMQP 1.0 message properties only the *content-type* and *ttl* can be set this way to a default value.
+Note that of the standard AMQP 1.0 message properties only the *content-type* and *ttl* can be set this way to a
+default value.
 
 ### Event Message Time-to-live
 
-Events published by devices will usually be persisted by the AMQP Messaging Network in order to support deferred delivery to downstream consumers.
-In most cases the AMQP Messaging Network can be configured with a maximum *time-to-live* to apply to the events so that the events will be removed
-from the persistent store if no consumer has attached to receive the event before the message expires.
+Events published by devices will usually be persisted by the messing infrastructure in order to support deferred
+delivery to downstream consumers.
 
-In order to support environments where the AMQP Messaging Network cannot be configured accordingly, the protocol adapter supports setting a
-downstream event message's *ttl* property based on the *hono-ttl* property set as a header or a query parameter in the event requests by the devices.
-Also the default *ttl* and *max-ttl* values can be configured for a tenant/device as described in the [Tenant API]({{< relref "/api/tenant#resource-limits-configuration-format" >}}).
+In most cases, the messaging infrastructure can be configured with a maximum *time-to-live* to apply to the events so
+that the events will be removed from the persistent store if no consumer has attached to receive the event before
+the message expires.
 
+In order to support environments where the messaging infrastructure cannot be configured accordingly, the protocol
+adapter supports setting a downstream event message's *ttl* property based on the default *ttl* and *max-ttl* values
+configured for a tenant/device as described in the [Tenant API]({{< relref "/api/tenant#resource-limits-configuration-format" >}}).
 
 ## Tenant specific Configuration
 
@@ -656,5 +815,5 @@ The following properties are (currently) supported:
 
 | Name               | Type       | Default Value | Description                                                     |
 | :----------------- | :--------- | :------------ | :-------------------------------------------------------------- |
-| *enabled*          | *boolean*  | `true`       | If set to `false` the adapter will reject all data from devices belonging to the tenant. |
-| *max-ttd*          | *integer*  | `60`         | Defines a tenant specific upper limit for the *time until disconnect* property that devices may include in requests for uploading telemetry data or events. Please refer to the [Command & Control concept page]({{< relref "/concepts/command-and-control/index.md" >}}) for a discussion of this parameter's purpose and usage.<br>This property can be set for the `hono-http` adapter type as an *extension* property in the adapter section of the tenant configuration.<br>If it is not set, then the default value of `60` seconds is used.|
+| *enabled*          | *boolean*  | `true`         | If set to `false` the adapter will reject all data from devices belonging to the tenant. |
+| *max-ttd*          | *integer*  | `60`            Defines a tenant specific upper limit for the *time until disconnect* property that devices may include in requests for uploading telemetry data or events. Please refer to the [Command & Control concept page]({{< relref "/concepts/command-and-control/index.md" >}}) for a discussion of this parameter's purpose and usage.<br>This property can be set for the `hono-http` adapter type as an *extension* property in the adapter section of the tenant configuration.<br>If it is not set, then the default value of `60` seconds is used.|

--- a/site/documentation/content/user-guide/http-adapter.md
+++ b/site/documentation/content/user-guide/http-adapter.md
@@ -39,7 +39,7 @@ The adapter extracts the *auth-id*, *tenant* and password from the request heade
 credentials that the
 [configured Credentials service]({{< relref "/admin-guide/common-config#credentials-service-connection-configuration" >}})
 has on record for the client as described in
-[Username/Password based Authentication]({{< relref "/concepts/device-identity#username-password-based-authentication" >}}).
+[Username/Password based Authentication]({{< relref "/concepts/device-identity#usernamepassword-based-authentication" >}}).
 If the credentials match, the client has been authenticated successfully and the request is being processed.
 
 **NB** There is a subtle difference between the *device identifier* (*device-id*) and the *auth-id* a device uses
@@ -797,7 +797,7 @@ default value.
 
 ### Event Message Time-to-live
 
-Events published by devices will usually be persisted by the messing infrastructure in order to support deferred
+Events published by devices will usually be persisted by the messaging infrastructure in order to support deferred
 delivery to downstream consumers.
 
 In most cases, the messaging infrastructure can be configured with a maximum *time-to-live* to apply to the events so

--- a/site/documentation/content/user-guide/kura-adapter.md
+++ b/site/documentation/content/user-guide/kura-adapter.md
@@ -49,7 +49,7 @@ The adapter extracts the *auth-id*, *tenant* and password from the CONNECT packe
 credentials that the
 [configured Credentials service]({{< relref "/admin-guide/common-config#credentials-service-connection-configuration" >}})
 has on record for the client as described in
-[Username/Password based Authentication]({{< relref "/concepts/device-identity#username-password-based-authentication" >}}).
+[Username/Password based Authentication]({{< relref "/concepts/device-identity#usernamepassword-based-authentication" >}}).
 If the credentials match, the client has been authenticated successfully and the connection is being established.
 
 **NB** There is a subtle difference between the *device identifier* (*device-id*) and the *auth-id* a device uses
@@ -137,7 +137,7 @@ default value.
 
 ### Event Message Time-to-live
 
-Events published by devices will usually be persisted by the messing infrastructure in order to support deferred
+Events published by devices will usually be persisted by the messaging infrastructure in order to support deferred
 delivery to downstream consumers.
 
 In most cases, the messaging infrastructure can be configured with a maximum *time-to-live* to apply to the events so

--- a/site/documentation/content/user-guide/kura-adapter.md
+++ b/site/documentation/content/user-guide/kura-adapter.md
@@ -20,46 +20,46 @@ later is still available by means of Hono's standard MQTT adapter.
 ## Authentication
 
 The Kura adapter by default requires devices (gateways) to authenticate during connection establishment.
-The adapter supports both the authentication based on the username/password provided in an MQTT CONNECT packet as well as client
-certificate based authentication as part of a TLS handshake for that purpose.
+The adapter supports both the authentication based on the username/password provided in an MQTT CONNECT packet as well
+as client certificate based authentication as part of a TLS handshake for that purpose.
 
 The adapter tries to authenticate the device using these mechanisms in the following order
 
 ### Client Certificate
 
-When a device uses a client certificate for authentication during the TLS handshake, the adapter tries to determine the tenant
-that the device belongs to based on the *issuer DN* contained in the certificate.
-In order for the lookup to succeed, the tenant's trust anchor needs to be configured by means of registering the
-[trusted certificate authority]({{< relref "/api/tenant#tenant-information-format" >}}). The device's client certificate will then be
-validated using the registered trust anchor, thus implicitly establishing the tenant that the device belongs to.
-In a second step, the adapter uses the Credentials API's *get* operation to retrieve the credentials on record, including the client
-certificate's *subject DN* as the *auth-id*, `x509-cert` as the *type* of secret and the MQTT client identifier as *client-id* in the
-request payload.
+The MQTT adapter supports authenticating clients based on TLS cipher suites using a digital signature based key
+exchange algorithm as described in [RFC 5246 (TLS 1.2)](https://datatracker.ietf.org/doc/html/rfc5246) and
+[RFC 8446 (TLS 1.3)](https://datatracker.ietf.org/doc/html/rfc8446). This requires a client to provide an X.509
+certificate containing a public key that can be used for digital signature. The adapter uses the information in the
+client certificate to verify the device's identity as described in
+[Client Certificate based Authentication]({{< relref "/concepts/device-identity#client-certificate-based-authentication" >}}).
 
-**NB** The adapter needs to be [configured for TLS]({{< relref "/admin-guide/secure_communication#mqtt-adapter" >}}) in order to support this mechanism.
+**NB** The adapter needs to be [configured for TLS]({{< relref "/admin-guide/secure_communication#mqtt-adapter" >}})
+in order to support this mechanism.
 
 ### Username/Password
 
-When a device wants to authenticate using this mechanism, it needs to provide a *username* and a *password* in the MQTT *CONNECT* packet
-it sends in order to initiate the connection. The *username* must have the form *auth-id@tenant*, e.g. `sensor1@DEFAULT_TENANT`.
-The adapter verifies the credentials provided by the client against the credentials that the
-[configured Credentials service]({{< relref "/admin-guide/common-config#credentials-service-connection-configuration" >}}) has on record for the client.
-The adapter uses the Credentials API's *get* operation to retrieve the credentials on record, including the *tenant* and *auth-id* provided
-by the client in the *username*, `hashed-password` as the *type* of secret and the MQTT client identifier as *client-id* in the request payload.
+The MQTT adapter supports authenticating clients based on credentials provided during MQTT connection establishment.
+This means that clients need to provide a *user* and a *password* field in their MQTT CONNECT packet as defined in
+[MQTT Version 3.1.1, Section 3.1](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718028)
+when connecting to the MQTT adapter. The username provided in the *user* field must match the pattern
+*auth-id@tenant*, e.g. `sensor1@DEFAULT_TENANT`.
 
-Please refer to the [Eclipse Kura documentation](http://eclipse.github.io/kura/config/cloud-services.html) on how to configure the
-gateway's cloud service connection accordingly. It is important to set the gateway's *topic.context.account-name* to the ID of the
-Hono tenant that the gateway has been registered with whereas the gateway's *client-id* needs to be set to the corresponding Hono
-device ID. The *auth-id* used as part of the gateway's *username* property needs to match the authentication identifier of a set of
-credentials registered for the device ID in Hono's Credentials service. In other words, the credentials configured on the gateway
-need to belong to the corresponding device ID.
+The adapter extracts the *auth-id*, *tenant* and password from the CONNECT packet and verifies them using the
+credentials that the
+[configured Credentials service]({{< relref "/admin-guide/common-config#credentials-service-connection-configuration" >}})
+has on record for the client as described in
+[Username/Password based Authentication]({{< relref "/concepts/device-identity#username-password-based-authentication" >}}).
+If the credentials match, the client has been authenticated successfully and the connection is being established.
 
-**NB** There is a subtle difference between the *device identifier* (*device-id*) and the *auth-id* a device uses for authentication.
-See [Device Identity]({{< relref "/concepts/device-identity.md" >}}) for a discussion of the concepts.
+**NB** There is a subtle difference between the *device identifier* (*device-id*) and the *auth-id* a device uses
+for authentication. See [Device Identity]({{< relref "/concepts/device-identity.md" >}}) for a discussion of the
+concepts.
 
 ## Resource Limit Checks
 
-The adapter performs additional checks regarding resource limits when a client tries to connect and/or send a message to the adapter.
+The adapter performs additional checks regarding resource limits when a client tries to connect and/or send a message
+to the adapter.
 
 ### Connection Limits
 
@@ -72,9 +72,9 @@ Please refer to [resource-limits]({{< ref "/concepts/resource-limits.md" >}}) fo
 
 ### Connection Duration Limits
 
-The adapter rejects a client's connection attempt with return code `0x05`, indicating `Connection Refused: not authorized`, if the
-[connection duration limit]({{< relref "/concepts/resource-limits#connection-duration-limit" >}}) that has been configured for
-the client's tenant is exceeded.
+The adapter rejects a client's connection attempt with return code `0x05`, indicating `Connection Refused: not authorized`, if
+the [connection duration limit]({{< relref "/concepts/resource-limits#connection-duration-limit" >}}) that has been
+configured for the client's tenant is exceeded.
 
 ### Message Limits
 
@@ -83,27 +83,33 @@ The adapter
 * discards any MQTT PUBLISH packet containing telemetry data or an event that is sent by a client and
 * rejects any AMQP 1.0 message containing a command sent by a north bound application
 
-if the [message limit]({{< relref "/concepts/resource-limits.md" >}}) that has been configured for the device's tenant is exceeded.
+if the [message limit]({{< relref "/concepts/resource-limits.md" >}}) that has been configured for the device's tenant
+is exceeded.
 
 ## Connection Events
 
-The adapter can emit [Connection Events]({{< relref "/api/event#connection-event" >}}) for client connections being established and/or terminated.
-Please refer to the [common configuration options]({{< relref "/admin-guide/common-config#connection-event-producer-configuration" >}})
+The adapter can emit [Connection Events]({{< relref "/api/event#connection-event" >}}) for client connections being
+established and/or terminated. Please refer to the
+[common configuration options]({{< relref "/admin-guide/common-config#connection-event-producer-configuration" >}})
 for details regarding how to enable this behavior.
 
 The adapter includes the *client identifier* from the client's MQTT CONNECT packet as the Connection Event's *remote-id*.
 
 ## Publishing Data
 
-Once the gateway has established a connection to the Kura adapter, all *control* and *data* messages published by applications running on
-the gateway are sent to the adapter and mapped to Hono's Telemetry and Event API endpoints as follows:
+Once the gateway has established a connection to the Kura adapter, all *control* and *data* messages published by
+applications running on the gateway are sent to the adapter and mapped to Hono's Telemetry and Event API endpoints as
+follows:
 
-1. The adapter treats all messages that are published to a topic starting with the configured `HONO_KURA_CONTROL_PREFIX` as control messages.
+1. The adapter treats all messages that are published to a topic starting with the configured `HONO_KURA_CONTROL_PREFIX` as
+   control messages.
    All other messages are considered to be data messages.
-1. *control* messages with QoS 0 are forwarded to Hono's telemetry endpoint whereas messages with QoS 1 are forwarded to the event endpoint.
-   The corresponding AMQP 1.0 messages that are sent downstream have a content type of `application/vnd.eclipse.kura-control`.
-1. *data* messages with QoS 0 are forwarded to the telemetry endpoint whereas messages with QoS 1 are forwarded to the event endpoint.
-   The corresponding AMQP 1.0 messages that are sent downstream have a content type of `application/vnd.eclipse.kura-data`.
+1. *control* messages with QoS 0 are forwarded to Hono's telemetry endpoint whereas messages with QoS 1 are forwarded to
+   the event endpoint. The corresponding messages that are sent downstream have a content type of
+   `application/vnd.eclipse.kura-control`.
+1. *data* messages with QoS 0 are forwarded to the telemetry endpoint whereas messages with QoS 1 are forwarded to the
+   event endpoint. The corresponding messages that are sent downstream have a content type of
+   `application/vnd.eclipse.kura-data`.
 
 ## Downstream Meta Data
 
@@ -115,29 +121,39 @@ The adapter includes the following meta data in messages being sent downstream:
 | *orig_adapter*     | *application*   | *string*  | Contains the adapter's *type name* which can be used by downstream consumers to determine the protocol adapter that the message has been received over. The Kura adapter's type name is `hono-kura-mqtt`. |
 | *orig_address*     | *application*   | *string*  | Contains the name of the MQTT topic that the Kura gateway has originally published the data to. |
 
-The adapter also considers *defaults* registered for the device at either the [tenant]({{< relref "/api/tenant#tenant-information-format" >}}) or the [device level]({{< relref "/api/device-registration#assert-device-registration" >}}). The values of the default properties are determined as follows:
+The adapter also considers *defaults* registered for the device at either the
+[tenant]({{< relref "/api/tenant#tenant-information-format" >}}) or the
+[device level]({{< relref "/api/device-registration#assert-device-registration" >}}).
+The values of the default properties are determined as follows:
 
 1. If the message already contains a non-empty property of the same name, the value if unchanged.
-2. Otherwise, if a default property of the same name is defined in the device's registration information, that value is used.
-3. Otherwise, if a default property of the same name is defined for the tenant that the device belongs to, that value is used.
+2. Otherwise, if a default property of the same name is defined in the device's registration information,
+   that value is used.
+3. Otherwise, if a default property of the same name is defined for the tenant that the device belongs to,
+   that value is used.
 
-Note that of the standard AMQP 1.0 message properties only the *content-type* and *ttl* can be set this way to a default value.
+Note that of the standard AMQP 1.0 message properties only the *content-type* and *ttl* can be set this way to a
+default value.
 
 ### Event Message Time-to-live
 
-Events published by devices will usually be persisted by the AMQP Messaging Network in order to support deferred delivery to downstream consumers.
-In most cases the AMQP Messaging Network can be configured with a maximum *time-to-live* to apply to the events so that the events will be removed
-from the persistent store if no consumer has attached to receive the event before the message expires.
+Events published by devices will usually be persisted by the messing infrastructure in order to support deferred
+delivery to downstream consumers.
 
-In order to support environments where the AMQP Messaging Network cannot be configured accordingly, the protocol adapter supports setting a
-downstream event message's *ttl* property based on the default *ttl* and *max-ttl* values configured for a tenant/device as described in the [Tenant API]({{< relref "/api/tenant#resource-limits-configuration-format" >}}).
+In most cases, the messaging infrastructure can be configured with a maximum *time-to-live* to apply to the events so
+that the events will be removed from the persistent store if no consumer has attached to receive the event before
+the message expires.
 
+In order to support environments where the messaging infrastructure cannot be configured accordingly, the protocol
+adapter supports setting a downstream event message's *ttl* property based on the default *ttl* and *max-ttl* values
+configured for a tenant/device as described in the
+[Tenant API]({{< relref "/api/tenant#resource-limits-configuration-format" >}}).
 
 ## Tenant specific Configuration
 
-The adapter uses the [Tenant API]({{< ref "/api/tenant#get-tenant-information" >}}) to retrieve *tenant specific configuration* for adapter type `hono-kura-mqtt`.
-The following properties are (currently) supported:
+The adapter uses the [Tenant API]({{< ref "/api/tenant#get-tenant-information" >}}) to retrieve *tenant specific
+configuration* for adapter type `hono-kura-mqtt`. The following properties are (currently) supported:
 
 | Name               | Type       | Default Value | Description                                                     |
 | :----------------- | :--------- | :------------ | :-------------------------------------------------------------- |
-| *enabled*          | *boolean*  | `true`       | If set to `false` the adapter will reject all data from devices belonging to the tenant. |
+| *enabled*          | *boolean*  | `true`         | If set to `false` the adapter will reject all data from devices belonging to the tenant. |

--- a/site/documentation/content/user-guide/mqtt-adapter.md
+++ b/site/documentation/content/user-guide/mqtt-adapter.md
@@ -52,7 +52,7 @@ The adapter extracts the *auth-id*, *tenant* and password from the CONNECT packe
 credentials that the
 [configured Credentials service]({{< relref "/admin-guide/common-config#credentials-service-connection-configuration" >}})
 has on record for the client as described in
-[Username/Password based Authentication]({{< relref "/concepts/device-identity#username-password-based-authentication" >}}).
+[Username/Password based Authentication]({{< relref "/concepts/device-identity#usernamepassword-based-authentication" >}}).
 If the credentials match, the client has been authenticated successfully and the connection is being established.
 
 **NB** There is a subtle difference between the *device identifier* (*device-id*) and the *auth-id* a device uses
@@ -845,7 +845,7 @@ default value.
 
 ### Event Message Time-to-live
 
-Events published by devices will usually be persisted by the messing infrastructure in order to support deferred
+Events published by devices will usually be persisted by the messaging infrastructure in order to support deferred
 delivery to downstream consumers.
 
 In most cases, the messaging infrastructure can be configured with a maximum *time-to-live* to apply to the events so


### PR DESCRIPTION
The (detailed) description of how devices are authenticated using the
information on record has been moved to the Device Identity concept
page's Authentication section in order to reduce text duplication.

The protocol adapter user guides now only describe the binding to the
concrete transport protocol.