### PR TITLE
[#3107] Fix support for extension jars

### DIFF
--- a/adapters/base-quarkus/pom.xml
+++ b/adapters/base-quarkus/pom.xml
@@ -145,10 +145,12 @@
                       <env>
                         <JAVA_MAJOR_VERSION>${maven.compiler.release}</JAVA_MAJOR_VERSION>
                         <JAVA_APP_NAME>${project.artifactId}</JAVA_APP_NAME>
-                        <JAVA_LIB_DIR>/opt/hono/lib/*:/opt/hono/extensions/*</JAVA_LIB_DIR>
+                        <JAVA_MAIN_CLASS>io.quarkus.bootstrap.runner.QuarkusEntryPoint</JAVA_MAIN_CLASS>
+                        <JAVA_LIB_DIR>app/*:quarkus/*:lib/boot/*:lib/main/*:extensions/*</JAVA_LIB_DIR>
                         <!-- use Base64 encoder/decoder that is compatible with vert.x 3 -->
-                        <JAVA_OPTIONS>-Dvertx.json.base64=legacy -Djava.util.logging.manager=org.jboss.logmanager.LogManager</JAVA_OPTIONS>
-                        <JAVA_APP_JAR>quarkus-run.jar</JAVA_APP_JAR>
+                        <JAVA_OPTIONS>
+                          -Dvertx.json.base64=legacy
+                          -Djava.util.logging.manager=org.jboss.logmanager.LogManager</JAVA_OPTIONS>
                       </env>
                       <entryPoint>
                         <arg>/opt/hono/run-java.sh</arg>

--- a/services/base-quarkus/pom.xml
+++ b/services/base-quarkus/pom.xml
@@ -142,10 +142,13 @@
                       <env>
                         <JAVA_MAJOR_VERSION>${maven.compiler.release}</JAVA_MAJOR_VERSION>
                         <JAVA_APP_NAME>${project.artifactId}</JAVA_APP_NAME>
-                        <JAVA_LIB_DIR>/opt/hono/lib/*:/opt/hono/extensions/*</JAVA_LIB_DIR>
+                        <JAVA_MAIN_CLASS>io.quarkus.bootstrap.runner.QuarkusEntryPoint</JAVA_MAIN_CLASS>
+                        <JAVA_LIB_DIR>app/*:quarkus/*:lib/boot/*:lib/main/*:extensions/*</JAVA_LIB_DIR>
                         <!-- use Base64 encoder/decoder that is compatible with vert.x 3 -->
-                        <JAVA_OPTIONS>-Dvertx.json.base64=legacy -Djava.util.logging.manager=org.jboss.logmanager.LogManager</JAVA_OPTIONS>
-                        <JAVA_APP_JAR>quarkus-run.jar</JAVA_APP_JAR>
+                        <JAVA_OPTIONS>
+                          -Dvertx.json.base64=legacy
+                          -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+                        </JAVA_OPTIONS>
                       </env>
                       <entryPoint>
                         <arg>/opt/hono/run-java.sh</arg>

--- a/site/documentation/content/admin-guide/secure_communication.md
+++ b/site/documentation/content/admin-guide/secure_communication.md
@@ -230,6 +230,11 @@ the `--mount` parameter. Please refer to the
 [Docker reference documentation](https://docs.docker.com/engine/reference/commandline/service_create/#add-bind-mounts-volumes-or-memory-filesystems)
 for details.
 
+{{% warning %}}
+Configuring containers to use OpenSSL the way described above does **not** work with container images based on
+native executables.
+{{% /warning %}}
+
 ## Server Name Indication (SNI)
 
 [Server Name Indication](https://tools.ietf.org/html/rfc6066#section-3) can be used to indicate to a server the host

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -13,6 +13,8 @@ description = "Information about changes in recent Hono releases. Includes new f
   *hono.mongodb.connectionString* property. This has been fixed.
 * When a tenant or device gets disabled or deleted, any open AMQP or MQTT connections from clients having authenticated
   themselves as belonging to that tenant or device are getting closed now.
+* Using OpenSSL with the Quarkus based variant of Hono components did not work as described in the Secure Communication
+  guide. This has been fixed.
 
 ### API Changes
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -168,7 +168,7 @@
     <hono.http-adapter.image>hono-adapter-http-vertx</hono.http-adapter.image>
     <hono.http-adapter.config-dir>opt/hono/config</hono.http-adapter.config-dir>
     <hono.http-adapter.max-mem>314572800</hono.http-adapter.max-mem>
-    <hono.http-adapter.nativeTlsRequired>false</hono.http-adapter.nativeTlsRequired>
+    <hono.http-adapter.nativeTlsRequired>true</hono.http-adapter.nativeTlsRequired>
     <hono.http-adapter.java-options>${default.java-options}</hono.http-adapter.java-options>
     <hono.http-adapter.native-image-args></hono.http-adapter.native-image-args>
 
@@ -184,6 +184,7 @@
     <hono.auth-server.max-mem>205520896</hono.auth-server.max-mem>
     <hono.auth-server.java-options>${default.java-options}</hono.auth-server.java-options>
     <hono.auth-server.native-image-args></hono.auth-server.native-image-args>
+    <hono.auth-server.nativeTlsRequired>true</hono.auth-server.nativeTlsRequired>
 
     <trace.frames>0</trace.frames>
     <jaeger.disabled>true</jaeger.disabled>
@@ -526,7 +527,6 @@
         <hono.amqp-adapter.config-dir>etc/hono</hono.amqp-adapter.config-dir>
         <hono.coap-adapter.config-dir>etc/hono</hono.coap-adapter.config-dir>
         <hono.http-adapter.config-dir>etc/hono</hono.http-adapter.config-dir>
-        <hono.http-adapter.nativeTlsRequired>true</hono.http-adapter.nativeTlsRequired>
         <hono.mqtt-adapter.config-dir>etc/hono</hono.mqtt-adapter.config-dir>
         <hono.auth-server.config-dir>etc/hono</hono.auth-server.config-dir>
         <hono.command-router.config-dir>etc/hono</hono.command-router.config-dir>
@@ -545,18 +545,16 @@
       <properties>
         <hono.image-suffix>-quarkus-native</hono.image-suffix>
         <hono.amqp-adapter.max-mem>67108864</hono.amqp-adapter.max-mem>
-        <hono.amqp-adapter.useNativeTransport>false</hono.amqp-adapter.useNativeTransport>
 
         <hono.coap-adapter.max-mem>67108864</hono.coap-adapter.max-mem>
-        <hono.coap-adapter.useNativeTransport>false</hono.coap-adapter.useNativeTransport>
 
         <hono.http-adapter.max-mem>67108864</hono.http-adapter.max-mem>
         <hono.http-adapter.nativeTlsRequired>false</hono.http-adapter.nativeTlsRequired>
 
         <hono.mqtt-adapter.max-mem>67108864</hono.mqtt-adapter.max-mem>
-        <hono.mqtt-adapter.useNativeTransport>false</hono.mqtt-adapter.useNativeTransport>
 
         <hono.auth-server.max-mem>33554432</hono.auth-server.max-mem>
+        <hono.auth-server.nativeTlsRequired>false</hono.auth-server.nativeTlsRequired>
         <hono.command-router.max-mem>67108864</hono.command-router.max-mem>
         <hono.deviceregistry.mongodb.max-mem>150000000</hono.deviceregistry.mongodb.max-mem>
         <hono.deviceregistry.image-suffix>-quarkus</hono.deviceregistry.image-suffix>
@@ -747,6 +745,15 @@
                       <basedir>/</basedir>
                       <inline>
                         <id>config</id>
+                        <dependencySets>
+                          <dependencySet>
+                            <includes>
+                              <!--  use openSSL in Auth server -->
+                              <include>io.netty:netty-tcnative-boringssl-static</include>
+                            </includes>
+                            <outputDirectory>opt/hono/extensions</outputDirectory>
+                          </dependencySet>
+                        </dependencySets>
                         <fileSets>
                           <fileSet>
                             <directory>${project.build.directory}/resources/auth</directory>

--- a/tests/src/test/resources/auth/application.yml
+++ b/tests/src/test/resources/auth/application.yml
@@ -9,6 +9,7 @@ hono:
       bindAddress: "0.0.0.0"
       keyPath: /etc/hono/certs/auth-server-key.pem
       certPath: /etc/hono/certs/auth-server-cert.pem
+      nativeTlsRequired: ${hono.auth-server.nativeTlsRequired}
     svc:
       permissionsPath: "/${hono.auth-server.config-dir}/permissions.json"
       signing:


### PR DESCRIPTION
The configuration of the run-java.sh command used for starting the
Quarkus based components has been changed to no longer invoke the
quarkus-run.jar but to set a main class to execute. This allows for the
additional classpath (including the jars in the extensions folder) to be
considered by the application.

Fixes #3107