### PR TITLE
Consider logging.profile when running Quarkus based ITs

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -881,8 +881,11 @@
                       </exec>
                     </cmd>
                     <env>
-                      <LOGGING_CONFIG>file:///etc/hono/logback-spring.xml</LOGGING_CONFIG>
-                      <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
+                      <SMALLRYE_CONFIG_LOCATIONS>
+                        /${hono.auth-server.config-dir}/logging-quarkus-${logging.profile}.yml
+                      </SMALLRYE_CONFIG_LOCATIONS>
+                      <LOGGING_CONFIG>file:///${hono.auth-server.config-dir}/logback-spring.xml</LOGGING_CONFIG>
+                      <SPRING_CONFIG_LOCATION>file:///${hono.auth-server.config-dir}/</SPRING_CONFIG_LOCATION>
                       <SPRING_PROFILES_ACTIVE>authentication-impl,${logging.profile}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${hono.auth-server.java-options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
@@ -1150,8 +1153,11 @@
                     <memorySwap>${hono.deviceregistry.max-mem}</memorySwap>
                     <memory>${hono.deviceregistry.max-mem}</memory>
                     <env>
-                      <LOGGING_CONFIG>file:///etc/hono/logback-spring.xml</LOGGING_CONFIG>
-                      <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
+                      <SMALLRYE_CONFIG_LOCATIONS>
+                        /${hono.deviceregistry.config-dir}/logging-quarkus-${logging.profile}.yml
+                      </SMALLRYE_CONFIG_LOCATIONS>
+                      <LOGGING_CONFIG>file:///${hono.deviceregistry.config-dir}/logback-spring.xml</LOGGING_CONFIG>
+                      <SPRING_CONFIG_LOCATION>file:///${hono.deviceregistry.config-dir}/</SPRING_CONFIG_LOCATION>
                       <SPRING_PROFILES_ACTIVE>${hono.deviceregistry.spring.profiles}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${hono.deviceregistry.java-options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
@@ -1308,8 +1314,11 @@
                       </exec>
                     </cmd>
                     <env>
-                      <LOGGING_CONFIG>file:///etc/hono/logback-spring.xml</LOGGING_CONFIG>
-                      <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
+                      <SMALLRYE_CONFIG_LOCATIONS>
+                        /${hono.command-router.config-dir}/logging-quarkus-${logging.profile}.yml
+                      </SMALLRYE_CONFIG_LOCATIONS>
+                      <LOGGING_CONFIG>file:///${hono.command-router.config-dir}/logback-spring.xml</LOGGING_CONFIG>
+                      <SPRING_CONFIG_LOCATION>file:///${hono.command-router.config-dir}/</SPRING_CONFIG_LOCATION>
                       <SPRING_PROFILES_ACTIVE>${logging.profile},embedded-cache,enable-device-connection-endpoint</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${hono.command-router.java-options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
@@ -1394,8 +1403,11 @@
                       </exec>
                     </cmd>
                     <env>
-                      <LOGGING_CONFIG>file:/etc/hono/logback-spring.xml</LOGGING_CONFIG>
-                      <SPRING_CONFIG_LOCATION>file:/etc/hono/</SPRING_CONFIG_LOCATION>
+                      <SMALLRYE_CONFIG_LOCATIONS>
+                        /${hono.http-adapter.config-dir}/logging-quarkus-${logging.profile}.yml
+                      </SMALLRYE_CONFIG_LOCATIONS>
+                      <LOGGING_CONFIG>file:/${hono.http-adapter.config-dir}/logback-spring.xml</LOGGING_CONFIG>
+                      <SPRING_CONFIG_LOCATION>file:/${hono.http-adapter.config-dir}/</SPRING_CONFIG_LOCATION>
                       <SPRING_PROFILES_ACTIVE>${logging.profile}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${hono.http-adapter.java-options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
@@ -1470,8 +1482,11 @@
                       </exec>
                     </cmd>
                     <env>
-                      <LOGGING_CONFIG>file:///etc/hono/logback-spring.xml</LOGGING_CONFIG>
-                      <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
+                      <SMALLRYE_CONFIG_LOCATIONS>
+                        /${hono.mqtt-adapter.config-dir}/logging-quarkus-${logging.profile}.yml
+                      </SMALLRYE_CONFIG_LOCATIONS>
+                      <LOGGING_CONFIG>file:///${hono.mqtt-adapter.config-dir}/logback-spring.xml</LOGGING_CONFIG>
+                      <SPRING_CONFIG_LOCATION>file:///${hono.mqtt-adapter.config-dir}/</SPRING_CONFIG_LOCATION>
                       <SPRING_PROFILES_ACTIVE>${logging.profile}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${hono.mqtt-adapter.java-options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
@@ -1546,8 +1561,11 @@
                       </exec>
                     </cmd>
                     <env>
-                      <LOGGING_CONFIG>file:///etc/hono/logback-spring.xml</LOGGING_CONFIG>
-                      <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
+                      <SMALLRYE_CONFIG_LOCATIONS>
+                        /${hono.amqp-adapter.config-dir}/logging-quarkus-${logging.profile}.yml
+                      </SMALLRYE_CONFIG_LOCATIONS>
+                      <LOGGING_CONFIG>file:///${hono.amqp-adapter.config-dir}/logback-spring.xml</LOGGING_CONFIG>
+                      <SPRING_CONFIG_LOCATION>file:///${hono.amqp-adapter.config-dir}/</SPRING_CONFIG_LOCATION>
                       <SPRING_PROFILES_ACTIVE>${logging.profile}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${hono.amqp-adapter.java-options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
@@ -1622,8 +1640,11 @@
                       </exec>
                     </cmd>
                     <env>
-                      <LOGGING_CONFIG>file:/etc/hono/logback-spring.xml</LOGGING_CONFIG>
-                      <SPRING_CONFIG_LOCATION>file:/etc/hono/</SPRING_CONFIG_LOCATION>
+                      <SMALLRYE_CONFIG_LOCATIONS>
+                        /${hono.coap-adapter.config-dir}/logging-quarkus-${logging.profile}.yml
+                      </SMALLRYE_CONFIG_LOCATIONS>
+                      <LOGGING_CONFIG>file:/${hono.coap-adapter.config-dir}/logback-spring.xml</LOGGING_CONFIG>
+                      <SPRING_CONFIG_LOCATION>file:/${hono.coap-adapter.config-dir}/</SPRING_CONFIG_LOCATION>
                       <SPRING_PROFILES_ACTIVE>${logging.profile}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${hono.coap-adapter.java-options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>

--- a/tests/src/test/resources/amqp/application.yml
+++ b/tests/src/test/resources/amqp/application.yml
@@ -97,12 +97,6 @@ quarkus:
     category:
       "io.quarkus.vertx.core.runtime":
         level: DEBUG
-      "org.apache.kafka":
-        level: WARN
-      "org.eclipse.hono":
-        level: INFO
-      "org.eclipse.hono.adapter":
-        level: INFO
   vertx:
     max-event-loop-execute-time: ${max.event-loop.execute-time}
 

--- a/tests/src/test/resources/amqp/logging-quarkus-dev.yml
+++ b/tests/src/test/resources/amqp/logging-quarkus-dev.yml
@@ -1,0 +1,7 @@
+quarkus:
+  log:
+    category:
+      "org.apache.kafka":
+        level: INFO
+      "org.eclipse.hono":
+        level: DEBUG

--- a/tests/src/test/resources/amqp/logging-quarkus-prod.yml
+++ b/tests/src/test/resources/amqp/logging-quarkus-prod.yml
@@ -1,0 +1,9 @@
+quarkus:
+  log:
+    category:
+      "org.apache.kafka":
+        level: WARN
+      "org.eclipse.hono":
+        level: INFO
+      "org.eclipse.hono.client.impl.HonoConnectionImpl":
+        level: ERROR

--- a/tests/src/test/resources/amqp/logging-quarkus-trace.yml
+++ b/tests/src/test/resources/amqp/logging-quarkus-trace.yml
@@ -1,0 +1,7 @@
+quarkus:
+  log:
+    category:
+      "org.apache.kafka":
+        level: INFO
+      "org.eclipse.hono":
+        level: TRACE

--- a/tests/src/test/resources/auth/application.yml
+++ b/tests/src/test/resources/auth/application.yml
@@ -29,12 +29,8 @@ quarkus:
     category:
       "io.quarkus.vertx.core.runtime":
         level: DEBUG
-      "org.eclipse.hono":
-        level: INFO
-      "org.eclipse.hono.authentication":
-        level: INFO
-      "org.eclipse.hono.authentication.file":
-        level: INFO
+  vertx:
+    max-event-loop-execute-time: ${max.event-loop.execute-time}
 
 spring:
   jmx:

--- a/tests/src/test/resources/auth/logging-quarkus-dev.yml
+++ b/tests/src/test/resources/auth/logging-quarkus-dev.yml
@@ -1,0 +1,7 @@
+quarkus:
+  log:
+    category:
+      "io.netty.handler.logging.LoggingHandler":
+        level: DEBUG
+      "org.eclipse.hono":
+        level: DEBUG

--- a/tests/src/test/resources/auth/logging-quarkus-prod.yml
+++ b/tests/src/test/resources/auth/logging-quarkus-prod.yml
@@ -1,0 +1,7 @@
+quarkus:
+  log:
+    category:
+      "org.eclipse.hono":
+        level: INFO
+      "org.eclipse.hono.client.impl.HonoConnectionImpl":
+        level: ERROR

--- a/tests/src/test/resources/auth/logging-quarkus-trace.yml
+++ b/tests/src/test/resources/auth/logging-quarkus-trace.yml
@@ -1,0 +1,7 @@
+quarkus:
+  log:
+    category:
+      "io.netty.handler.logging.LoggingHandler":
+        level: DEBUG
+      "org.eclipse.hono":
+        level: TRACE

--- a/tests/src/test/resources/coap/application.yml
+++ b/tests/src/test/resources/coap/application.yml
@@ -96,12 +96,6 @@ quarkus:
     category:
       "io.quarkus.vertx.core.runtime":
         level: DEBUG
-      "org.apache.kafka":
-        level: WARN
-      "org.eclipse.hono":
-        level: INFO
-      "org.eclipse.hono.adapter":
-        level: INFO
   vertx:
     max-event-loop-execute-time: ${max.event-loop.execute-time}
 

--- a/tests/src/test/resources/coap/logging-quarkus-dev.yml
+++ b/tests/src/test/resources/coap/logging-quarkus-dev.yml
@@ -1,0 +1,7 @@
+quarkus:
+  log:
+    category:
+      "org.apache.kafka":
+        level: INFO
+      "org.eclipse.hono":
+        level: DEBUG

--- a/tests/src/test/resources/coap/logging-quarkus-prod.yml
+++ b/tests/src/test/resources/coap/logging-quarkus-prod.yml
@@ -1,0 +1,9 @@
+quarkus:
+  log:
+    category:
+      "org.apache.kafka":
+        level: WARN
+      "org.eclipse.hono":
+        level: INFO
+      "org.eclipse.hono.client.impl.HonoConnectionImpl":
+        level: ERROR

--- a/tests/src/test/resources/coap/logging-quarkus-trace.yml
+++ b/tests/src/test/resources/coap/logging-quarkus-trace.yml
@@ -1,0 +1,7 @@
+quarkus:
+  log:
+    category:
+      "org.apache.kafka":
+        level: INFO
+      "org.eclipse.hono":
+        level: TRACE

--- a/tests/src/test/resources/commandrouter/clustered-cache/application.yml
+++ b/tests/src/test/resources/commandrouter/clustered-cache/application.yml
@@ -70,26 +70,6 @@ quarkus:
     category:
       "io.quarkus.vertx.core.runtime":
         level: DEBUG
-      "org.apache.kafka":
-        level: WARN
-      "org.eclipse.hono":
-        level: INFO
-      "org.eclipse.hono.authentication.impl":
-        level: INFO
-      "org.eclipse.hono.client":
-        level: INFO
-      "org.eclipse.hono.commandrouter":
-        level: INFO
-      "org.eclipse.hono.commandrouter.impl.amqp":
-        level: INFO
-      "org.eclipse.hono.commandrouter.impl.kafka":
-        level: INFO
-      "org.eclipse.hono.connection":
-        level: INFO
-      "org.eclipse.hono.deviceconnection.infinispan.client":
-        level: INFO
-      "org.infinispan":
-        level: INFO
   vertx:
     max-event-loop-execute-time: ${max.event-loop.execute-time}
 

--- a/tests/src/test/resources/commandrouter/embedded-cache/application.yml
+++ b/tests/src/test/resources/commandrouter/embedded-cache/application.yml
@@ -61,24 +61,8 @@ quarkus:
     level: INFO
     min-level: TRACE
     category:
-      "org.eclipse.hono":
-        level: INFO
-      "org.eclipse.hono.authentication.impl":
-        level: INFO
-      "org.eclipse.hono.client":
-        level: INFO
-      "org.eclipse.hono.commandrouter":
-        level: INFO
-      "org.eclipse.hono.commandrouter.impl.amqp":
-        level: INFO
-      "org.eclipse.hono.connection":
-        level: INFO
-      "org.eclipse.hono.deviceconnection.infinispan.client":
-        level: INFO
-      "org.infinispan":
-        level: INFO
-      "org.apache.kafka":
-        level: WARN
+      "io.quarkus.vertx.core.runtime":
+        level: DEBUG
   vertx:
     max-event-loop-execute-time: ${max.event-loop.execute-time}
 

--- a/tests/src/test/resources/commandrouter/logback-spring.xml
+++ b/tests/src/test/resources/commandrouter/logback-spring.xml
@@ -41,6 +41,7 @@
   </root>
 
   <springProfile name="trace">
+    <logger name="org.eclipse.hono" level="DEBUG"/>
     <logger name="org.eclipse.hono.client" level="TRACE"/>
     <logger name="org.eclipse.hono.client.command" level="TRACE"/>
     <logger name="org.eclipse.hono.client.registry" level="TRACE"/>
@@ -48,7 +49,6 @@
     <logger name="org.eclipse.hono.commandrouter" level="TRACE"/>
     <logger name="org.eclipse.hono.connection" level="TRACE"/>
     <logger name="org.eclipse.hono.service" level="TRACE"/>
-    <logger name="org.eclipse.hono" level="DEBUG"/>
 
     <logger name="org.infinispan" level="DEBUG"/>
     <logger name="org.apache.kafka" level="INFO"/>

--- a/tests/src/test/resources/commandrouter/logging-quarkus-dev.yml
+++ b/tests/src/test/resources/commandrouter/logging-quarkus-dev.yml
@@ -1,0 +1,11 @@
+quarkus:
+  log:
+    category:
+      "io.netty.handler.logging.LoggingHandler":
+        level: DEBUG
+      "org.apache.kafka":
+        level: INFO
+      "org.eclipse.hono":
+        level: DEBUG
+      "org.infinispan":
+        level: DEBUG

--- a/tests/src/test/resources/commandrouter/logging-quarkus-prod.yml
+++ b/tests/src/test/resources/commandrouter/logging-quarkus-prod.yml
@@ -1,0 +1,9 @@
+quarkus:
+  log:
+    category:
+      "org.apache.kafka":
+        level: WARN
+      "org.eclipse.hono":
+        level: INFO
+      "org.eclipse.hono.client.impl.HonoConnectionImpl":
+        level: ERROR

--- a/tests/src/test/resources/commandrouter/logging-quarkus-trace.yml
+++ b/tests/src/test/resources/commandrouter/logging-quarkus-trace.yml
@@ -1,0 +1,11 @@
+quarkus:
+  log:
+    category:
+      "io.netty.handler.logging.LoggingHandler":
+        level: DEBUG
+      "org.apache.kafka":
+        level: INFO
+      "org.eclipse.hono":
+        level: TRACE
+      "org.infinispan":
+        level: DEBUG

--- a/tests/src/test/resources/deviceregistry-mongodb/application.yml
+++ b/tests/src/test/resources/deviceregistry-mongodb/application.yml
@@ -66,23 +66,8 @@ quarkus:
     category:
       "io.quarkus.vertx.core.runtime":
         level: DEBUG
-      "org.apache.kafka":
-        level: WARN
-      "org.eclipse.hono":
-        level: INFO
-      "org.eclipse.hono.authentication.impl":
-        level: INFO
-      "org.eclipse.hono.client":
-        level: INFO
-      "org.eclipse.hono.deviceregistry":
-        level: INFO
-      "org.eclipse.hono.deviceregistry.mongodb":
-        level: INFO
-      "org.eclipse.hono.service":
-        level: INFO
   vertx:
     max-event-loop-execute-time: ${max.event-loop.execute-time}
-    prefer-native-transport: true
 
 spring:
   jmx:

--- a/tests/src/test/resources/deviceregistry-mongodb/logback-spring.xml
+++ b/tests/src/test/resources/deviceregistry-mongodb/logback-spring.xml
@@ -64,6 +64,8 @@
 
     <logger name="io.netty.handler.logging.LoggingHandler" level="DEBUG"/>
 
+    <logger name="org.apache.kafka" level="INFO"/>
+
     <logger name="io.vertx.proton.impl" level="INFO"/>
     <logger name="io.vertx.core.net.impl" level="INFO"/>
   </springProfile>
@@ -92,6 +94,8 @@
 
     <logger name="io.netty.handler.logging.LoggingHandler" level="DEBUG"/>
 
+    <logger name="org.apache.kafka" level="INFO"/>
+
     <logger name="io.vertx.proton.impl" level="INFO"/>
     <logger name="io.vertx.core.net.impl" level="INFO"/>
   </springProfile>
@@ -103,6 +107,8 @@
     <logger name="org.eclipse.hono.connection" level="INFO"/>
 
     <logger name="io.netty.handler.logging.LoggingHandler" level="INFO"/>
+
+    <logger name="org.apache.kafka" level="WARN"/>
 
     <logger name="io.vertx.proton.impl" level="INFO"/>
     <logger name="io.vertx.core.net.impl" level="INFO"/>

--- a/tests/src/test/resources/deviceregistry-mongodb/logging-quarkus-dev.yml
+++ b/tests/src/test/resources/deviceregistry-mongodb/logging-quarkus-dev.yml
@@ -1,0 +1,9 @@
+quarkus:
+  log:
+    category:
+      "io.netty.handler.logging.LoggingHandler":
+        level: DEBUG
+      "org.apache.kafka":
+        level: INFO
+      "org.eclipse.hono":
+        level: DEBUG

--- a/tests/src/test/resources/deviceregistry-mongodb/logging-quarkus-prod.yml
+++ b/tests/src/test/resources/deviceregistry-mongodb/logging-quarkus-prod.yml
@@ -1,0 +1,9 @@
+quarkus:
+  log:
+    category:
+      "org.apache.kafka":
+        level: WARN
+      "org.eclipse.hono":
+        level: INFO
+      "org.eclipse.hono.client.impl.HonoConnectionImpl":
+        level: ERROR

--- a/tests/src/test/resources/deviceregistry-mongodb/logging-quarkus-trace.yml
+++ b/tests/src/test/resources/deviceregistry-mongodb/logging-quarkus-trace.yml
@@ -1,0 +1,9 @@
+quarkus:
+  log:
+    category:
+      "io.netty.handler.logging.LoggingHandler":
+        level: DEBUG
+      "org.apache.kafka":
+        level: INFO
+      "org.eclipse.hono":
+        level: TRACE

--- a/tests/src/test/resources/http/application.yml
+++ b/tests/src/test/resources/http/application.yml
@@ -90,12 +90,6 @@ quarkus:
     category:
       "io.quarkus.vertx.core.runtime":
         level: DEBUG
-      "org.apache.kafka":
-        level: WARN
-      "org.eclipse.hono":
-        level: INFO
-      "org.eclipse.hono.adapter":
-        level: INFO
   vertx:
     max-event-loop-execute-time: ${max.event-loop.execute-time}
 

--- a/tests/src/test/resources/http/logging-quarkus-dev.yml
+++ b/tests/src/test/resources/http/logging-quarkus-dev.yml
@@ -1,0 +1,7 @@
+quarkus:
+  log:
+    category:
+      "org.apache.kafka":
+        level: INFO
+      "org.eclipse.hono":
+        level: DEBUG

--- a/tests/src/test/resources/http/logging-quarkus-prod.yml
+++ b/tests/src/test/resources/http/logging-quarkus-prod.yml
@@ -1,0 +1,9 @@
+quarkus:
+  log:
+    category:
+      "org.apache.kafka":
+        level: WARN
+      "org.eclipse.hono":
+        level: INFO
+      "org.eclipse.hono.client.impl.HonoConnectionImpl":
+        level: ERROR

--- a/tests/src/test/resources/http/logging-quarkus-trace.yml
+++ b/tests/src/test/resources/http/logging-quarkus-trace.yml
@@ -1,0 +1,7 @@
+quarkus:
+  log:
+    category:
+      "org.apache.kafka":
+        level: INFO
+      "org.eclipse.hono":
+        level: TRACE

--- a/tests/src/test/resources/mqtt/application.yml
+++ b/tests/src/test/resources/mqtt/application.yml
@@ -88,12 +88,6 @@ quarkus:
     category:
       "io.quarkus.vertx.core.runtime":
         level: DEBUG
-      "org.apache.kafka":
-        level: WARN
-      "org.eclipse.hono":
-        level: INFO
-      "org.eclipse.hono.adapter":
-        level: INFO
   vertx:
     max-event-loop-execute-time: ${max.event-loop.execute-time}
 

--- a/tests/src/test/resources/mqtt/logging-quarkus-dev.yml
+++ b/tests/src/test/resources/mqtt/logging-quarkus-dev.yml
@@ -1,0 +1,7 @@
+quarkus:
+  log:
+    category:
+      "org.apache.kafka":
+        level: INFO
+      "org.eclipse.hono":
+        level: DEBUG

--- a/tests/src/test/resources/mqtt/logging-quarkus-prod.yml
+++ b/tests/src/test/resources/mqtt/logging-quarkus-prod.yml
@@ -1,0 +1,9 @@
+quarkus:
+  log:
+    category:
+      "org.apache.kafka":
+        level: WARN
+      "org.eclipse.hono":
+        level: INFO
+      "org.eclipse.hono.client.impl.HonoConnectionImpl":
+        level: ERROR

--- a/tests/src/test/resources/mqtt/logging-quarkus-trace.yml
+++ b/tests/src/test/resources/mqtt/logging-quarkus-trace.yml
@@ -1,0 +1,7 @@
+quarkus:
+  log:
+    category:
+      "org.apache.kafka":
+        level: INFO
+      "org.eclipse.hono":
+        level: TRACE


### PR DESCRIPTION
Running the integration tests with the Quarkus based images now properly
considers the "logging.profile" Maven property for setting the
components' log level(s).
