### PR TITLE
[#2933] Move AMQP specific error conversion methods

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/StatusCodeMapper.java
+++ b/client/src/main/java/org/eclipse/hono/client/StatusCodeMapper.java
@@ -17,10 +17,6 @@ import java.net.HttpURLConnection;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.apache.qpid.proton.amqp.Symbol;
-import org.apache.qpid.proton.amqp.transport.AmqpError;
-import org.apache.qpid.proton.amqp.transport.ErrorCondition;
-import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.eclipse.hono.util.RegistrationResult;
 import org.eclipse.hono.util.RequestResponseResult;
@@ -133,80 +129,6 @@ public abstract class StatusCodeMapper {
             return new ServerErrorException(tenant, statusCode, detailMessage, cause);
         } else {
             throw new IllegalArgumentException(String.format("illegal error code [%d], must be >= 400 and < 600", statusCode));
-        }
-    }
-
-    /**
-     * Creates an exception for an AMQP error condition that occurred when attaching a link.
-     *
-     * @param error The error condition.
-     * @return The exception.
-     * @throws NullPointerException if error is {@code null}.
-     */
-    public static final ServiceInvocationException fromAttachError(final ErrorCondition error) {
-
-        Objects.requireNonNull(error);
-        return fromAttachError(error.getCondition(), error.getDescription());
-    }
-
-    /**
-     * Creates an exception for an AMQP error condition that occurred when attaching a link.
-     *
-     * @param condition The error condition.
-     * @param description The error description or {@code null} if not available.
-     * @return The exception.
-     * @throws NullPointerException if error is {@code null}.
-     */
-    public static final ServiceInvocationException fromAttachError(final Symbol condition, final String description) {
-
-        Objects.requireNonNull(condition);
-
-        if (AmqpError.RESOURCE_LIMIT_EXCEEDED.equals(condition)) {
-            return new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN, description);
-        } else if (AmqpError.UNAUTHORIZED_ACCESS.equals(condition)) {
-            return new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN, description);
-        } else if (AmqpError.INTERNAL_ERROR.equals(condition)) {
-            return new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, description);
-        } else if (Constants.AMQP_BAD_REQUEST.equals(condition)) {
-            return new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, description);
-        } else {
-            return new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND, description);
-        }
-    }
-
-    /**
-     * Creates an exception for an AMQP error condition that occurred during a message transfer.
-     *
-     * @param error The error condition.
-     * @return The exception.
-     * @throws NullPointerException if error is {@code null}.
-     */
-    public static final ServiceInvocationException fromTransferError(final ErrorCondition error) {
-
-        Objects.requireNonNull(error);
-        return fromTransferError(error.getCondition(), error.getDescription());
-    }
-
-    /**
-     * Creates an exception for an AMQP error condition that occurred during a message transfer.
-     *
-     * @param condition The error condition.
-     * @param description The error description or {@code null} if not available.
-     * @return The exception.
-     * @throws NullPointerException if error is {@code null}.
-     */
-    public static final ServiceInvocationException fromTransferError(final Symbol condition, final String description) {
-
-        Objects.requireNonNull(condition);
-
-        if (AmqpError.RESOURCE_LIMIT_EXCEEDED.equals(condition)) {
-            return new ResourceLimitExceededException(description);
-        } else if (AmqpError.UNAUTHORIZED_ACCESS.equals(condition)) {
-            return new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN, description);
-        } else if (AmqpError.INTERNAL_ERROR.equals(condition)) {
-            return new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, description);
-        } else {
-            return new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, description);
         }
     }
 

--- a/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/GenericSenderLink.java
+++ b/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/GenericSenderLink.java
@@ -39,7 +39,7 @@ import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.SendMessageTimeoutException;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
-import org.eclipse.hono.client.StatusCodeMapper;
+import org.eclipse.hono.client.amqp.connection.ErrorConverter;
 import org.eclipse.hono.client.amqp.connection.HonoConnection;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.tracing.TracingHelper;
@@ -548,7 +548,7 @@ public class GenericSenderLink extends AbstractHonoClient {
         if (Rejected.class.isInstance(remoteState)) {
             final Rejected rejected = (Rejected) remoteState;
             e = Optional.ofNullable(rejected.getError())
-                    .map(StatusCodeMapper::fromTransferError)
+                    .map(ErrorConverter::fromTransferError)
                     .orElseGet(() -> new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST));
         } else if (Released.class.isInstance(remoteState)) {
             e = new MessageNotProcessedException();

--- a/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/RequestResponseClient.java
+++ b/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/RequestResponseClient.java
@@ -34,7 +34,7 @@ import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServerErrorException;
-import org.eclipse.hono.client.StatusCodeMapper;
+import org.eclipse.hono.client.amqp.connection.ErrorConverter;
 import org.eclipse.hono.client.amqp.connection.HonoConnection;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.HonoProtonHelper;
@@ -651,7 +651,7 @@ public class RequestResponseClient<R extends RequestResponseResult<?>> extends A
                         if (rejected.getError() != null) {
                             LOG.debug("service did not accept request [target address: {}, subject: {}, correlation ID: {}]: {}",
                                     requestTargetAddress, request.getSubject(), correlationId, rejected.getError());
-                            failedResult.fail(StatusCodeMapper.fromTransferError(rejected.getError()));
+                            failedResult.fail(ErrorConverter.fromTransferError(rejected.getError()));
                             cancelRequest(correlationId, failedResult.future());
                         } else {
                             LOG.debug("service did not accept request [target address: {}, subject: {}, correlation ID: {}]",

--- a/clients/amqp-connection/src/main/java/org/eclipse/hono/client/amqp/connection/ErrorConverter.java
+++ b/clients/amqp-connection/src/main/java/org/eclipse/hono/client/amqp/connection/ErrorConverter.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.client.amqp.connection;
+
+import java.net.HttpURLConnection;
+import java.util.Objects;
+
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.transport.AmqpError;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.ResourceLimitExceededException;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.util.Constants;
+
+/**
+ * Utility methods for converting AMQP 1.0 error conditions to
+ * {@link org.eclipse.hono.client.ServiceInvocationException}s.
+ *
+ */
+public final class ErrorConverter {
+
+    private ErrorConverter() {
+        // prevent instantiation
+    }
+
+    /**
+     * Creates an exception for an AMQP error condition that occurred during a message transfer.
+     *
+     * @param error The error condition.
+     * @return The exception.
+     * @throws NullPointerException if error is {@code null}.
+     */
+    public static ServiceInvocationException fromTransferError(final ErrorCondition error) {
+
+        Objects.requireNonNull(error);
+        return fromTransferError(error.getCondition(), error.getDescription());
+    }
+
+    /**
+     * Creates an exception for an AMQP error condition that occurred during a message transfer.
+     *
+     * @param condition The error condition.
+     * @param description The error description or {@code null} if not available.
+     * @return The exception.
+     * @throws NullPointerException if error is {@code null}.
+     */
+    public static ServiceInvocationException fromTransferError(final Symbol condition, final String description) {
+
+        Objects.requireNonNull(condition);
+
+        if (AmqpError.RESOURCE_LIMIT_EXCEEDED.equals(condition)) {
+            return new ResourceLimitExceededException(description);
+        } else if (AmqpError.UNAUTHORIZED_ACCESS.equals(condition)) {
+            return new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN, description);
+        } else if (AmqpError.INTERNAL_ERROR.equals(condition)) {
+            return new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, description);
+        } else {
+            return new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, description);
+        }
+    }
+
+    /**
+     * Creates an exception for an AMQP error condition that occurred when attaching a link.
+     *
+     * @param error The error condition.
+     * @return The exception.
+     * @throws NullPointerException if error is {@code null}.
+     */
+    public static ServiceInvocationException fromAttachError(final ErrorCondition error) {
+
+        Objects.requireNonNull(error);
+        return fromAttachError(error.getCondition(), error.getDescription());
+    }
+
+    /**
+     * Creates an exception for an AMQP error condition that occurred when attaching a link.
+     *
+     * @param condition The error condition.
+     * @param description The error description or {@code null} if not available.
+     * @return The exception.
+     * @throws NullPointerException if error is {@code null}.
+     */
+    public static ServiceInvocationException fromAttachError(final Symbol condition, final String description) {
+
+        Objects.requireNonNull(condition);
+
+        if (AmqpError.RESOURCE_LIMIT_EXCEEDED.equals(condition)) {
+            return new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN, description);
+        } else if (AmqpError.UNAUTHORIZED_ACCESS.equals(condition)) {
+            return new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN, description);
+        } else if (AmqpError.INTERNAL_ERROR.equals(condition)) {
+            return new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, description);
+        } else if (Constants.AMQP_BAD_REQUEST.equals(condition)) {
+            return new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, description);
+        } else {
+            return new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND, description);
+        }
+    }
+}

--- a/clients/amqp-connection/src/main/java/org/eclipse/hono/client/amqp/connection/impl/HonoConnectionImpl.java
+++ b/clients/amqp-connection/src/main/java/org/eclipse/hono/client/amqp/connection/impl/HonoConnectionImpl.java
@@ -37,8 +37,8 @@ import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
-import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.client.amqp.connection.DisconnectListener;
+import org.eclipse.hono.client.amqp.connection.ErrorConverter;
 import org.eclipse.hono.client.amqp.connection.HonoConnection;
 import org.eclipse.hono.client.amqp.connection.ReconnectListener;
 import org.eclipse.hono.config.ClientConfigProperties;
@@ -617,7 +617,7 @@ public class HonoConnectionImpl implements HonoConnection {
                                     "cannot open sender", senderOpen.cause()));
                         } else {
                             log.debug("opening sender [{}] failed: {} - {}", targetAddress, error.getCondition(), error.getDescription());
-                            senderPromise.tryFail(StatusCodeMapper.fromAttachError(error));
+                            senderPromise.tryFail(ErrorConverter.fromAttachError(error));
                         }
 
                     } else if (HonoProtonHelper.isLinkEstablished(sender)) {
@@ -765,7 +765,7 @@ public class HonoConnectionImpl implements HonoConnection {
                                     "cannot open receiver", recvOpen.cause()));
                         } else {
                             log.debug("opening receiver [{}] failed: {} - {}", sourceAddress, error.getCondition(), error.getDescription());
-                            receiverPromise.tryFail(StatusCodeMapper.fromAttachError(error));
+                            receiverPromise.tryFail(ErrorConverter.fromAttachError(error));
                         }
                     } else if (HonoProtonHelper.isLinkEstablished(receiver)) {
                         log.debug("receiver open [source: {}]", sourceAddress);

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpAdapterTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpAdapterTestBase.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import org.eclipse.hono.client.StatusCodeMapper;
+import org.eclipse.hono.client.amqp.connection.ErrorConverter;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.Constants;
 import org.junit.jupiter.api.AfterEach;
@@ -316,7 +316,7 @@ public abstract class AmqpAdapterTestBase {
                             hostname, IntegrationTestSupport.AMQPS_PORT);
 
                     return Optional.ofNullable(unopenedConnection.getRemoteCondition())
-                            .map(condition -> Future.<ProtonConnection>failedFuture(StatusCodeMapper.fromAttachError(condition)))
+                            .map(condition -> Future.<ProtonConnection>failedFuture(ErrorConverter.fromAttachError(condition)))
                             .orElseGet(() -> Future.failedFuture(t));
                 });
     }

--- a/tests/src/test/java/org/eclipse/hono/tests/jms/JmsBasedRequestResponseClient.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/jms/JmsBasedRequestResponseClient.java
@@ -36,6 +36,7 @@ import org.apache.qpid.proton.amqp.Symbol;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.StatusCodeMapper;
+import org.eclipse.hono.client.amqp.connection.ErrorConverter;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.Pair;
 import org.eclipse.hono.util.RequestResponseResult;
@@ -202,7 +203,7 @@ public class JmsBasedRequestResponseClient<R extends RequestResponseResult<?>> {
             if (matcher.matches()) {
                 final Symbol condition = Symbol.getSymbol(matcher.group(2));
                 final String description = matcher.group(1);
-                return StatusCodeMapper.fromTransferError(condition, description);
+                return ErrorConverter.fromTransferError(condition, description);
             }
         }
         return new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, cause);


### PR DESCRIPTION
2nd step of #2933

Moved AMQP specific error conversion methods of StatusCodeMapper to
separate class in amqp-connection module in order to remove dependencies
to Proton-J.
