### PR TITLE
Fix NPE concerning connection events of unauthenticated devices

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -936,8 +936,10 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      */
     protected Future<Void> sendConnectedEvent(final String remoteId, final Device authenticatedDevice, final SpanContext context) {
         if (this.connectionEventProducer != null) {
-            return getTenantClient().get(authenticatedDevice.getTenantId(), context)
-                    .map(this::getEventSender)
+            return Optional.ofNullable(authenticatedDevice)
+                    .map(device -> getTenantClient().get(device.getTenantId(), context)
+                            .map(this::getEventSender))
+                    .orElseGet(() -> Future.succeededFuture(null))
                     .compose(es -> this.connectionEventProducer.connected(
                             new ConnectionEventProducer.Context() {
                                 @Override
@@ -972,8 +974,10 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      */
     protected Future<Void> sendDisconnectedEvent(final String remoteId, final Device authenticatedDevice, final SpanContext context) {
         if (this.connectionEventProducer != null) {
-            return getTenantClient().get(authenticatedDevice.getTenantId(), context)
-                    .map(this::getEventSender)
+            return Optional.ofNullable(authenticatedDevice)
+                    .map(device -> getTenantClient().get(device.getTenantId(), context)
+                            .map(this::getEventSender))
+                    .orElseGet(() -> Future.succeededFuture(null))
                     .compose(es -> this.connectionEventProducer.disconnected(
                             new ConnectionEventProducer.Context() {
                                 @Override

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/monitoring/AbstractMessageSenderConnectionEventProducer.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/monitoring/AbstractMessageSenderConnectionEventProducer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -11,6 +11,8 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package org.eclipse.hono.adapter.monitoring;
+
+import java.util.Optional;
 
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.util.EventConstants;
@@ -84,13 +86,15 @@ public abstract class AbstractMessageSenderConnectionEventProducer implements Co
                         payload.put("data", data);
                     }
 
-                    return context.getMessageSenderClient().sendEvent(
-                            tenant,
-                            new RegistrationAssertion(deviceId),
-                            EventConstants.EVENT_CONNECTION_NOTIFICATION_CONTENT_TYPE,
-                            payload.toBuffer(),
-                            null,
-                            spanContext);
+                    return Optional.ofNullable(context.getMessageSenderClient())
+                            .map(client -> client.sendEvent(
+                                    tenant,
+                                    new RegistrationAssertion(deviceId),
+                                    EventConstants.EVENT_CONNECTION_NOTIFICATION_CONTENT_TYPE,
+                                    payload.toBuffer(),
+                                    null,
+                                    spanContext))
+                            .orElseGet(Future::succeededFuture);
                 });
     }
 }

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/monitoring/ConnectionEventProducer.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/monitoring/ConnectionEventProducer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -49,9 +49,13 @@ public interface ConnectionEventProducer {
 
         /**
          * Gets the client for sending connection events downstream.
+         * <p>
+         * If no client is available in this context, {@code null} is returned. 
+         * <p>
+         * A returned client here is required to be initialized and started.
          *
          * @return The instance of the message sender client which the {@link ConnectionEventProducer} should
-         *         use. This client has to be initialized and started.
+         *         use or {@code null} if no client is available. 
          */
         EventSender getMessageSenderClient();
         /**


### PR DESCRIPTION
`sendConnectedEvent` and `sendDisconnectedEvent` may be invoked with an `authenticatedDevice` that is `null`.
This PR fixes the NPE that occurred in that case.