### PR TITLE
[#2981] Support usage of SNI to indicate tenant (MQTT adapter)

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/auth/device/X509Authentication.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/auth/device/X509Authentication.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,6 +14,7 @@
 package org.eclipse.hono.adapter.auth.device;
 
 import java.security.cert.Certificate;
+import java.util.List;
 
 import io.opentracing.SpanContext;
 import io.vertx.core.Future;
@@ -29,6 +30,8 @@ public interface X509Authentication {
      * Validates a certificate path.
      *
      * @param path The certificate path to validate.
+     * @param requestedHostNames The host names conveyed by the client in a TLS SNI extension or {@code null} if
+     *                          the client did not provide any.
      * @param spanContext The <em>OpenTracing</em> context in which the
      *                    validation should be executed, or {@code null}
      *                    if no context exists (yet).
@@ -47,5 +50,6 @@ public interface X509Authentication {
      */
     Future<JsonObject> validateClientCertificate(
             Certificate[] path,
+            List<String> requestedHostNames,
             SpanContext spanContext);
 }

--- a/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/SaslExternalAuthHandler.java
+++ b/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/SaslExternalAuthHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,7 +16,6 @@ package org.eclipse.hono.adapter.amqp;
 import java.net.HttpURLConnection;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
-import java.util.List;
 import java.util.List;
 import java.util.Objects;
 

--- a/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/SaslExternalAuthHandler.java
+++ b/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/SaslExternalAuthHandler.java
@@ -16,6 +16,8 @@ package org.eclipse.hono.adapter.amqp;
 import java.net.HttpURLConnection;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.hono.adapter.auth.device.DeviceCredentialsAuthProvider;
@@ -105,6 +107,6 @@ public class SaslExternalAuthHandler extends ExecutionContextAuthHandler<SaslRes
             return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_UNAUTHORIZED,
                     "Only X.509 certificates are supported"));
         }
-        return auth.validateClientCertificate(peerCertificateChain, context.getTracingContext());
+        return auth.validateClientCertificate(peerCertificateChain, List.of(), context.getTracingContext());
     }
 }

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/DeviceRegistryBasedCertificateVerifier.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/DeviceRegistryBasedCertificateVerifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/DeviceRegistryBasedCertificateVerifier.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/DeviceRegistryBasedCertificateVerifier.java
@@ -109,7 +109,7 @@ public class DeviceRegistryBasedCertificateVerifier implements NewAdvancedCertif
         final Certificate[] certChain = list.toArray(new Certificate[list.size()]);
         final Promise<AdditionalInfo> authResult = Promise.promise();
 
-        auth.validateClientCertificate(certChain, span.context())
+        auth.validateClientCertificate(certChain, List.of(), span.context())
                 .onSuccess(ar -> {
                     final SubjectDnCredentials credentials = authProvider.getCredentials(ar);
                     if (credentials == null) {

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/X509AuthHandler.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/X509AuthHandler.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.adapter.http;
 
 import java.net.HttpURLConnection;
 import java.security.cert.Certificate;
+import java.util.List;
 import java.util.Objects;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -105,7 +106,7 @@ public class X509AuthHandler extends AuthenticationHandlerImpl<DeviceCredentials
         if (context.request().isSSL()) {
             try {
                 final Certificate[] path = context.request().sslSession().getPeerCertificates();
-                auth.validateClientCertificate(path, TracingHandler.serverSpanContext(context))
+                auth.validateClientCertificate(path, List.of(), TracingHandler.serverSpanContext(context))
                     .compose(credentialsJson -> {
                         final ExecutionContextAuthHandler<HttpContext> authHandler = new ExecutionContextAuthHandler<>(
                                 (DeviceCredentialsAuthProvider<?>) authProvider,

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/X509AuthHandler.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/X509AuthHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/X509AuthHandlerTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/X509AuthHandlerTest.java
@@ -32,6 +32,7 @@ import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.time.Period;
 import java.util.Date;
+import java.util.List;
 import java.util.Set;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -83,13 +84,18 @@ public class X509AuthHandlerTest {
      *
      * @throws SSLPeerUnverifiedException if the client certificate cannot be validated.
      */
+    @SuppressWarnings("unchecked")
     @Test
     public void testHandleFailsWithStatusCodeFromAuthProvider() throws SSLPeerUnverifiedException {
 
         // GIVEN an auth handler configured with an auth provider that
         // fails with a 503 error code during authentication
         final ServiceInvocationException error = new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE);
-        when(clientAuth.validateClientCertificate(any(Certificate[].class), (SpanContext) any())).thenReturn(Future.failedFuture(error));
+        when(clientAuth.validateClientCertificate(
+                any(Certificate[].class),
+                any(List.class),
+                (SpanContext) any()))
+            .thenReturn(Future.failedFuture(error));
 
         // WHEN trying to authenticate a request that contains a client certificate
         final EmptyCertificate clientCert = new EmptyCertificate("CN=device", "CN=tenant");

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/X509AuthHandlerTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/X509AuthHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/SniExtensionHelper.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/SniExtensionHelper.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.service.auth;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.net.ssl.ExtendedSSLSession;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.StandardConstants;
+
+/**
+ * A wrapper around host names provided by clients in a TLS ServerNameIndication extension.
+ */
+public final class SniExtensionHelper {
+
+    private SniExtensionHelper() {
+        // prevent instantiation
+    }
+
+    /**
+     * Extracts the host names conveyed in a TLS SNI extension.
+     *
+     * @param tlsSession The TLS session.
+     * @return The host names.
+     */
+    public static List<String> getHostNames(final SSLSession tlsSession) {
+        Objects.requireNonNull(tlsSession);
+
+        return Optional.ofNullable(tlsSession)
+                .filter(ExtendedSSLSession.class::isInstance)
+                .map(ExtendedSSLSession.class::cast)
+                .map(session -> session.getRequestedServerNames().stream()
+                        .filter(serverName -> serverName.getType() == StandardConstants.SNI_HOST_NAME)
+                        .map(serverName -> new String(serverName.getEncoded(), StandardCharsets.US_ASCII))
+                        .collect(Collectors.toUnmodifiableList()))
+                .orElse(List.of());
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/SniExtensionHelper.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/SniExtensionHelper.java
@@ -16,7 +16,6 @@ package org.eclipse.hono.service.auth;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -40,7 +39,6 @@ public final class SniExtensionHelper {
      * @return The host names.
      */
     public static List<String> getHostNames(final SSLSession tlsSession) {
-        Objects.requireNonNull(tlsSession);
 
         return Optional.ofNullable(tlsSession)
                 .filter(ExtendedSSLSession.class::isInstance)

--- a/service-base/src/test/java/org/eclipse/hono/service/auth/SniExtensionHelperTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/auth/SniExtensionHelperTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.service.auth;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.List;
+
+import javax.net.ssl.ExtendedSSLSession;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
+
+import org.junit.jupiter.api.Test;
+
+
+/**
+ * Tests verifying behavior of {@link SniExtensionHelperTest}.
+ */
+public class SniExtensionHelperTest {
+
+    /**
+     * Verifies that all host names are extracted from a TLS session.
+     */
+    @Test
+    public void testGetRequestedHostNamesExtractsAllHostNames() {
+        final ExtendedSSLSession session = mock(ExtendedSSLSession.class);
+        when(session.getRequestedServerNames()).thenReturn(List.of(
+                new SNIHostName("tenant.hono.eclipse.org"),
+                new UndefinedServerName(new byte[] { 0x01, 0x02, 0x03 }),
+                new SNIHostName("bumlux.eclipse.org")));
+
+        final List<String> hostNames = SniExtensionHelper.getHostNames(session);
+        assertThat(hostNames).containsExactly("tenant.hono.eclipse.org", "bumlux.eclipse.org");
+    }
+
+    private static class UndefinedServerName extends SNIServerName {
+
+        /**
+         * Creates a new instance.
+         *
+         * @param encodedName The byte representation of the name.
+         */
+        UndefinedServerName(final byte[] encodedName) {
+            super(1, encodedName);
+        }
+    }
+}

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -428,7 +428,7 @@ public final class IntegrationTestSupport {
     /**
      * The IP address of the CoAP protocol adapter.
      */
-    public static final String COAP_HOST = System.getProperty(PROPERTY_COAP_HOST, DEFAULT_HOST);
+    public static final String COAP_HOST = IntegrationTestSupport.getResolvableHostname(PROPERTY_COAP_HOST);
     /**
      * The  port number that the CoAP adapter listens on for requests.
      */
@@ -440,7 +440,7 @@ public final class IntegrationTestSupport {
     /**
      * The IP address of the HTTP protocol adapter.
      */
-    public static final String HTTP_HOST = System.getProperty(PROPERTY_HTTP_HOST, DEFAULT_HOST);
+    public static final String HTTP_HOST = IntegrationTestSupport.getResolvableHostname(PROPERTY_HTTP_HOST);
     /**
      * The  port number that the HTTP adapter listens on for requests.
      */
@@ -452,7 +452,7 @@ public final class IntegrationTestSupport {
     /**
      * The IP address of the MQTT protocol adapter.
      */
-    public static final String MQTT_HOST = System.getProperty(PROPERTY_MQTT_HOST, DEFAULT_HOST);
+    public static final String MQTT_HOST = IntegrationTestSupport.getResolvableHostname(PROPERTY_MQTT_HOST);
     /**
      * The  port number that the MQTT adapter listens on for connections.
      */
@@ -464,7 +464,7 @@ public final class IntegrationTestSupport {
     /**
      * The IP address of the AMQP protocol adapter.
      */
-    public static final String AMQP_HOST = System.getProperty(PROPERTY_AMQP_HOST, DEFAULT_HOST);
+    public static final String AMQP_HOST = IntegrationTestSupport.getResolvableHostname(PROPERTY_AMQP_HOST);
     /**
      * The  port number that the AMQP adapter listens on for connections.
      */
@@ -498,6 +498,15 @@ public final class IntegrationTestSupport {
      * The absolute path to the trust store to use for establishing secure connections with Hono.
      */
     public static final String TRUST_STORE_PATH = System.getProperty("trust-store.path");
+
+    /**
+     * The identifier of the TLS 1.2 protocol.
+     */
+    public static final String TLS_VERSION_1_2 = "TLSv1.2";
+    /**
+     * The identifier of the TLS 1.3 protocol.
+     */
+    public static final String TLS_VERSION_1_3 = "TLSv1.3";
 
     /**
      * Pattern used for the <em>name</em> field of the {@code @ParameterizedTest} annotation.
@@ -556,6 +565,19 @@ public final class IntegrationTestSupport {
      */
     public IntegrationTestSupport(final Vertx vertx) {
         this.vertx = Objects.requireNonNull(vertx);
+    }
+
+    /**
+     * Gets a host name/IP address that can be resolved via DNS from the value of a Java system property.
+     *
+     * @param systemPropertyName The name of the property to read.
+     * @return The host name.
+     */
+    private static String getResolvableHostname(final String systemPropertyName) {
+        return Optional.of(System.getProperty(systemPropertyName, DEFAULT_HOST))
+                .map(host -> "localhost".equals(host) ? DEFAULT_HOST : host)
+                .map(ipAddress -> ipAddress + ".nip.io")
+                .get();
     }
 
     private static ClientConfigProperties getClientConfigProperties(


### PR DESCRIPTION
This is for #2981

The MQTT adapter's X509 handler has been changed to retrieve and
consider the requested host names contained in the SNI extension
provided by the device in the TLS handshake.

The other protocol adapters will be updated in subsequent PRs as well.