### PR TITLE
[#2981] Support usage of SNI to indicate tenant (HTTP adapter)

### DIFF
--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -158,7 +158,7 @@ import io.vertx.junit5.VertxTestContext;
                 .setTrustOptions(new PemTrustOptions().addCertPath(IntegrationTestSupport.TRUST_STORE_PATH))
                 .setVerifyHost(false)
                 .setSsl(true)
-                .setEnabledSecureTransportProtocols(Set.of("TLSv1.2"));
+                .setEnabledSecureTransportProtocols(Set.of(IntegrationTestSupport.TLS_VERSION_1_2));
 
     }
 


### PR DESCRIPTION
This is for #2981

The HTTP adapter's X509 handler has been changed to retrieve and
consider the requested host names contained in the SNI extension
provided by the device in the TLS handshake.
