### PR TITLE
Use remote sampling configuration for running ITs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,4 +60,4 @@ jobs:
       with:
         java-version: '11'
     - name: Build all components (incl. unit tests) and run integration tests
-      run: mvn install -B -e -DcreateJavadoc=true -DCI=$CI -Dhono.components.type=${{ matrix.component-type }} -Dhono.deviceregistry.type=${{ matrix.device-registry }} -Dhono.messaging-infra.type=${{ matrix.messaging-type }} -Dhono.commandrouting.mode=${{ matrix.commandrouting-mode }} -Dhono.commandrouting.cache=${{ matrix.commandrouting-cache }} -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Pbuild-docker-image,run-tests
+      run: mvn install -B -e -DcreateJavadoc=true -DCI=$CI -Dhono.components.type=${{ matrix.component-type }} -Dhono.deviceregistry.type=${{ matrix.device-registry }} -Dhono.messaging-infra.type=${{ matrix.messaging-type }} -Dhono.commandrouting.mode=${{ matrix.commandrouting-mode }} -Dhono.commandrouting.cache=${{ matrix.commandrouting-cache }} -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Pbuild-docker-image,jaeger,run-tests

--- a/.github/workflows/native-images-tests.yml
+++ b/.github/workflows/native-images-tests.yml
@@ -57,4 +57,4 @@ jobs:
         mvn verify -pl :hono-tests -B -e -DCI=$CI \
         -Dhono.components.type=quarkus-native -Dhono.deviceregistry.type=file \
         -Dhono.messaging-infra.type=amqp -Dhono.commandrouting.cache=embedded \
-        -Prun-tests,jaeger
+        -Prun-tests

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -36,7 +36,7 @@
     <guava.version>30.1-jre</guava.version>
     <gson.version>2.8.6</gson.version>
     <infinispan-image.name>quay.io/infinispan/server-native:13.0</infinispan-image.name>
-    <jaeger.image.name>jaegertracing/all-in-one:1.29</jaeger.image.name>
+    <jaeger.image.name>jaegertracing/all-in-one:1.31</jaeger.image.name>
     <jaeger.version>1.6.0</jaeger.version>
     <!-- 
       We want to allow users to run containers in a rootless Docker environment.

--- a/service-base-quarkus/pom.xml
+++ b/service-base-quarkus/pom.xml
@@ -39,8 +39,8 @@
       <artifactId>hono-service-base</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.opentracing.contrib</groupId>
-      <artifactId>opentracing-tracerresolver</artifactId>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-util</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/TracerProducer.java
+++ b/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/TracerProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,38 +12,29 @@
  */
 package org.eclipse.hono.service.quarkus;
 
-import java.util.Optional;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
-import io.jaegertracing.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.opentracing.Tracer;
-import io.opentracing.contrib.tracerresolver.TracerResolver;
-import io.opentracing.noop.NoopTracerFactory;
-import io.quarkus.arc.DefaultBean;
-import io.quarkus.arc.properties.IfBuildProperty;
+import io.opentracing.util.GlobalTracer;
 
 /**
- * A factory class that creates a proper tracer based on the profile.
+ * A producer for an OpenTracting Tracer.
  */
 @ApplicationScoped
 public class TracerProducer {
 
-    @Singleton
-    @Produces
-    @DefaultBean
-    Tracer tracer() {
-        return Optional.ofNullable(TracerResolver.resolveTracer())
-                .orElse(NoopTracerFactory.create());
-    }
+    private static final Logger LOG = LoggerFactory.getLogger(TracerProducer.class);
 
     @Singleton
     @Produces
-    @IfBuildProperty(name = "hono.tracing", stringValue = "jaeger")
     Tracer jaegerTracer() {
-        return Configuration.fromEnv().getTracer();
+        final var tracer = GlobalTracer.get();
+        LOG.info("using tracer instance: {}", tracer.toString());
+        return tracer;
     }
-
 }

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -154,18 +154,21 @@
 
     <hono.postgres.disabled>true</hono.postgres.disabled>
 
+    <hono.amqp-adapter.host>hono-adapter-amqp</hono.amqp-adapter.host>
     <hono.amqp-adapter.image>hono-adapter-amqp-vertx</hono.amqp-adapter.image>
     <hono.amqp-adapter.config-dir>opt/hono/config</hono.amqp-adapter.config-dir>
     <hono.amqp-adapter.max-mem>314572800</hono.amqp-adapter.max-mem>
     <hono.amqp-adapter.java-options>${default.java-options}</hono.amqp-adapter.java-options>
     <hono.amqp-adapter.native-image-args></hono.amqp-adapter.native-image-args>
 
+    <hono.coap-adapter.host>hono-adapter-coap</hono.coap-adapter.host>
     <hono.coap-adapter.image>hono-adapter-coap-vertx</hono.coap-adapter.image>
     <hono.coap-adapter.config-dir>opt/hono/config</hono.coap-adapter.config-dir>
     <hono.coap-adapter.max-mem>314572800</hono.coap-adapter.max-mem>
     <hono.coap-adapter.java-options>${default.java-options}</hono.coap-adapter.java-options>
     <hono.coap-adapter.native-image-args></hono.coap-adapter.native-image-args>
 
+    <hono.http-adapter.host>hono-adapter-http</hono.http-adapter.host>
     <hono.http-adapter.image>hono-adapter-http-vertx</hono.http-adapter.image>
     <hono.http-adapter.config-dir>opt/hono/config</hono.http-adapter.config-dir>
     <hono.http-adapter.max-mem>314572800</hono.http-adapter.max-mem>
@@ -173,6 +176,7 @@
     <hono.http-adapter.java-options>${default.java-options}</hono.http-adapter.java-options>
     <hono.http-adapter.native-image-args></hono.http-adapter.native-image-args>
 
+    <hono.mqtt-adapter.host>hono-adapter-mqtt</hono.mqtt-adapter.host>
     <hono.mqtt-adapter.image>hono-adapter-mqtt-vertx</hono.mqtt-adapter.image>
     <hono.mqtt-adapter.config-dir>opt/hono/config</hono.mqtt-adapter.config-dir>
     <hono.mqtt-adapter.max-mem>314572800</hono.mqtt-adapter.max-mem>
@@ -780,14 +784,31 @@
                 </image>
                 <!-- ##### Jaeger tracing component ##### -->
                 <image>
-                  <name>${jaeger.image.name}</name>
-                  <run>
+                  <name>${docker.repository}/hono-jaeger-test:${project.version}</name>
+                  <build>
                     <skip>${jaeger.disabled}</skip>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
+                    <from>${jaeger.image.name}</from>
+                    <assembly>
+                      <mode>dir</mode>
+                      <basedir>/</basedir>
+                      <inline>
+                        <id>config</id>
+                        <fileSet>
+                          <directory>${project.build.directory}/resources/jaeger</directory>
+                          <outputDirectory>etc/hono</outputDirectory>
+                          <includes>
+                            <include>*</include>
+                          </includes>
+                        </fileSet>
+                      </inline>
+                    </assembly>
+                  </build>
+                  <run>
+                    <skip>${jaeger.disabled}</skip>
                     <ports>
                       <port>+jaeger.ip:jaeger.health.port:14269</port><!-- admin-http -->
                       <port>+jaeger.ip:jaeger.query.port:16686</port><!-- query-http -->
-                      <port>+jaeger.ip:jaeger.agent.port:6831/udp</port><!-- agent (compact thrift protocol) -->
                     </ports>
                     <portPropertyFile>${project.build.directory}/docker/jaeger.port.properties</portPropertyFile>
                     <network>
@@ -807,7 +828,9 @@
                     <memorySwap>314572800</memorySwap>
                     <memory>314572800</memory>
                     <env>
+                      <LOG_LEVEL>info</LOG_LEVEL>
                       <MEMORY_MAX_TRACES>2000</MEMORY_MAX_TRACES>
+                      <SAMPLING_STRATEGIES_FILE>/etc/hono/default-sampling-strategies.json</SAMPLING_STRATEGIES_FILE>
                     </env>
                     <log>
                       <prefix>JAEGER</prefix>
@@ -1161,11 +1184,9 @@
                       <SPRING_PROFILES_ACTIVE>${hono.deviceregistry.spring.profiles}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${hono.deviceregistry.java-options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
-                      <JAEGER_SERVICE_NAME>device-registry</JAEGER_SERVICE_NAME>
+                      <JAEGER_SERVICE_NAME>${hono.registration.host}</JAEGER_SERVICE_NAME>
                       <JAEGER_AGENT_HOST>${jaeger.host}</JAEGER_AGENT_HOST>
-                      <JAEGER_AGENT_PORT>6831</JAEGER_AGENT_PORT>
-                      <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
-                      <JAEGER_SAMPLER_PARAM>1</JAEGER_SAMPLER_PARAM>
+                      <JAEGER_SAMPLER_MANAGER_HOST_PORT>${jaeger.host}:5778</JAEGER_SAMPLER_MANAGER_HOST_PORT>
                     </env>
                     <log>
                       <prefix>REGISTRY</prefix>
@@ -1234,11 +1255,9 @@
                       <SPRING_PROFILES_ACTIVE>${logging.profile},embedded-cache</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${default.java-options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
-                      <JAEGER_SERVICE_NAME>device-connection</JAEGER_SERVICE_NAME>
+                      <JAEGER_SERVICE_NAME>${hono.device-connection.host}</JAEGER_SERVICE_NAME>
                       <JAEGER_AGENT_HOST>${jaeger.host}</JAEGER_AGENT_HOST>
-                      <JAEGER_AGENT_PORT>6831</JAEGER_AGENT_PORT>
-                      <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
-                      <JAEGER_SAMPLER_PARAM>1</JAEGER_SAMPLER_PARAM>
+                      <JAEGER_SAMPLER_MANAGER_HOST_PORT>${jaeger.host}:5778</JAEGER_SAMPLER_MANAGER_HOST_PORT>
                     </env>
                     <log>
                       <prefix>DEVCON</prefix>
@@ -1322,11 +1341,9 @@
                       <SPRING_PROFILES_ACTIVE>${logging.profile},embedded-cache,enable-device-connection-endpoint</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${hono.command-router.java-options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
-                      <JAEGER_SERVICE_NAME>command-router</JAEGER_SERVICE_NAME>
+                      <JAEGER_SERVICE_NAME>${hono.commandrouter.host}</JAEGER_SERVICE_NAME>
                       <JAEGER_AGENT_HOST>${jaeger.host}</JAEGER_AGENT_HOST>
-                      <JAEGER_AGENT_PORT>6831</JAEGER_AGENT_PORT>
-                      <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
-                      <JAEGER_SAMPLER_PARAM>1</JAEGER_SAMPLER_PARAM>
+                      <JAEGER_SAMPLER_MANAGER_HOST_PORT>${jaeger.host}:5778</JAEGER_SAMPLER_MANAGER_HOST_PORT>
                     </env>
                     <log>
                       <prefix>CMDROUTER</prefix>
@@ -1393,7 +1410,7 @@
                     <network>
                       <mode>custom</mode>
                       <name>${custom.network.name}</name>
-                      <alias>hono-adapter-http-vertx</alias>
+                      <alias>${hono.http-adapter.host}</alias>
                     </network>
                     <memorySwap>${hono.http-adapter.max-mem}</memorySwap>
                     <memory>${hono.http-adapter.max-mem}</memory>
@@ -1411,11 +1428,9 @@
                       <SPRING_PROFILES_ACTIVE>${logging.profile}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${hono.http-adapter.java-options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
-                      <JAEGER_SERVICE_NAME>hono-adapter-http</JAEGER_SERVICE_NAME>
+                      <JAEGER_SERVICE_NAME>${hono.http-adapter.host}</JAEGER_SERVICE_NAME>
                       <JAEGER_AGENT_HOST>${jaeger.host}</JAEGER_AGENT_HOST>
-                      <JAEGER_AGENT_PORT>6831</JAEGER_AGENT_PORT>
-                      <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
-                      <JAEGER_SAMPLER_PARAM>1</JAEGER_SAMPLER_PARAM>
+                      <JAEGER_SAMPLER_MANAGER_HOST_PORT>${jaeger.host}:5778</JAEGER_SAMPLER_MANAGER_HOST_PORT>
                     </env>
                     <log>
                       <prefix>HTTP</prefix>
@@ -1472,7 +1487,7 @@
                     <network>
                       <mode>custom</mode>
                       <name>${custom.network.name}</name>
-                      <alias>hono-adapter-mqtt-vertx</alias>
+                      <alias>${hono.mqtt-adapter.host}</alias>
                     </network>
                     <memorySwap>${hono.mqtt-adapter.max-mem}</memorySwap>
                     <memory>${hono.mqtt-adapter.max-mem}</memory>
@@ -1490,11 +1505,9 @@
                       <SPRING_PROFILES_ACTIVE>${logging.profile}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${hono.mqtt-adapter.java-options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
-                      <JAEGER_SERVICE_NAME>hono-adapter-mqtt</JAEGER_SERVICE_NAME>
+                      <JAEGER_SERVICE_NAME>${hono.mqtt-adapter.host}</JAEGER_SERVICE_NAME>
                       <JAEGER_AGENT_HOST>${jaeger.host}</JAEGER_AGENT_HOST>
-                      <JAEGER_AGENT_PORT>6831</JAEGER_AGENT_PORT>
-                      <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
-                      <JAEGER_SAMPLER_PARAM>1</JAEGER_SAMPLER_PARAM>
+                      <JAEGER_SAMPLER_MANAGER_HOST_PORT>${jaeger.host}:5778</JAEGER_SAMPLER_MANAGER_HOST_PORT>
                     </env>
                     <log>
                       <prefix>MQTT</prefix>
@@ -1543,6 +1556,7 @@
                   </build>
                   <run>
                     <ports>
+                      <port>5005</port>
                       <port>+adapter.amqp.ip:adapter.amqp.port:5672</port>
                       <port>+adapter.amqps.ip:adapter.amqps.port:5671</port>
                       <port>+adapter.amqp.ip:adapter.amqp.health.port:${vertx.health.port}</port>
@@ -1551,7 +1565,7 @@
                     <network>
                       <mode>custom</mode>
                       <name>${custom.network.name}</name>
-                      <alias>hono-adapter-amqp-vertx</alias>
+                      <alias>${hono.amqp-adapter.host}</alias>
                     </network>
                     <memorySwap>${hono.amqp-adapter.max-mem}</memorySwap>
                     <memory>${hono.amqp-adapter.max-mem}</memory>
@@ -1569,11 +1583,9 @@
                       <SPRING_PROFILES_ACTIVE>${logging.profile}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${hono.amqp-adapter.java-options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
-                      <JAEGER_SERVICE_NAME>hono-adapter-amqp</JAEGER_SERVICE_NAME>
+                      <JAEGER_SERVICE_NAME>${hono.amqp-adapter.host}</JAEGER_SERVICE_NAME>
                       <JAEGER_AGENT_HOST>${jaeger.host}</JAEGER_AGENT_HOST>
-                      <JAEGER_AGENT_PORT>6831</JAEGER_AGENT_PORT>
-                      <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
-                      <JAEGER_SAMPLER_PARAM>1</JAEGER_SAMPLER_PARAM>
+                      <JAEGER_SAMPLER_MANAGER_HOST_PORT>${jaeger.host}:5778</JAEGER_SAMPLER_MANAGER_HOST_PORT>
                     </env>
                     <log>
                       <prefix>AMQP</prefix>
@@ -1630,7 +1642,7 @@
                     <network>
                       <mode>custom</mode>
                       <name>${custom.network.name}</name>
-                      <alias>hono-adapter-coap-vertx</alias>
+                      <alias>${hono.coap-adapter.host}</alias>
                     </network>
                     <memorySwap>${hono.coap-adapter.max-mem}</memorySwap>
                     <memory>${hono.coap-adapter.max-mem}</memory>
@@ -1648,11 +1660,9 @@
                       <SPRING_PROFILES_ACTIVE>${logging.profile}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${hono.coap-adapter.java-options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
-                      <JAEGER_SERVICE_NAME>hono-adapter-coap</JAEGER_SERVICE_NAME>
+                      <JAEGER_SERVICE_NAME>${hono.coap-adapter.host}</JAEGER_SERVICE_NAME>
                       <JAEGER_AGENT_HOST>${jaeger.host}</JAEGER_AGENT_HOST>
-                      <JAEGER_AGENT_PORT>6831</JAEGER_AGENT_PORT>
-                      <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
-                      <JAEGER_SAMPLER_PARAM>1</JAEGER_SAMPLER_PARAM>
+                      <JAEGER_SAMPLER_MANAGER_HOST_PORT>${jaeger.host}:5778</JAEGER_SAMPLER_MANAGER_HOST_PORT>
                     </env>
                     <log>
                       <prefix>COAP</prefix>

--- a/tests/src/test/resources/amqp/application.yml
+++ b/tests/src/test/resources/amqp/application.yml
@@ -89,12 +89,16 @@ hono:
       bootstrap.servers: ${hono.kafka.bootstrap.servers}
 
 quarkus:
+  jaeger:
+    service-name: "${hono.amqp-adapter.host}"
   log:
     console:
       color: true
     level: INFO
     min-level: TRACE
     category:
+      "io.quarkus.jaeger":
+        level: DEBUG
       "io.quarkus.vertx.core.runtime":
         level: DEBUG
   vertx:

--- a/tests/src/test/resources/coap/application.yml
+++ b/tests/src/test/resources/coap/application.yml
@@ -88,12 +88,16 @@ hono:
       bootstrap.servers: ${hono.kafka.bootstrap.servers}
 
 quarkus:
+  jaeger:
+    service-name: "${hono.coap-adapter.host}"
   log:
     console:
       color: true
     level: INFO
     min-level: TRACE
     category:
+      "io.quarkus.jaeger":
+        level: DEBUG
       "io.quarkus.vertx.core.runtime":
         level: DEBUG
   vertx:

--- a/tests/src/test/resources/commandrouter/clustered-cache/application.yml
+++ b/tests/src/test/resources/commandrouter/clustered-cache/application.yml
@@ -62,12 +62,16 @@ hono:
     preferNative: true
 
 quarkus:
+  jaeger:
+    service-name: "${hono.commandrouter.host}"
   log:
     console:
       color: true
     level: INFO
     min-level: TRACE
     category:
+      "io.quarkus.jaeger":
+        level: DEBUG
       "io.quarkus.vertx.core.runtime":
         level: DEBUG
   vertx:

--- a/tests/src/test/resources/commandrouter/embedded-cache/application.yml
+++ b/tests/src/test/resources/commandrouter/embedded-cache/application.yml
@@ -55,12 +55,16 @@ hono:
     preferNative: true
 
 quarkus:
+  jaeger:
+    service-name: "${hono.commandrouter.host}"
   log:
     console:
       color: true
     level: INFO
     min-level: TRACE
     category:
+      "io.quarkus.jaeger":
+        level: DEBUG
       "io.quarkus.vertx.core.runtime":
         level: DEBUG
   vertx:

--- a/tests/src/test/resources/deviceregistry-mongodb/application.yml
+++ b/tests/src/test/resources/deviceregistry-mongodb/application.yml
@@ -59,12 +59,16 @@ hono:
       bootstrap.servers: ${hono.kafka.bootstrap.servers}
 
 quarkus:
+  jaeger:
+    service-name: "${hono.registration.host}"
   log:
     console:
       color: true
     level: INFO
     min-level: TRACE
     category:
+      "io.quarkus.jaeger":
+        level: DEBUG
       "io.quarkus.vertx.core.runtime":
         level: DEBUG
   vertx:

--- a/tests/src/test/resources/http/application.yml
+++ b/tests/src/test/resources/http/application.yml
@@ -82,12 +82,16 @@ hono:
       bootstrap.servers: ${hono.kafka.bootstrap.servers}
 
 quarkus:
+  jaeger:
+    service-name: "${hono.http-adapter.host}"
   log:
     console:
       color: true
     level: INFO
     min-level: TRACE
     category:
+      "io.quarkus.jaeger":
+        level: DEBUG
       "io.quarkus.vertx.core.runtime":
         level: DEBUG
   vertx:

--- a/tests/src/test/resources/jaeger/default-sampling-strategies.json
+++ b/tests/src/test/resources/jaeger/default-sampling-strategies.json
@@ -1,0 +1,57 @@
+{
+  "service_strategies": [
+    {
+      "service": "${hono.registration.host}",
+      "type": "probabilistic",
+      "param": 1.0,
+      "operation_strategies": [
+      ]
+    },
+    {
+      "service": "${hono.device-connection.host}",
+      "type": "probabilistic",
+      "param": 1.0,
+      "operation_strategies": [
+      ]
+    },
+    {
+      "service": "${hono.commandrouter.host}",
+      "type": "probabilistic",
+      "param": 1.0,
+      "operation_strategies": [
+      ]
+    },
+    {
+      "service": "${hono.amqp-adapter.host}",
+      "type": "probabilistic",
+      "param": 1.0,
+      "operation_strategies": [
+      ]
+    },
+    {
+      "service": "${hono.coap-adapter.host}",
+      "type": "probabilistic",
+      "param": 1.0,
+      "operation_strategies": [
+      ]
+    },
+    {
+      "service": "${hono.http-adapter.host}",
+      "type": "probabilistic",
+      "param": 1.0,
+      "operation_strategies": [
+      ]
+    },
+    {
+      "service": "${hono.mqtt-adapter.host}",
+      "type": "probabilistic",
+      "param": 1.0,
+      "operation_strategies": [
+      ]
+    }
+  ],
+  "default_strategy": {
+    "type": "probabilistic",
+    "param": 1.0
+  }
+}

--- a/tests/src/test/resources/mqtt/application.yml
+++ b/tests/src/test/resources/mqtt/application.yml
@@ -80,12 +80,16 @@ hono:
       bootstrap.servers: ${hono.kafka.bootstrap.servers}
 
 quarkus:
+  jaeger:
+    service-name: "${hono.mqtt-adapter.host}"
   log:
     console:
       color: true
     level: INFO
     min-level: TRACE
     category:
+      "io.quarkus.jaeger":
+        level: DEBUG
       "io.quarkus.vertx.core.runtime":
         level: DEBUG
   vertx:


### PR DESCRIPTION
The sampler configuration is now defined in a central JSON config file
that is served by the Jaeger agent. This makes configuration easier to
maintain and also implicitly helps verifying that all necessary classes
have been registered for reflection when running the ITs with native
images.
