### PR TITLE
#3045 Remove application startup timeout property

### DIFF
--- a/core/src/main/java/org/eclipse/hono/config/ApplicationConfigProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/ApplicationConfigProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,7 +22,6 @@ import org.eclipse.hono.config.quarkus.ApplicationOptions;
 public class ApplicationConfigProperties {
 
     private int maxInstances = 0;
-    private int startupTimeout = 20;
 
     /**
      * Creates new properties using default values.
@@ -39,33 +38,6 @@ public class ApplicationConfigProperties {
     public ApplicationConfigProperties(final ApplicationOptions options) {
         super();
         setMaxInstances(options.maxInstances());
-        setStartupTimeout(options.startupTimeout());
-    }
-
-    /**
-     * Gets the maximum time to wait for the server to start up.
-     * <p>
-     * The default value of this property is 20 (seconds).
-     *
-     * @return The number of seconds to wait.
-     */
-    public final int getStartupTimeout() {
-        return startupTimeout;
-    }
-
-    /**
-     * Sets the maximum time to wait for the server to start up.
-     * <p>
-     * The default value of this property is 20 (seconds).
-     *
-     * @param seconds The maximum number of seconds to wait.
-     * @throws IllegalArgumentException if <em>seconds</em> &lt; 1.
-     */
-    public final void setStartupTimeout(final int seconds) {
-        if (seconds < 1) {
-            throw new IllegalArgumentException("startup timeout must be at least 1 second");
-        }
-        this.startupTimeout = seconds;
     }
 
     /**

--- a/core/src/main/java/org/eclipse/hono/config/quarkus/ApplicationOptions.java
+++ b/core/src/main/java/org/eclipse/hono/config/quarkus/ApplicationOptions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,16 +22,6 @@ import io.smallrye.config.WithDefault;
  */
 @ConfigMapping(prefix = "hono.app", namingStrategy = ConfigMapping.NamingStrategy.VERBATIM)
 public interface ApplicationOptions {
-
-    /**
-     * Gets the maximum time to wait for the server to start up.
-     * <p>
-     * The default value of this property is 20.
-     *
-     * @return The number of seconds to wait.
-     */
-    @WithDefault("20")
-    int startupTimeout();
 
     /**
      * Gets the number of verticle instances to deploy.

--- a/service-base-quarkus/src/test/java/org/eclipse/hono/service/quarkus/QuarkusPropertyBindingTest.java
+++ b/service-base-quarkus/src/test/java/org/eclipse/hono/service/quarkus/QuarkusPropertyBindingTest.java
@@ -74,7 +74,6 @@ public class QuarkusPropertyBindingTest {
         assertThat(applicationOptions).isNotNull();
         final var props = new ApplicationConfigProperties(applicationOptions);
         assertThat(props.getMaxInstances()).isEqualTo(1);
-        assertThat(props.getStartupTimeout()).isEqualTo(60);
     }
 
     /**

--- a/service-base-quarkus/src/test/resources/application.yaml
+++ b/service-base-quarkus/src/test/resources/application.yaml
@@ -1,7 +1,6 @@
 hono:
   app:
     maxInstances: 1
-    startupTimeout: 60
   server:
     bindAddress: "10.2.0.1"
     insecurePort: 11001

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -4,6 +4,13 @@ title = "What is new & noteworthy in Hono?"
 description = "Information about changes in recent Hono releases. Includes new features, fixes, enhancements and API changes."
 +++
 
+## 1.12.0 (not yet released)
+
+### Fixes & Enhancements
+
+* The device registry containers might not have started up properly when used with Kafka as the messaging
+  infrastructure. This has been fixed.
+
 ## 1.11.0
 
 ### New Features

--- a/tests/src/test/resources/amqp/application.yml
+++ b/tests/src/test/resources/amqp/application.yml
@@ -1,7 +1,6 @@
 hono:
   app:
     maxInstances: 1
-    startupTimeout: 120
   connectionEvents:
     producer: logging
     logLevel: debug

--- a/tests/src/test/resources/coap/application.yml
+++ b/tests/src/test/resources/coap/application.yml
@@ -1,7 +1,6 @@
 hono:
   app:
     maxInstances: 1
-    startupTimeout: 120
   connectionEvents:
     producer: none
   healthCheck:

--- a/tests/src/test/resources/commandrouter/clustered-cache/application.yml
+++ b/tests/src/test/resources/commandrouter/clustered-cache/application.yml
@@ -1,7 +1,6 @@
 hono:
   app:
     maxInstances: 1
-    startupTimeout: 90
   healthCheck:
     insecurePortBindAddress: 0.0.0.0
     insecurePort: ${vertx.health.port}

--- a/tests/src/test/resources/commandrouter/embedded-cache/application.yml
+++ b/tests/src/test/resources/commandrouter/embedded-cache/application.yml
@@ -1,7 +1,6 @@
 hono:
   app:
     maxInstances: 1
-    startupTimeout: 90
   healthCheck:
     insecurePortBindAddress: 0.0.0.0
     insecurePort: ${vertx.health.port}

--- a/tests/src/test/resources/deviceconnection/application.yml
+++ b/tests/src/test/resources/deviceconnection/application.yml
@@ -1,7 +1,6 @@
 hono:
   app:
     maxInstances: 1
-    startupTimeout: 90
   healthCheck:
     insecurePortBindAddress: 0.0.0.0
     insecurePort: ${vertx.health.port}

--- a/tests/src/test/resources/deviceregistry-jdbc-h2/application.yml
+++ b/tests/src/test/resources/deviceregistry-jdbc-h2/application.yml
@@ -2,7 +2,6 @@ hono:
 
   app:
     maxInstances: 1
-    startupTimeout: 90
 
   healthCheck:
     insecurePortBindAddress: 0.0.0.0

--- a/tests/src/test/resources/deviceregistry-jdbc-postgres/application.yml
+++ b/tests/src/test/resources/deviceregistry-jdbc-postgres/application.yml
@@ -2,7 +2,6 @@ hono:
 
   app:
     maxInstances: 1
-    startupTimeout: 90
 
   healthCheck:
     insecurePortBindAddress: 0.0.0.0

--- a/tests/src/test/resources/deviceregistry-mongodb/application.yml
+++ b/tests/src/test/resources/deviceregistry-mongodb/application.yml
@@ -1,7 +1,6 @@
 hono:
   app:
     maxInstances: 1
-    startupTimeout: 90
   healthCheck:
     insecurePortBindAddress: 0.0.0.0
     insecurePort: ${vertx.health.port}

--- a/tests/src/test/resources/http/application.yml
+++ b/tests/src/test/resources/http/application.yml
@@ -1,7 +1,6 @@
 hono:
   app:
     maxInstances: 1
-    startupTimeout: 120
   connectionEvents:
     producer: none
   healthCheck:

--- a/tests/src/test/resources/mqtt/application.yml
+++ b/tests/src/test/resources/mqtt/application.yml
@@ -1,7 +1,6 @@
 hono:
   app:
     maxInstances: 1
-    startupTimeout: 120
   connectionEvents:
     producer: logging
     logLevel: debug


### PR DESCRIPTION
This addresses #3045

Spring based application components had been using the value (default
20s) of the (undocumented) ApplicationConfigProperties#startupTimeout
property as the upper limit to wait for the component to start up.

In cases where the component's startup methods took longer to complete,
the component therefore shut down prematurely.

The property has been removed completely so that Spring based components
(like the device registry) no longer run into the timeout.

The Quarkus based components are not affected because they have never
considered this configuration property.
