### PR TITLE
[#3083] Only allow mapped target device id in MappedMessage

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
@@ -552,6 +552,9 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
 
     /**
      * Validates a message's target address for consistency with Hono's addressing rules.
+     * <p>
+     * It is ensured that the returned address contains tenant and device identifiers, adopting them from the
+     * given device information if not already set.
      *
      * @param address The address to validate.
      * @param authenticatedDevice The device that has uploaded the message.

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MappedMessage.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MappedMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,8 +18,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.eclipse.hono.util.ResourceIdentifier;
-
 import io.vertx.core.buffer.Buffer;
 
 /**
@@ -27,47 +25,47 @@ import io.vertx.core.buffer.Buffer;
  */
 public final class MappedMessage {
 
-    private final ResourceIdentifier targetAddress;
+    private final String targetDeviceId;
     private final Buffer payload;
     private final Map<String, String> additionalProperties = new HashMap<>();
 
     /**
      * Creates a new mapping result.
      *
-     * @param targetAddress The target address that the original message has been mapped to.
+     * @param targetDeviceId The identifier of the target device that the original message has been mapped to.
      * @param payload The payload that the original message has been mapped to.
      * @throws NullPointerException if targetAddress is {@code null}.
      */
-    public MappedMessage(final ResourceIdentifier targetAddress, final Buffer payload) {
-        this(targetAddress, payload, null);
+    public MappedMessage(final String targetDeviceId, final Buffer payload) {
+        this(targetDeviceId, payload, null);
     }
 
     /**
      * Creates a new mapping result.
      *
-     * @param targetAddress The target address that the original message has been mapped to.
+     * @param targetDeviceId The identifier of the target device that the original message has been mapped to.
      * @param payload The payload that the original message has been mapped to.
      * @param additionalProperties Extra properties that should be included with the mapped message.
      * @throws NullPointerException if targetAddress is {@code null}.
      */
     public MappedMessage(
-            final ResourceIdentifier targetAddress,
+            final String targetDeviceId,
             final Buffer payload,
             final Map<String, String> additionalProperties) {
 
-        this.targetAddress = Objects.requireNonNull(targetAddress);
+        this.targetDeviceId = Objects.requireNonNull(targetDeviceId);
         this.payload = Optional.ofNullable(payload).orElseGet(Buffer::buffer);
         Optional.ofNullable(additionalProperties)
             .ifPresent(props -> this.additionalProperties.putAll(additionalProperties));
     }
 
     /**
-     * Gets the address that the message should be forwarded to.
+     * Gets the identifier of the device that the message should be forwarded to.
      *
-     * @return The address.
+     * @return The device identifier.
      */
-    public ResourceIdentifier getTargetAddress() {
-        return targetAddress;
+    public String getTargetDeviceId() {
+        return targetDeviceId;
     }
 
     /**

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MessageMapping.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MessageMapping.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,7 +16,6 @@ package org.eclipse.hono.adapter.mqtt;
 import org.eclipse.hono.client.command.Command;
 import org.eclipse.hono.util.ExecutionContext;
 import org.eclipse.hono.util.RegistrationAssertion;
-import org.eclipse.hono.util.ResourceIdentifier;
 
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
@@ -41,9 +40,9 @@ public interface MessageMapping<T extends ExecutionContext> {
      * target address. In all other cases, this method returns a failed future with a {@link org.eclipse.hono.client.ServiceInvocationException}.
      *
      * @param ctx              The context in which the message has been uploaded.
-     * @param targetAddress    The downstream address that the message will be forwarded to.
+     * @param tenantId         The tenant that the device that uploaded the message belongs to.
      * @param registrationInfo The information included in the registration assertion for
-     *                         the authenticated device that has uploaded the message.
+     *                         the device that has uploaded the message.
      * @return                 A successful future containing the mapped message.
      *                         Otherwise, the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}
      *                         if the message could not be mapped.
@@ -51,7 +50,7 @@ public interface MessageMapping<T extends ExecutionContext> {
      */
     Future<MappedMessage> mapDownstreamMessage(
             T ctx,
-            ResourceIdentifier targetAddress,
+            String tenantId,
             RegistrationAssertion registrationInfo);
 
     /**

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/impl/VertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/impl/VertxBasedMqttProtocolAdapterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -92,13 +92,13 @@ public class VertxBasedMqttProtocolAdapterTest {
      * @param ctx The helper to use for running tests on vert.x.
      */
     @Test
-    public void testMapTopicFailsForUnknownEndpoint(final VertxTestContext ctx) {
+    public void testCheckQosAndMapTopicFailsForUnknownEndpoint(final VertxTestContext ctx) {
 
         givenAnAdapter();
 
         // WHEN a device publishes a message to a topic with an unknown endpoint
         final MqttPublishMessage message = newMessage(MqttQoS.AT_MOST_ONCE, "unknown");
-        adapter.mapTopic(newContext(message, span, null)).onComplete(ctx.failing(t -> {
+        adapter.checkQosAndMapTopic(newContext(message, span, null)).onComplete(ctx.failing(t -> {
             // THEN the message cannot be mapped to a topic
             assertServiceInvocationException(ctx, t, HttpURLConnection.HTTP_NOT_FOUND);
             ctx.completeNow();
@@ -111,13 +111,13 @@ public class VertxBasedMqttProtocolAdapterTest {
      * @param ctx The helper to use for running tests on vert.x.
      */
     @Test
-    public void testMapTopicFailsForQoS2TelemetryMessage(final VertxTestContext ctx) {
+    public void testCheckQosAndMapTopicFailsForQoS2TelemetryMessage(final VertxTestContext ctx) {
 
         givenAnAdapter();
 
         // WHEN a device publishes a message with QoS 2 to a "telemetry" topic
         final MqttPublishMessage message = newMessage(MqttQoS.EXACTLY_ONCE, TelemetryConstants.TELEMETRY_ENDPOINT);
-        adapter.mapTopic(newContext(message, span, null)).onComplete(ctx.failing(t -> {
+        adapter.checkQosAndMapTopic(newContext(message, span, null)).onComplete(ctx.failing(t -> {
             // THEN the message cannot be mapped to a topic
             assertServiceInvocationException(ctx, t, HttpURLConnection.HTTP_BAD_REQUEST);
             ctx.completeNow();
@@ -130,13 +130,13 @@ public class VertxBasedMqttProtocolAdapterTest {
      * @param ctx The helper to use for running tests on vert.x.
      */
     @Test
-    public void testMapTopicFailsForQoS0EventMessage(final VertxTestContext ctx) {
+    public void testCheckQosAndMapTopicFailsForQoS0EventMessage(final VertxTestContext ctx) {
 
         givenAnAdapter();
 
         // WHEN a device publishes a message with QoS 0 to an "event" topic
         final MqttPublishMessage message = newMessage(MqttQoS.AT_MOST_ONCE, EventConstants.EVENT_ENDPOINT);
-        adapter.mapTopic(newContext(message, span, null)).onComplete(ctx.failing(t -> {
+        adapter.checkQosAndMapTopic(newContext(message, span, null)).onComplete(ctx.failing(t -> {
             // THEN the message cannot be mapped to a topic
             assertServiceInvocationException(ctx, t, HttpURLConnection.HTTP_BAD_REQUEST);
             ctx.completeNow();
@@ -149,13 +149,13 @@ public class VertxBasedMqttProtocolAdapterTest {
      * @param ctx The helper to use for running tests on vert.x.
      */
     @Test
-    public void testMapTopicFailsForQoS2EventMessage(final VertxTestContext ctx) {
+    public void testCheckQosAndMapTopicFailsForQoS2EventMessage(final VertxTestContext ctx) {
 
         givenAnAdapter();
 
         // WHEN a device publishes a message with QoS 2 to an "event" topic
         final MqttPublishMessage message = newMessage(MqttQoS.EXACTLY_ONCE, EventConstants.EVENT_ENDPOINT);
-        adapter.mapTopic(newContext(message, span, null)).onComplete(ctx.failing(t -> {
+        adapter.checkQosAndMapTopic(newContext(message, span, null)).onComplete(ctx.failing(t -> {
             // THEN the message cannot be mapped to a topic
             assertServiceInvocationException(ctx, t, HttpURLConnection.HTTP_BAD_REQUEST);
             ctx.completeNow();
@@ -253,37 +253,37 @@ public class VertxBasedMqttProtocolAdapterTest {
      * @param ctx The helper to use for running tests on vert.x.
      */
     @Test
-    public void testMapTopicSupportsShortAndLongTopicNames(final VertxTestContext ctx) {
+    public void testCheckQosAndMapTopicSupportsShortAndLongTopicNames(final VertxTestContext ctx) {
 
         givenAnAdapter();
 
         MqttPublishMessage message = newMessage(MqttQoS.AT_LEAST_ONCE, EventConstants.EVENT_ENDPOINT);
         MqttContext context = newContext(message, span, null);
-        adapter.mapTopic(context).onComplete(ctx.succeeding(address -> {
+        adapter.checkQosAndMapTopic(context).onComplete(ctx.succeeding(address -> {
             ctx.verify(() -> assertThat(MetricsTags.EndpointType.fromString(address.getEndpoint())).isEqualTo(MetricsTags.EndpointType.EVENT));
         }));
 
         message = newMessage(MqttQoS.AT_LEAST_ONCE, EventConstants.EVENT_ENDPOINT_SHORT);
         context = newContext(message, span, null);
-        adapter.mapTopic(context).onComplete(ctx.succeeding(address -> {
+        adapter.checkQosAndMapTopic(context).onComplete(ctx.succeeding(address -> {
             ctx.verify(() -> assertThat(MetricsTags.EndpointType.fromString(address.getEndpoint())).isEqualTo(MetricsTags.EndpointType.EVENT));
         }));
 
         message = newMessage(MqttQoS.AT_LEAST_ONCE, TelemetryConstants.TELEMETRY_ENDPOINT);
         context = newContext(message, span, null);
-        adapter.mapTopic(context).onComplete(ctx.succeeding(address -> {
+        adapter.checkQosAndMapTopic(context).onComplete(ctx.succeeding(address -> {
             ctx.verify(() -> assertThat(MetricsTags.EndpointType.fromString(address.getEndpoint())).isEqualTo(MetricsTags.EndpointType.TELEMETRY));
         }));
 
         message = newMessage(MqttQoS.AT_LEAST_ONCE, TelemetryConstants.TELEMETRY_ENDPOINT_SHORT);
         context = newContext(message, span, null);
-        adapter.mapTopic(context).onComplete(ctx.succeeding(address -> {
+        adapter.checkQosAndMapTopic(context).onComplete(ctx.succeeding(address -> {
             ctx.verify(() -> assertThat(MetricsTags.EndpointType.fromString(address.getEndpoint())).isEqualTo(MetricsTags.EndpointType.TELEMETRY));
         }));
 
         message = newMessage(MqttQoS.AT_LEAST_ONCE, "unknown");
         context = newContext(message, span, null);
-        adapter.mapTopic(context).onSuccess(v -> ctx.failNow("should not have succeeded mapping topic"));
+        adapter.checkQosAndMapTopic(context).onSuccess(v -> ctx.failNow("should not have succeeded mapping topic"));
         ctx.completeNow();
 
     }

--- a/site/documentation/content/admin-guide/mqtt-adapter-config.md
+++ b/site/documentation/content/admin-guide/mqtt-adapter-config.md
@@ -124,6 +124,7 @@ An implementation of the mapper needs to be provided. Following data will be pro
 - HTTP headers:
   - orig_address
   - content-type
+  - tenant_id
   - all strings configured during registration
 - Body
   - The payload of the message is provided in the body of the mapping request

--- a/site/documentation/content/user-guide/mqtt-adapter.md
+++ b/site/documentation/content/user-guide/mqtt-adapter.md
@@ -775,9 +775,9 @@ functionality are therefore subject to change without prior notice.
 {{% /notice %}}
 
 This feature is useful in scenarios where devices are connected to the adapter via a gateway but the gateway is not
-able to include the device ID in the topic that the gateway publishes data to. The gateway will use the plain `telemetry`
-or `event` topics in this case. The message payload will usually contain the identifier of the device that the data
-originates from.
+able to include the device ID in the topic that the gateway publishes data to. The gateway will use the plain `telemetry`,
+`event` or `command` topics in this case. The message payload will usually contain the identifier of the device that the
+data originates from.
 
 The same functionality can also be used to transform the payload of messages uploaded by a device. This can be used for
 example to transform binary encoded data into a JSON document which can be consumed more easily by downstream consumers.


### PR DESCRIPTION
Not allowing the whole target address to be set in the MQTT adapter Message Mapping result, thereby making it clear that the tenant identifier can't be overridden.

I've also added a `tenant_id` HTTP header to the request sent by the `HttpBasedMessageMapping`.

Also copying of payload data for the Message Mapping is removed - this shouldn't be necessary anymore (issues were probably due to the message payload Buffer's ByteBuf getting duplicated to create a new MqttPublishMessage).

Handling of a mapped payload for a command response message has been fixed.

This is for #3083.