### PR TITLE
[#2981] Support usage of SNI to indicate tenant (CoAP adapter)

### DIFF
--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/impl/ConfigBasedCoapEndpointFactory.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/impl/ConfigBasedCoapEndpointFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -326,6 +326,7 @@ public class ConfigBasedCoapEndpointFactory implements CoapEndpointFactory {
         dtlsConfig.setAdvancedPskStore(pskStore);
         dtlsConfig.setRetransmissionTimeout(config.getDtlsRetransmissionTimeout());
         dtlsConfig.setMaxConnections(networkConfig.getInt(Keys.MAX_ACTIVE_PEERS));
+        dtlsConfig.setSniEnabled(true);
         addIdentity(dtlsConfig);
 
         try {


### PR DESCRIPTION
This is for #2981

The CoAP adapter's (client) certificate verifier has been changed to
retrieve and consider the requested host names contained in the SNI
extension provided by the device in the DTLS handshake.