### PR TITLE
[#2981] Extend Mongo DB registry to support tenant alias

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
@@ -271,6 +271,10 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      */
     public static final String FIELD_ADAPTERS_DEVICE_AUTHENTICATION_REQUIRED = "device-authentication-required";
     /**
+     * The name of the property that contains a tenant's optional alternative identifier.
+     */
+    public static final String FIELD_ALIAS = "alias";
+    /**
      * The name of the property that indicates whether a unregistered device that authenticates with
      * a client certificate should be auto-provisioned as a gateway. 
      */

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/tenant/Tenant.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/tenant/Tenant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -26,6 +26,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.security.auth.x500.X500Principal;
@@ -54,8 +56,13 @@ import io.vertx.core.Future;
 @JsonInclude(value = Include.NON_NULL)
 public class Tenant {
 
+    private static Predicate<String> PREDICATE_LDH_LABEL = Pattern.compile("[a-z0-9-]+").asMatchPredicate();
+
     @JsonProperty(RegistryManagementConstants.FIELD_ENABLED)
     private Boolean enabled;
+
+    @JsonProperty(RegistryManagementConstants.FIELD_ALIAS)
+    private String alias;
 
     @JsonProperty(RegistryManagementConstants.FIELD_EXT)
     @JsonInclude(Include.NON_EMPTY)
@@ -109,6 +116,7 @@ public class Tenant {
         Objects.requireNonNull(other);
 
         this.enabled = other.enabled;
+        this.alias = other.alias;
         if (other.extensions != null) {
             this.extensions = new HashMap<>(other.extensions);
         }
@@ -167,6 +175,35 @@ public class Tenant {
     @JsonIgnore
     public final boolean isEnabled() {
         return Optional.ofNullable(enabled).orElse(true);
+    }
+
+    /**
+     * Sets the alternative identifier that this tenant may be looked up by.
+     *
+     * @param alias The alias.
+     * @return This instance, to allow chained invocations.
+     * @throws NullPointerException if alias is {@code null}.
+     * @throws IllegalArgumentException if the alias is not a valid LDH-label as defined by
+     *                          <a href="https://datatracker.ietf.org/doc/html/rfc5890#section-2.3.1">RFC 5890</a>.
+     */
+    public final Tenant setAlias(final String alias) {
+
+        Objects.requireNonNull(alias);
+        if (PREDICATE_LDH_LABEL.test(alias)) {
+            this.alias = alias;
+            return this;
+        } else {
+            throw new IllegalArgumentException("alias must be a valid LDH label");
+        }
+    }
+
+    /**
+     * Gets the alternative identifier that this tenant may be looked up by.
+     *
+     * @return The alias or {@code null} if not set.
+     */
+    public final String getAlias() {
+        return alias;
     }
 
     /**

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/tenant/TenantTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/tenant/TenantTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.service.management.tenant;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -497,12 +498,34 @@ public class TenantTest {
     }
 
     /**
-     * Encode with absent "enabled" flag.
+     * Verifies that a serialized default tenant object has no properties.
      */
     @Test
     public void testEncodeDefault() {
         final var json = JsonObject.mapFrom(new Tenant());
         assertThat(json).isEmpty();
+    }
+
+    /**
+     * Encode tenant with alias.
+     */
+    @Test
+    public void testEncodeWithAlias() {
+        final var tenant = new Tenant();
+        tenant.setAlias("the-alias-1");
+        final var json = JsonObject.mapFrom(tenant);
+        assertThat(json.getString(RegistryManagementConstants.FIELD_ALIAS)).isEqualTo("the-alias-1");
+    }
+
+    /**
+     * Verifies that the alias property cannot be set to a non-LDH label.
+     */
+    @Test
+    public void testSetAliasAcceptsLdhLabelOnly() {
+        final var tenant = new Tenant();
+        assertAll(
+                () -> assertThrows(NullPointerException.class, () -> tenant.setAlias(null)),
+                () -> assertThrows(IllegalArgumentException.class, () -> tenant.setAlias("NOT_a-valid=Alias")));
     }
 
     /**

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/TenantDao.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/TenantDao.java
@@ -65,6 +65,20 @@ public interface TenantDao {
     Future<TenantDto> getById(String tenantId, SpanContext tracingContext);
 
     /**
+     * Gets a tenant by its identifier or alias.
+     *
+     * @param tenantId The identifier or alias of the tenant to get.
+     * @param tracingContext The context to track the processing of the request in
+     *                       or {@code null} if no such context exists.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if an instance with the given identifier or alias exists, otherwise
+     *         it will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     * @throws NullPointerException if tenant identifier is {@code null}.
+     */
+    Future<TenantDto> getByIdOrAlias(String tenantId, SpanContext tracingContext);
+
+    /**
      * Gets a tenant by the subject DN of one of its configured trusted certificate authorities.
      *
      * @param subjectDn The subject DN.

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedTenantService.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedTenantService.java
@@ -60,10 +60,10 @@ public final class MongoDbBasedTenantService extends AbstractTenantService {
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(span);
 
-        return dao.getById(tenantId, span.context())
+        return dao.getByIdOrAlias(tenantId, span.context())
                 .map(tenantDto -> TenantResult.from(
                             HttpURLConnection.HTTP_OK,
-                            DeviceRegistryUtils.convertTenant(tenantId, tenantDto.getData(), true),
+                            DeviceRegistryUtils.convertTenant(tenantDto.getTenantId(), tenantDto.getData(), true),
                             DeviceRegistryUtils.getCacheDirective(config.getCacheMaxAge())))
                 .otherwise(t -> TenantResult.from(ServiceInvocationException.extractStatusCode(t)));
     }

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedTenantServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedTenantServiceTest.java
@@ -12,23 +12,34 @@
  *******************************************************************************/
 package org.eclipse.hono.deviceregistry.mongodb.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.net.HttpURLConnection;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedTenantsConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.model.MongoDbBasedTenantDao;
+import org.eclipse.hono.deviceregistry.util.Assertions;
+import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.service.management.tenant.TenantManagementService;
 import org.eclipse.hono.service.tenant.AbstractTenantServiceTest;
 import org.eclipse.hono.service.tenant.TenantService;
+import org.eclipse.hono.util.RegistryManagementConstants;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.opentracing.noop.NoopSpan;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Timeout;
@@ -113,5 +124,109 @@ public class MongoDbBasedTenantServiceTest implements AbstractTenantServiceTest 
     @Override
     public TenantManagementService getTenantManagementService() {
         return tenantManagementService;
+    }
+
+    /**
+     * Verifies that a tenant cannot be added if it uses an already registered
+     * alias.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testAddTenantFailsForDuplicateAlias(final VertxTestContext ctx) {
+
+        final var tenantSpec = new Tenant().setAlias("the-alias");
+        addTenant("tenant", tenantSpec)
+            .compose(ok -> getTenantManagementService().createTenant(
+                    Optional.of("other-tenant"),
+                    tenantSpec,
+                    NoopSpan.INSTANCE))
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_CONFLICT));
+                ctx.completeNow();
+            }));
+    }
+
+    /**
+     * Verifies that a tenant cannot be updated with an alias that is already in use by another tenant.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testUpdateTenantFailsForDuplicateAlias(final VertxTestContext ctx) {
+
+        final var tenantSpec = new Tenant().setAlias("the-alias");
+        addTenant("tenant", tenantSpec)
+            .compose(ok -> getTenantManagementService().createTenant(
+                    Optional.of("other-tenant"),
+                    new Tenant(),
+                    NoopSpan.INSTANCE))
+            .compose(ok -> getTenantManagementService().updateTenant(
+                    "other-tenant",
+                    tenantSpec,
+                    Optional.empty(),
+                    NoopSpan.INSTANCE))
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_CONFLICT));
+                ctx.completeNow();
+            }));
+    }
+
+    /**
+     * Verifies that a tenant can be looked up by its alias using the {@link TenantManagementService} API.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testGetTenantByAliasSucceedsForExistingTenant(final VertxTestContext ctx) {
+
+        final Tenant tenantSpec = new Tenant().setAlias("the-alias");
+
+        // GIVEN a tenant that has been added via the Management API
+        addTenant("tenant", tenantSpec)
+            .compose(ok -> {
+                ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_CREATED, ok.getStatus());
+                });
+                // WHEN retrieving the tenant by alias using the Tenant API
+                return getTenantService().get("the-alias", NoopSpan.INSTANCE);
+            })
+            .onComplete(ctx.succeeding(tenantResult -> {
+                ctx.verify(() -> {
+                    // THEN the tenant is found
+                    assertThat(tenantResult.isOk()).isTrue();
+                    // and the response can be cached
+                    assertThat(tenantResult.getCacheDirective()).isNotNull();
+                    assertThat(tenantResult.getCacheDirective().isCachingAllowed()).isTrue();
+                    assertThat(tenantResult.getPayload().getString(RegistryManagementConstants.FIELD_PAYLOAD_TENANT_ID))
+                        .isEqualTo("tenant");
+                });
+                ctx.completeNow();
+            }));
+    }
+
+    /**
+     * Verifies that the service returns 404 if a client wants to retrieve a tenant using a non-existing
+     * identifier/alias.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testGetTenantFailsForNonMatchingAlias(final VertxTestContext ctx) {
+
+        // GIVEN a tenant that has been added via the Management API
+        addTenant("tenant", new Tenant().setAlias("the-alias"))
+            .compose(ok -> {
+                ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_CREATED, ok.getStatus());
+                });
+                // WHEN retrieving the tenant by a non-matching identifier
+                return getTenantService().get("not-the-alias", NoopSpan.INSTANCE);
+            })
+            .onComplete(ctx.succeeding(s -> {
+                // THEN no tenant is found
+                ctx.verify(() -> assertEquals(HttpURLConnection.HTTP_NOT_FOUND, s.getStatus()));
+                ctx.completeNow();
+            }));
     }
 }

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -726,6 +726,17 @@ components:
             "enabled":
                type: boolean
                default: true
+            "alias":
+               type: string
+               pattern: "[a-z0-9-]+"
+               description: |
+                  An alternative identifier that this tenant may be looked up by. Registry implementations MAY
+                  choose to ignore this property. Otherwise, the alias MUST consist of only lower case letters,
+                  digits and hyphens and thus be a valid LDH-label as defined by
+                  [RFC 5890](https://datatracker.ietf.org/doc/html/rfc5890#section-2.3.1).
+                  If set, the alias MUST be unique among all tenants. Implementations of Hono's Tenant service
+                  MAY consider this property when looking up a tenant by its identifier as defined by the
+                  [get Tenant operation](https://www.eclipse.org/hono/docs/api/tenant/#get-tenant-information).
             "ext":
                $ref: '#/components/schemas/Extensions'
             "adapters":

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -636,6 +636,15 @@ public final class IntegrationTestSupport {
     }
 
     /**
+     * Checks if the Device Registry supports specifying and using a tenant alias.
+     *
+     * @return {@code true} if the registry supports tenant aliases.
+     */
+    public static boolean isTenantAliasSupported() {
+        return HONO_DEVICEREGISTRY_TYPE.equals(DEVICEREGISTRY_TYPE_MONGODB);
+    }
+
+    /**
      * Creates properties for connecting to the AMQP Messaging Network's secure port.
      *
      * @return The properties.


### PR DESCRIPTION
The Device Registry Management API has been extended to support an
"alias" property in the "Tenant" object. The alias is an optional
alternative identifier that the tenant may be looked up by.

The Mongo DB based Tenant service implementation has been extended to
include the alias when looking up a tenant by ID.

Signed-off-by: Kai Hudalla <kai.hudalla@bosch.io>