### PR TITLE
[#3093] Remove support for wild card character in topic filter

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractSubscription.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractSubscription.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -61,11 +61,15 @@ public abstract class AbstractSubscription implements Subscription {
 
         Objects.requireNonNull(topicResource);
         Objects.requireNonNull(qos);
+
+        if ("+".equals(topicResource.getTenantId())) {
+            throw new IllegalArgumentException("topic filter must not contain '+' wildcard for tenant ID");
+        }
+
         this.topic = topicResource.toString();
         this.qos = qos;
-
         this.endpoint = topicResource.getEndpoint();
-        final String resourceTenant = "+".equals(topicResource.getTenantId()) ? null : topicResource.getTenantId();
+        final String resourceTenant = topicResource.getTenantId();
         this.containsTenantId = !Strings.isNullOrEmpty(resourceTenant);
         final String resourceDeviceId = "+".equals(topicResource.getResourceId()) ? null : topicResource.getResourceId();
         this.containsDeviceId = !Strings.isNullOrEmpty(resourceDeviceId);

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/CommandSubscriptionTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/CommandSubscriptionTest.java
@@ -92,7 +92,7 @@ public class CommandSubscriptionTest {
         String topic = String.format("%s///%s/#", endpointName, reqPartName);
         assertThat(CommandSubscription.fromTopic(topic, MqttQoS.AT_MOST_ONCE, null)).isNull();
 
-        topic = String.format("%s/+/+/%s/#", endpointName, reqPartName);
+        topic = String.format("%s//+/%s/#", endpointName, reqPartName);
         assertThat(CommandSubscription.fromTopic(topic, MqttQoS.AT_MOST_ONCE, null)).isNull();
     }
 
@@ -112,7 +112,7 @@ public class CommandSubscriptionTest {
         topic = String.format("%s///notReqNorQ/#", endpointName);
         assertThat(CommandSubscription.fromTopic(topic, MqttQoS.AT_MOST_ONCE, device)).isNull();
 
-        topic = String.format("%s/+/+/notReqNorQ/#", endpointName);
+        topic = String.format("%s//+/notReqNorQ/#", endpointName);
         assertThat(CommandSubscription.fromTopic(topic, MqttQoS.AT_MOST_ONCE, device)).isNull();
     }
 
@@ -135,7 +135,7 @@ public class CommandSubscriptionTest {
         topic = String.format("%s///%s/not#", endpointName, reqPartName);
         assertThat(CommandSubscription.fromTopic(topic, MqttQoS.AT_MOST_ONCE, device)).isNull();
 
-        topic = String.format("%s/+/+/%s/not#", endpointName, reqPartName);
+        topic = String.format("%s//+/%s/not#", endpointName, reqPartName);
         assertThat(CommandSubscription.fromTopic(topic, MqttQoS.AT_MOST_ONCE, device)).isNull();
     }
 
@@ -159,6 +159,18 @@ public class CommandSubscriptionTest {
         assertThat(CommandSubscription.fromTopic(topic, MqttQoS.AT_MOST_ONCE, null)).isNull();
     }
 
+    /**
+     * Verifies that topic filters containing the {@code +} wild card character for the tenant ID are not supported.
+     *
+     * @param topicFilter The topic filter to test.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { "command/+/+/req/#", "command/+//req/#", "command/+/device-id/req/#" })
+    public void testSubscriptionFailsForWildcardTenantId(final String topicFilter) {
+
+        final var topicSubscription = new MqttTopicSubscriptionImpl(topicFilter, MqttQoS.AT_LEAST_ONCE);
+        assertThat(CommandSubscription.fromTopic(topicSubscription, null)).isNull();
+    }
 
     /**
      * Verifies that an unauthenticated device can successfully subscribe for commands
@@ -384,19 +396,6 @@ public class CommandSubscriptionTest {
                 String.format("%s/otherTenant/+/%s/#", endpointName, reqPartName),
                 qos);
         assertThat(CommandSubscription.fromTopic(mqttTopicSubscription, gw)).isNull();
-    }
-
-    /**
-     * Verifies that topic filters containing the {@code +} wildcard character for the tenant ID are not supported.
-     *
-     * @param topicFilter The topic filter to test.
-     */
-    @ParameterizedTest
-    @ValueSource(strings = { "command/+/+/req/#", "command/+//req/#", "command/+/device-id/req/#" })
-    public void testSubscriptionFailsForWildcardDeviceId(final String topicFilter) {
-
-        final var topicSubscription = new MqttTopicSubscriptionImpl(topicFilter, MqttQoS.AT_LEAST_ONCE);
-        assertThat(CommandSubscription.fromTopic(topicSubscription, null)).isNull();
     }
 
     private static String getCommandEndpoint() {

--- a/site/documentation/content/user-guide/mqtt-adapter.md
+++ b/site/documentation/content/user-guide/mqtt-adapter.md
@@ -380,12 +380,6 @@ The protocol adapter will publish commands for the device to the following topic
 The *tenant-id* and/or *device-id* will be included in the topic name if the tenant and/or device ID had been included
 in the topic filter used for subscribing to commands.
 
-{{% notice info %}}
-Previous versions of Hono required authenticated devices to use `command/+/+/req/#` for subscribing to commands.
-This old topic filter is deprecated. Devices MAY still use it until support for it will be removed in a future Hono
-version.
-{{% /notice %}}
-
 **Examples**
 
 The following command can be used to subscribe to commands resulting in command messages being published to a
@@ -490,12 +484,12 @@ for details.
 
 An authenticated gateway MUST use one of the following topic filters for subscribing to commands:
 
-| Topic Filter                          | Description                                                                                     |
-| :------------------------------------ | :---------------------------------------------------------------------------------------------- |
-| `command//+/req/#`                       | Subscribe to commands for all devices that the gateway is authorized to act on behalf of. |
-| `command/${tenant-id}/+/req/#`             | Subscribe to commands for all devices that the gateway is authorized to act on behalf of. |
-| `command//${device-id}/req/#`              | Subscribe to commands for a specific device that the gateway is authorized to act on behalf of. |
-| `command/${tenant-id}/${device-id}/req/#`    | Subscribe to commands for a specific device that the gateway is authorized to act on behalf of. |
+| Topic Filter                       | Description                                                                  |
+| :--------------------------------- | :--------------------------------------------------------------------------- |
+| `command//+/req/#`                    | Subscribe to commands for all devices that the gateway is authorized to act on behalf of. |
+| `command/${tenant-id}/+/req/#`          | Subscribe to commands for all devices that the gateway is authorized to act on behalf of. |
+| `command//${device-id}/req/#`           | Subscribe to commands for a specific device that the gateway is authorized to act on behalf of. |
+| `command/${tenant-id}/${device-id}/req/#` | Subscribe to commands for a specific device that the gateway is authorized to act on behalf of. |
 
 The protocol adapter will publish commands for devices to the following topic names
 
@@ -504,12 +498,6 @@ The protocol adapter will publish commands for devices to the following topic na
 
 The `${tenant-id}` will be included in the topic name if the tenant ID had been included in the topic filter used for
 subscribing to commands.
-
-{{% notice info %}}
-Previous versions of Hono required authenticated gateways to use `command/+/+/req/#` for subscribing to commands.
-This old topic filter is deprecated. Gateways MAY still use it until support for it will be removed in a future Hono
-version.
-{{% /notice %}}
 
 When processing an incoming command message, the protocol adapter will give precedence to a device-specific command
 subscription matching the command target device, whether the subscription comes from a gateway or the device itself.

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -4,7 +4,7 @@ title = "What is new & noteworthy in Hono?"
 description = "Information about changes in recent Hono releases. Includes new features, fixes, enhancements and API changes."
 +++
 
-## 1.13.0 (not yet released)
+## 2.0.0 (not yet released)
 
 ### Fixes & Enhancements
 
@@ -13,6 +13,11 @@ description = "Information about changes in recent Hono releases. Includes new f
   *hono.mongodb.connectionString* property. This has been fixed.
 * When a tenant or device gets disabled or deleted, any open AMQP or MQTT connections from clients having authenticated
   themselves as belonging to that tenant or device are getting closed now.
+
+# API Changes
+
+* The MQTT adapter no longer accepts the `+` wild card character for the device ID in a topic filter used for
+  subscribing to commands.
 
 ## 1.12.0
 

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -16,7 +16,7 @@ description = "Information about changes in recent Hono releases. Includes new f
 
 # API Changes
 
-* The MQTT adapter no longer accepts the `+` wild card character for the device ID in a topic filter used for
+* The MQTT adapter no longer accepts the `+` wild card character for the tenant ID in a topic filter used for
   subscribing to commands.
 
 ## 1.12.0

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -89,23 +89,15 @@ public class CommandAndControlMqttIT extends MqttTestBase {
 
     static Stream<MqttCommandEndpointConfiguration> allCombinations() {
         return Stream.of(
-                new MqttCommandEndpointConfiguration(SubscriberRole.DEVICE, false),
-                new MqttCommandEndpointConfiguration(SubscriberRole.GATEWAY_FOR_ALL_DEVICES, false),
-                new MqttCommandEndpointConfiguration(SubscriberRole.GATEWAY_FOR_SINGLE_DEVICE, false),
-
-                // the following variants can be removed once we no longer support the legacy topic filters
-                new MqttCommandEndpointConfiguration(SubscriberRole.DEVICE, true),
-                new MqttCommandEndpointConfiguration(SubscriberRole.GATEWAY_FOR_ALL_DEVICES, true),
-                new MqttCommandEndpointConfiguration(SubscriberRole.GATEWAY_FOR_SINGLE_DEVICE, true)
+                new MqttCommandEndpointConfiguration(SubscriberRole.DEVICE),
+                new MqttCommandEndpointConfiguration(SubscriberRole.GATEWAY_FOR_ALL_DEVICES),
+                new MqttCommandEndpointConfiguration(SubscriberRole.GATEWAY_FOR_SINGLE_DEVICE)
                 );
     }
 
     static Stream<MqttCommandEndpointConfiguration> gatewayForSingleDevice() {
         return Stream.of(
-                new MqttCommandEndpointConfiguration(SubscriberRole.GATEWAY_FOR_SINGLE_DEVICE, false),
-
-                // the following variants can be removed once we no longer support the legacy topic filters
-                new MqttCommandEndpointConfiguration(SubscriberRole.GATEWAY_FOR_SINGLE_DEVICE, true)
+                new MqttCommandEndpointConfiguration(SubscriberRole.GATEWAY_FOR_SINGLE_DEVICE)
         );
     }
 
@@ -121,7 +113,9 @@ public class CommandAndControlMqttIT extends MqttTestBase {
         helper.registry.addTenant(tenantId).onComplete(ctx.succeedingThenComplete());
     }
 
-    private Future<MessageConsumer> createConsumer(final String tenantId, final Handler<DownstreamMessage<? extends MessageContext>> messageConsumer) {
+    private Future<MessageConsumer> createConsumer(
+            final String tenantId,
+            final Handler<DownstreamMessage<? extends MessageContext>> messageConsumer) {
         return helper.applicationClient.createEventConsumer(tenantId, (Handler) messageConsumer, remoteClose -> {});
     }
 

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttCommandEndpointConfiguration.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttCommandEndpointConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -27,20 +27,14 @@ import org.eclipse.hono.util.ResourceIdentifier;
  */
 public class MqttCommandEndpointConfiguration extends CommandEndpointConfiguration {
 
-    private final boolean legacyTopicFilter;
-
     /**
      * Creates a new configuration.
      *
      * @param subscriberRole The way in which to subscribe for commands.
-     * @param useLegacyTopicFilter {@code true} if the device uses the legacy topic filter for subscribing to commands.
      */
-    public MqttCommandEndpointConfiguration(
-            final SubscriberRole subscriberRole,
-            final boolean useLegacyTopicFilter) {
+    public MqttCommandEndpointConfiguration(final SubscriberRole subscriberRole) {
 
         super(subscriberRole);
-        this.legacyTopicFilter = useLegacyTopicFilter;
     }
 
     /**
@@ -48,8 +42,12 @@ public class MqttCommandEndpointConfiguration extends CommandEndpointConfigurati
      */
     @Override
     public String toString() {
-        return String.format("subscribe as: %s, southbound endpoint: %s, northbound endpoint: %s, topic filter: %s",
-                getSubscriberRole(), getSouthboundEndpoint(), getNorthboundEndpoint(), getCommandTopicFilter("${deviceId}"));
+        return String.format(
+                "subscribe as: %s, southbound endpoint: %s, northbound endpoint: %s, topic filter: %s",
+                getSubscriberRole(),
+                getSouthboundEndpoint(),
+                getNorthboundEndpoint(),
+                getCommandTopicFilter("${deviceId}"));
     }
 
     /**
@@ -63,14 +61,11 @@ public class MqttCommandEndpointConfiguration extends CommandEndpointConfigurati
     public final String getCommandTopicFilter(final String deviceId) {
         switch (getSubscriberRole()) {
         case DEVICE:
-            return String.format(
-                    "%s/%s/req/#", getSouthboundEndpoint(), legacyTopicFilter ? "+/+" : "/");
+            return String.format("%s///req/#", getSouthboundEndpoint());
         case GATEWAY_FOR_ALL_DEVICES:
-            return String.format(
-                    "%s/%s/req/#", getSouthboundEndpoint(), legacyTopicFilter ? "+/+" : "/+");
+            return String.format("%s//+/req/#", getSouthboundEndpoint());
         case GATEWAY_FOR_SINGLE_DEVICE:
-            return String.format(
-                    "%s/%s/req/#", getSouthboundEndpoint(), (legacyTopicFilter ? "+/" : "/") + deviceId);
+            return String.format("%s//%s/req/#", getSouthboundEndpoint(), deviceId);
         default:
             throw new IllegalStateException("unknown role");
         }


### PR DESCRIPTION
The MQTT adapter no longer accepts the "+" wild card character for the
device ID in a topic filter used for subscribing to commands.

Fixes #3093
