### PR TITLE
Run ITs using the Quarkus based components by default

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -83,6 +83,8 @@
       -DenableForcedCommandRerouting=true
     </default.java-options>
 
+    <hono.image-suffix>-quarkus</hono.image-suffix>
+
     <!--
      Properties defining whether the Device Connection service (now deprecated) or the Command Router service
      shall be used for Command & Control. The default here lets the Command Router service be used.
@@ -91,7 +93,7 @@
     <hono.command-related-service.configname>commandRouter</hono.command-related-service.configname>
     <hono.command-related-service.host>${hono.commandrouter.host}</hono.command-related-service.host>
 
-    <hono.command-router.config-dir>etc/hono</hono.command-router.config-dir>
+    <hono.command-router.config-dir>opt/hono/config</hono.command-router.config-dir>
     <hono.command-router.config-src>clustered-cache</hono.command-router.config-src>
     <hono.command-router.disabled>false</hono.command-router.disabled>
     <hono.command-router.image>hono-service-command-router</hono.command-router.image>
@@ -122,7 +124,7 @@
     <hono.deviceregistry.image>hono-service-device-registry-mongodb</hono.deviceregistry.image>
     <hono.deviceregistry.resources.folder>deviceregistry-mongodb</hono.deviceregistry.resources.folder>
     <!-- default memory limit of the device registry container is 400MB -->
-    <hono.deviceregistry.containerMemoryLimit>400000000</hono.deviceregistry.containerMemoryLimit>
+    <hono.deviceregistry.max-mem>400000000</hono.deviceregistry.max-mem>
     <hono.deviceregistry.java-options>${default.java-options}</hono.deviceregistry.java-options>
     <!-- Spring application profiles to activate for the registry -->
     <hono.deviceregistry.spring.profiles>${logging.profile}</hono.deviceregistry.spring.profiles>
@@ -150,32 +152,32 @@
     <hono.postgres.disabled>true</hono.postgres.disabled>
 
     <hono.amqp-adapter.image>hono-adapter-amqp-vertx</hono.amqp-adapter.image>
-    <hono.amqp-adapter.config-dir>etc/hono</hono.amqp-adapter.config-dir>
+    <hono.amqp-adapter.config-dir>opt/hono/config</hono.amqp-adapter.config-dir>
     <hono.amqp-adapter.max-mem>314572800</hono.amqp-adapter.max-mem>
     <hono.amqp-adapter.java-options>${default.java-options}</hono.amqp-adapter.java-options>
     <hono.amqp-adapter.native-image-args></hono.amqp-adapter.native-image-args>
 
     <hono.coap-adapter.image>hono-adapter-coap-vertx</hono.coap-adapter.image>
-    <hono.coap-adapter.config-dir>etc/hono</hono.coap-adapter.config-dir>
+    <hono.coap-adapter.config-dir>opt/hono/config</hono.coap-adapter.config-dir>
     <hono.coap-adapter.max-mem>314572800</hono.coap-adapter.max-mem>
     <hono.coap-adapter.java-options>${default.java-options}</hono.coap-adapter.java-options>
     <hono.coap-adapter.native-image-args></hono.coap-adapter.native-image-args>
 
     <hono.http-adapter.image>hono-adapter-http-vertx</hono.http-adapter.image>
-    <hono.http-adapter.config-dir>etc/hono</hono.http-adapter.config-dir>
+    <hono.http-adapter.config-dir>opt/hono/config</hono.http-adapter.config-dir>
     <hono.http-adapter.max-mem>314572800</hono.http-adapter.max-mem>
-    <hono.http-adapter.nativeTlsRequired>true</hono.http-adapter.nativeTlsRequired>
+    <hono.http-adapter.nativeTlsRequired>false</hono.http-adapter.nativeTlsRequired>
     <hono.http-adapter.java-options>${default.java-options}</hono.http-adapter.java-options>
     <hono.http-adapter.native-image-args></hono.http-adapter.native-image-args>
 
     <hono.mqtt-adapter.image>hono-adapter-mqtt-vertx</hono.mqtt-adapter.image>
-    <hono.mqtt-adapter.config-dir>etc/hono</hono.mqtt-adapter.config-dir>
+    <hono.mqtt-adapter.config-dir>opt/hono/config</hono.mqtt-adapter.config-dir>
     <hono.mqtt-adapter.max-mem>314572800</hono.mqtt-adapter.max-mem>
     <hono.mqtt-adapter.java-options>${default.java-options}</hono.mqtt-adapter.java-options>
     <hono.mqtt-adapter.native-image-args></hono.mqtt-adapter.native-image-args>
 
     <hono.auth-server.image>hono-service-auth</hono.auth-server.image>
-    <hono.auth-server.config-dir>etc/hono</hono.auth-server.config-dir>
+    <hono.auth-server.config-dir>opt/hono/config</hono.auth-server.config-dir>
     <hono.auth-server.max-mem>205520896</hono.auth-server.max-mem>
     <hono.auth-server.java-options>${default.java-options}</hono.auth-server.java-options>
     <hono.auth-server.native-image-args></hono.auth-server.native-image-args>
@@ -527,32 +529,22 @@
       </properties>
     </profile>
     <profile>
-      <id>components-quarkus-jvm</id>
+      <id>components-spring-boot</id>
       <activation>
         <property>
           <name>hono.components.type</name>
-          <value>quarkus-jvm</value>
+          <value>spring-boot</value>
         </property>
       </activation>
       <properties>
-        <hono.amqp-adapter.config-dir>opt/hono/config</hono.amqp-adapter.config-dir>
-        <hono.amqp-adapter.image>hono-adapter-amqp-vertx-quarkus</hono.amqp-adapter.image>
-
-        <hono.coap-adapter.config-dir>opt/hono/config</hono.coap-adapter.config-dir>
-        <hono.coap-adapter.image>hono-adapter-coap-vertx-quarkus</hono.coap-adapter.image>
-
-        <hono.http-adapter.config-dir>opt/hono/config</hono.http-adapter.config-dir>
-        <hono.http-adapter.image>hono-adapter-http-vertx-quarkus</hono.http-adapter.image>
-        <hono.http-adapter.nativeTlsRequired>false</hono.http-adapter.nativeTlsRequired>
-
-        <hono.mqtt-adapter.config-dir>opt/hono/config</hono.mqtt-adapter.config-dir>
-        <hono.mqtt-adapter.image>hono-adapter-mqtt-vertx-quarkus</hono.mqtt-adapter.image>
-
-        <hono.auth-server.config-dir>opt/hono/config</hono.auth-server.config-dir>
-        <hono.auth-server.image>hono-service-auth-quarkus</hono.auth-server.image>
-
-        <hono.command-router.config-dir>opt/hono/config</hono.command-router.config-dir>
-        <hono.command-router.image>hono-service-command-router-quarkus</hono.command-router.image>
+        <hono.image-suffix></hono.image-suffix>
+        <hono.amqp-adapter.config-dir>etc/hono</hono.amqp-adapter.config-dir>
+        <hono.coap-adapter.config-dir>etc/hono</hono.coap-adapter.config-dir>
+        <hono.http-adapter.config-dir>etc/hono</hono.http-adapter.config-dir>
+        <hono.http-adapter.nativeTlsRequired>true</hono.http-adapter.nativeTlsRequired>
+        <hono.mqtt-adapter.config-dir>etc/hono</hono.mqtt-adapter.config-dir>
+        <hono.auth-server.config-dir>etc/hono</hono.auth-server.config-dir>
+        <hono.command-router.config-dir>etc/hono</hono.command-router.config-dir>
       </properties>
     </profile>
     <profile>
@@ -564,32 +556,21 @@
         </property>
       </activation>
       <properties>
-        <hono.amqp-adapter.config-dir>opt/hono/config</hono.amqp-adapter.config-dir>
-        <hono.amqp-adapter.image>hono-adapter-amqp-vertx-quarkus-native</hono.amqp-adapter.image>
+        <hono.image-suffix>-quarkus-native</hono.image-suffix>
         <hono.amqp-adapter.max-mem>67108864</hono.amqp-adapter.max-mem>
         <hono.amqp-adapter.useNativeTransport>false</hono.amqp-adapter.useNativeTransport>
 
-        <hono.coap-adapter.config-dir>opt/hono/config</hono.coap-adapter.config-dir>
-        <hono.coap-adapter.image>hono-adapter-coap-vertx-quarkus-native</hono.coap-adapter.image>
         <hono.coap-adapter.max-mem>67108864</hono.coap-adapter.max-mem>
         <hono.coap-adapter.useNativeTransport>false</hono.coap-adapter.useNativeTransport>
 
-        <hono.http-adapter.config-dir>opt/hono/config</hono.http-adapter.config-dir>
-        <hono.http-adapter.image>hono-adapter-http-vertx-quarkus-native</hono.http-adapter.image>
         <hono.http-adapter.max-mem>67108864</hono.http-adapter.max-mem>
         <hono.http-adapter.nativeTlsRequired>false</hono.http-adapter.nativeTlsRequired>
 
-        <hono.mqtt-adapter.config-dir>opt/hono/config</hono.mqtt-adapter.config-dir>
-        <hono.mqtt-adapter.image>hono-adapter-mqtt-vertx-quarkus-native</hono.mqtt-adapter.image>
         <hono.mqtt-adapter.max-mem>67108864</hono.mqtt-adapter.max-mem>
         <hono.mqtt-adapter.useNativeTransport>false</hono.mqtt-adapter.useNativeTransport>
 
-        <hono.auth-server.config-dir>opt/hono/config</hono.auth-server.config-dir>
-        <hono.auth-server.image>hono-service-auth-quarkus-native</hono.auth-server.image>
         <hono.auth-server.max-mem>33554432</hono.auth-server.max-mem>
 
-        <hono.command-router.config-dir>opt/hono/config</hono.command-router.config-dir>
-        <hono.command-router.image>hono-service-command-router-quarkus-native</hono.command-router.image>
         <hono.command-router.max-mem>67108864</hono.command-router.max-mem>
       </properties>
     </profile>
@@ -836,7 +817,7 @@
                   <name>${docker.repository}/hono-service-auth-test:${project.version}</name>
                   <build>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
-                    <from>${docker.repository}/${hono.auth-server.image}:${project.version}</from>
+                    <from>${docker.repository}/${hono.auth-server.image}${hono.image-suffix}:${project.version}</from>
                     <assembly>
                       <mode>dir</mode>
                       <basedir>/</basedir>
@@ -1150,8 +1131,8 @@
                       <name>${custom.network.name}</name>
                       <alias>${hono.registration.host}</alias>
                     </network>
-                    <memorySwap>${hono.deviceregistry.containerMemoryLimit}</memorySwap>
-                    <memory>${hono.deviceregistry.containerMemoryLimit}</memory>
+                    <memorySwap>${hono.deviceregistry.max-mem}</memorySwap>
+                    <memory>${hono.deviceregistry.max-mem}</memory>
                     <env>
                       <LOGGING_CONFIG>file:///etc/hono/logback-spring.xml</LOGGING_CONFIG>
                       <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
@@ -1257,7 +1238,7 @@
                   <build>
                     <skip>${hono.command-router.disabled}</skip>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
-                    <from>${docker.repository}/${hono.command-router.image}:${project.version}</from>
+                    <from>${docker.repository}/${hono.command-router.image}${hono.image-suffix}:${project.version}</from>
                     <assembly>
                       <mode>dir</mode>
                       <basedir>/</basedir>
@@ -1341,7 +1322,7 @@
                   <name>${docker.repository}/hono-adapter-http-test:${project.version}</name>
                   <build>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
-                    <from>${docker.repository}/${hono.http-adapter.image}:${project.version}</from>
+                    <from>${docker.repository}/${hono.http-adapter.image}${hono.image-suffix}:${project.version}</from>
                     <assembly>
                       <mode>dir</mode>
                       <basedir>/</basedir>
@@ -1427,7 +1408,7 @@
                   <name>${docker.repository}/hono-adapter-mqtt-test:${project.version}</name>
                   <build>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
-                    <from>${docker.repository}/${hono.mqtt-adapter.image}:${project.version}</from>
+                    <from>${docker.repository}/${hono.mqtt-adapter.image}${hono.image-suffix}:${project.version}</from>
                     <assembly>
                       <mode>dir</mode>
                       <basedir>/</basedir>
@@ -1503,7 +1484,7 @@
                   <name>${docker.repository}/hono-adapter-amqp-test:${project.version}</name>
                   <build>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
-                    <from>${docker.repository}/${hono.amqp-adapter.image}:${project.version}</from>
+                    <from>${docker.repository}/${hono.amqp-adapter.image}${hono.image-suffix}:${project.version}</from>
                     <assembly>
                       <mode>dir</mode>
                       <basedir>/</basedir>
@@ -1579,7 +1560,7 @@
                   <name>${docker.repository}/hono-adapter-coap-test:${project.version}</name>
                   <build>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
-                    <from>${docker.repository}/${hono.coap-adapter.image}:${project.version}</from>
+                    <from>${docker.repository}/${hono.coap-adapter.image}${hono.image-suffix}:${project.version}</from>
                     <assembly>
                       <mode>dir</mode>
                       <basedir>/</basedir>

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -144,14 +144,14 @@ In order to stop and remove the Docker containers started by a test run, use:
 mvn verify -PstopContainers
 ```
 
-### Running the Tests with the Quarkus based Components
+### Running the Tests with the Spring Boot based Components
 
-By default, the integration tests are run using the Spring Boot based Hono components. For some components there are
-Quarkus based alternative implementations. The tests can be run using these Quarkus based components by means of
-activating setting the `hono.components.type` Maven property to value `quarkus-jvm`:
+By default, the integration tests are run using the Quarkus based Hono components. For some components there is only
+the original Spring Boot based variant available. The tests can be run using the Spring Boot based variant of all
+components by means of setting the `hono.components.type` Maven property to value `spring-boot`:
 
 ```sh
-mvn verify -Prun-tests -Dhono.components.type=quarkus-jvm
+mvn verify -Prun-tests -Dhono.components.type=spring-boot
 ```
 
 ### Running the Tests with the Command Router using an embedded Cache


### PR DESCRIPTION
Since the Quarkus based implementations are the default variant for some
time now, the integration tests are now also by default executed using
the Quarkus based images.
