### PR TITLE
Close TCP connection when disconnecting from peer

### DIFF
--- a/clients/amqp-connection/src/main/java/org/eclipse/hono/client/amqp/connection/impl/ConnectionFactoryImpl.java
+++ b/clients/amqp-connection/src/main/java/org/eclipse/hono/client/amqp/connection/impl/ConnectionFactoryImpl.java
@@ -32,6 +32,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.net.JdkSSLEngineOptions;
 import io.vertx.core.net.KeyCertOptions;
 import io.vertx.core.net.OpenSSLEngineOptions;
 import io.vertx.core.net.TrustOptions;
@@ -388,11 +389,12 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
                     isOpenSslAvailable, supportsKeyManagerFactory);
 
             if (useOpenSsl) {
-                logger.debug("using OpenSSL [version: {}] instead of JDK's default SSL engine",
+                logger.debug("using OpenSSL [version: {}] instead of JVM's default SSL engine",
                         OpenSsl.versionString());
-                clientOptions.setSslEngineOptions(new OpenSSLEngineOptions());
+                clientOptions.setOpenSslEngineOptions(new OpenSSLEngineOptions());
             } else {
-                logger.debug("using JDK's default SSL engine");
+                logger.debug("using JVM's default SSL engine");
+                clientOptions.setJdkSslEngineOptions(new JdkSSLEngineOptions());
             }
 
             if (config.isHostnameVerificationRequired()) {

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -17,6 +17,8 @@ description = "Information about changes in recent Hono releases. Includes new f
   guide. This has been fixed.
 * The connection pool configuration for the HotRod client in the Quarkus variant of the Command Router component
   didn't support using property names in camel-case. This has been fixed.
+* *HonoConnectionImpl* instances failed to release/close the underlying TCP/TLS connection when its *disconnect* or
+  *shutdown* method had been invoked. This has been fixed.
 
 ### API Changes
 


### PR DESCRIPTION
Fixes #3143

The ConnectionFactoryImpl class also has a method for closing a ProtonConnection to a peer. However, it only does so when an attempt to establish a connection has timed out but the connection got established anyway, I do not see much value in tracking the closing of such a connection in the same way as we do when closing a connection that has actually been in use, as is the case with the HonoConnectionImpl. Refactoring the code would also require quite some effort which FMPOV is not worth it.