### PR TITLE
[#2981] Support usage of SNI to indicate tenant (AMQP adapter)

### DIFF
--- a/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/SaslExternalAuthHandler.java
+++ b/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/SaslExternalAuthHandler.java
@@ -16,7 +16,6 @@ package org.eclipse.hono.adapter.amqp;
 import java.net.HttpURLConnection;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
-import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.hono.adapter.auth.device.DeviceCredentialsAuthProvider;
@@ -81,8 +80,8 @@ public class SaslExternalAuthHandler extends ExecutionContextAuthHandler<SaslRes
      * <ul>
      * <li>the subject DN of the validated client certificate in the
      * {@link org.eclipse.hono.util.RequestResponseApiConstants#FIELD_PAYLOAD_SUBJECT_DN} property,</li>
-     * <li>the tenant that the device belongs to in the {@link org.eclipse.hono.util.RequestResponseApiConstants#FIELD_PAYLOAD_TENANT_ID}
-     * property</li>
+     * <li>the tenant that the device belongs to in the
+     * {@link org.eclipse.hono.util.RequestResponseApiConstants#FIELD_PAYLOAD_TENANT_ID} property.</li>
      * </ul>
      *
      * @param context The context containing the SASL response.
@@ -106,6 +105,9 @@ public class SaslExternalAuthHandler extends ExecutionContextAuthHandler<SaslRes
             return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_UNAUTHORIZED,
                     "Only X.509 certificates are supported"));
         }
-        return auth.validateClientCertificate(peerCertificateChain, List.of(), context.getTracingContext());
+        return auth.validateClientCertificate(
+                peerCertificateChain,
+                context.getRequestedHostNames(),
+                context.getTracingContext());
     }
 }

--- a/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/SaslPlainAuthHandler.java
+++ b/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/SaslPlainAuthHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -70,7 +70,7 @@ public class SaslPlainAuthHandler extends ExecutionContextAuthHandler<SaslRespon
      * @return A future indicating the outcome of the operation. The future will succeed with the client's credentials
      *         extracted from context.
      * @throws NullPointerException if the context is {@code null}.
-     * @throws IllegalArgumentException if the context does not the response fields.
+     * @throws IllegalArgumentException if the context does not contain the required SASL response fields.
      */
     @Override
     public Future<JsonObject> parseCredentials(final SaslResponseContext context) {

--- a/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/SaslResponseContext.java
+++ b/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/SaslResponseContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,8 +14,14 @@
 package org.eclipse.hono.adapter.amqp;
 
 import java.security.cert.Certificate;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+
+import org.eclipse.hono.service.auth.SniExtensionHelper;
 import org.eclipse.hono.util.AuthenticationConstants;
 import org.eclipse.hono.util.MapBasedExecutionContext;
 
@@ -28,17 +34,25 @@ import io.vertx.proton.ProtonConnection;
 public final class SaslResponseContext extends MapBasedExecutionContext {
 
     private final ProtonConnection protonConnection;
-    private final Certificate[] peerCertificateChain;
+    private final Certificate[] clientCertificateChain;
     private final String[] saslResponseFields;
     private final String remoteMechanism;
+    private final List<String> requestedHostNames;
 
-    private SaslResponseContext(final ProtonConnection protonConnection, final String remoteMechanism,
-            final String[] saslResponseFields, final Certificate[] peerCertificateChain, final Span span) {
+    private SaslResponseContext(
+            final ProtonConnection protonConnection,
+            final String remoteMechanism,
+            final Span span,
+            final String[] saslResponseFields,
+            final Certificate[] clientCertificateChain,
+            final List<String> requestedHostNames) {
+
         super(span);
         this.protonConnection = Objects.requireNonNull(protonConnection);
         this.remoteMechanism = Objects.requireNonNull(remoteMechanism);
         this.saslResponseFields = saslResponseFields;
-        this.peerCertificateChain = peerCertificateChain;
+        this.clientCertificateChain = clientCertificateChain;
+        this.requestedHostNames = requestedHostNames;
     }
 
     /**
@@ -47,33 +61,62 @@ public final class SaslResponseContext extends MapBasedExecutionContext {
      * @param protonConnection The connection on which the SASL handshake is done.
      * @param saslResponseFields The <em>authzid</em>, <em>authcid</em> and <em>pwd</em> parts of the saslResponse.
      * @param span The OpenTracing span to track the opening of an AMQP connection.
+     * @param tlsSession The TLS session that has been established between the device and the server or {@code null}
+     *                   if TLS is not used by the client.
      * @return The created SaslResponseContext.
-     * @throws NullPointerException if any of the parameters is {@code null}.
+     * @throws NullPointerException if any of the parameters except TLS session are {@code null}.
      */
-    public static SaslResponseContext forMechanismPlain(final ProtonConnection protonConnection,
-            final String[] saslResponseFields, final Span span) {
+    public static SaslResponseContext forMechanismPlain(
+            final ProtonConnection protonConnection,
+            final String[] saslResponseFields,
+            final Span span,
+            final SSLSession tlsSession) {
+
         Objects.requireNonNull(protonConnection);
         Objects.requireNonNull(saslResponseFields);
         Objects.requireNonNull(span);
-        return new SaslResponseContext(protonConnection, AuthenticationConstants.MECHANISM_PLAIN, saslResponseFields,
-                null, span);
+
+        final List<String> hostNames = Optional.ofNullable(tlsSession)
+                .map(SniExtensionHelper::getHostNames)
+                .orElse(null);
+
+        return new SaslResponseContext(
+                protonConnection,
+                AuthenticationConstants.MECHANISM_PLAIN,
+                span,
+                saslResponseFields,
+                (Certificate[]) null,
+                hostNames);
     }
 
     /**
      * Creates a new SaslResponseContext with the EXTERNAL SASL mechanism.
      *
      * @param protonConnection The connection on which the SASL handshake is done.
-     * @param peerCertificateChain The client certificates. May be {@code null} if none were provided.
      * @param span The OpenTracing span to track the opening of an AMQP connection.
+     * @param tlsSession The TLS session that has been established between the device and the server.
      * @return The created SaslResponseContext.
-     * @throws NullPointerException if protonConnection or span is {@code null}.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     * @throws SSLPeerUnverifiedException if the TLS session does not contain a verified client certificate chain.
      */
-    public static SaslResponseContext forMechanismExternal(final ProtonConnection protonConnection,
-            final Certificate[] peerCertificateChain, final Span span) {
+    public static SaslResponseContext forMechanismExternal(
+            final ProtonConnection protonConnection,
+            final Span span,
+            final SSLSession tlsSession) throws SSLPeerUnverifiedException {
+
         Objects.requireNonNull(protonConnection);
         Objects.requireNonNull(span);
-        return new SaslResponseContext(protonConnection, AuthenticationConstants.MECHANISM_EXTERNAL, null,
-                peerCertificateChain, span);
+        Objects.requireNonNull(tlsSession);
+
+        final Certificate[] certChain = tlsSession.getPeerCertificates();
+        final List<String> hostNames = SniExtensionHelper.getHostNames(tlsSession);
+        return new SaslResponseContext(
+                protonConnection,
+                AuthenticationConstants.MECHANISM_EXTERNAL,
+                span,
+                (String[]) null,
+                certChain,
+                hostNames);
     }
 
     /**
@@ -82,7 +125,7 @@ public final class SaslResponseContext extends MapBasedExecutionContext {
      * @return The client certificates or {@code null}.
      */
     public Certificate[] getPeerCertificateChain() {
-        return peerCertificateChain;
+        return clientCertificateChain;
     }
 
     /**
@@ -111,5 +154,14 @@ public final class SaslResponseContext extends MapBasedExecutionContext {
      */
     public ProtonConnection getProtonConnection() {
         return protonConnection;
+    }
+
+    /**
+     * Gets the host names conveyed by the client in the SNI extension during a TLS handshake.
+     *
+     * @return The host names.
+     */
+    public List<String> getRequestedHostNames() {
+        return requestedHostNames;
     }
 }


### PR DESCRIPTION
This is for #2981

The AMQP adapter's SASL authenticator has been changed to
retrieve and consider the requested host names contained in the SNI
extension provided by the device in the TLS handshake.
