### PR TITLE
[#3106] Allow nested HotRod config keys to be in camel-case

### DIFF
--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/InfinispanRemoteConfigurationOptions.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/InfinispanRemoteConfigurationOptions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -34,6 +34,13 @@ public interface InfinispanRemoteConfigurationOptions {
      * @return The options.
      */
     Map<String, String> connectionPool();
+
+    /**
+     * Gets the default executor factory options.
+     *
+     * @return The options.
+     */
+    Map<String, String> defaultExecutorFactory();
 
     /**
      * Gets the SASL properties.

--- a/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/InfinispanRemoteConfigurationPropertiesTest.java
+++ b/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/InfinispanRemoteConfigurationPropertiesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -45,6 +45,12 @@ class InfinispanRemoteConfigurationPropertiesTest {
         final Configuration config = props.getConfigurationBuilder().build();
         assertThat(config.connectionPool().minIdle()).isEqualTo(2);
         assertThat(config.connectionPool().minEvictableIdleTime()).isGreaterThan(0L);
+    }
+
+    @Test
+    void testDefaultExecutorFactoryProperties() {
+        props.setDefaultExecutorFactory(Map.of("pool_size", "50"));
+        assertThat(props.getDefaultExecutorFactoryPoolSize()).isEqualTo(50);
     }
 
 }

--- a/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/QuarkusPropertyBindingTest.java
+++ b/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/QuarkusPropertyBindingTest.java
@@ -11,15 +11,18 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-
 package org.eclipse.hono.deviceconnection.infinispan.client;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.eclipse.hono.test.ConfigMappingSupport;
-import org.infinispan.client.hotrod.impl.ConfigurationProperties;
-import org.junit.jupiter.api.Test;
+import java.util.List;
 
+import javax.security.sasl.Sasl;
+
+import org.eclipse.hono.test.ConfigMappingSupport;
+import org.infinispan.client.hotrod.configuration.ClusterConfiguration;
+import org.infinispan.client.hotrod.configuration.Configuration;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests verifying binding of configuration properties to {@link CommonCacheConfig} and
@@ -49,20 +52,39 @@ public class QuarkusPropertyBindingTest {
                 ConfigMappingSupport.getConfigMapping(
                         InfinispanRemoteConfigurationOptions.class,
                         this.getClass().getResource("/remote-cache-options.yaml")));
+        final Configuration builtRemoteCacheConfig = remoteCacheConfig.getConfigurationBuilder().build(false);
 
         assertThat(remoteCacheConfig.getServerList()).contains("data-grid:11222");
         assertThat(remoteCacheConfig.getAuthUsername()).isEqualTo("user");
         assertThat(remoteCacheConfig.getAuthPassword()).isEqualTo("secret");
         assertThat(remoteCacheConfig.getAuthRealm()).isEqualTo("ApplicationRealm");
+
+        final List<ClusterConfiguration> clusters = builtRemoteCacheConfig.clusters();
+        assertThat(clusters.size()).isEqualTo(2);
+        assertThat(clusters.get(0).getClusterName()).isEqualTo("siteA");
+        assertThat(clusters.get(0).getCluster().size()).isEqualTo(2);
+        assertThat(clusters.get(0).getCluster().get(0).host()).isEqualTo("hostA1");
+        assertThat(clusters.get(0).getCluster().get(0).port()).isEqualTo(11222);
+        assertThat(clusters.get(1).getClusterName()).isEqualTo("siteB");
+
+        assertThat(remoteCacheConfig.gtConnectionPoolMinIdle()).isEqualTo(10);
+        assertThat(remoteCacheConfig.getConnectionPoolMaxActive()).isEqualTo(10);
+        assertThat(remoteCacheConfig.getConnectionPoolMaxPendingRequests()).isEqualTo(400);
+        assertThat(remoteCacheConfig.getConnectionPoolMaxWait()).isEqualTo(500);
+
+        assertThat(remoteCacheConfig.getDefaultExecutorFactoryPoolSize()).isEqualTo(200);
+
         assertThat(remoteCacheConfig.getSaslMechanism()).contains("DIGEST-MD5");
+        final var saslProperties = builtRemoteCacheConfig.security().authentication().saslProperties();
+        assertThat(saslProperties.get(Sasl.QOP)).isEqualTo("auth");
+
         assertThat(remoteCacheConfig.getSoTimeout()).isEqualTo(5000);
         assertThat(remoteCacheConfig.getConnectTimeout()).isEqualTo(5000);
         assertThat(remoteCacheConfig.getKeyStoreFileName()).isEqualTo("/etc/hono/key-store.p12");
         assertThat(remoteCacheConfig.getKeyStoreType()).isEqualTo("PKCS12");
         assertThat(remoteCacheConfig.getKeyStorePassword()).isEqualTo("key-store-secret");
         assertThat(remoteCacheConfig.getKeyAlias()).isEqualTo("infinispan");
-        assertThat(remoteCacheConfig.getProperties().getProperty(ConfigurationProperties.KEY_STORE_CERTIFICATE_PASSWORD))
-            .isEqualTo("cert-secret");
+        assertThat(remoteCacheConfig.getKeyStoreCertificatePassword()).isEqualTo("cert-secret");
         assertThat(remoteCacheConfig.getTrustStoreFileName()).isEqualTo("/etc/hono/trust-store-file.p12");
         assertThat(remoteCacheConfig.getTrustStorePath()).isEqualTo("/etc/hono/trust-store.p12");
         assertThat(remoteCacheConfig.getTrustStoreType()).isEqualTo("PKCS12");

--- a/client-device-connection-infinispan/src/test/resources/remote-cache-options.yaml
+++ b/client-device-connection-infinispan/src/test/resources/remote-cache-options.yaml
@@ -6,7 +6,19 @@ hono:
       authUsername: "user"
       authPassword: "secret"
       authRealm: "ApplicationRealm"
+      cluster:
+        siteA: "hostA1:11222; hostA2:11223"
+        siteB: "hostB1:11222; hostB2:11223"
+      connectionPool:
+        minIdle: 10
+        maxActive: 10
+        maxPendingRequests: 400
+        maxWait: 500
+      defaultExecutorFactory:
+        poolSize: 200
       saslMechanism: "DIGEST-MD5"
+      saslProperties:
+        "javax.security.sasl.qop": "auth"
       socketTimeout: 5000
       connectTimeout: 5000
       keyStoreFileName: "/etc/hono/key-store.p12"


### PR DESCRIPTION
Also add support for configuring `infinispan.client.hotrod.default_executor_factory.*` HotRod client properties.

This is for #3106.