### PR TITLE
[#3148] Remove Proton-J dependency from RequestResponseResult hierarchy

### DIFF
--- a/clients/amqp-common/src/test/java/org/eclipse/hono/client/amqp/AbstractRequestResponseServiceClientTest.java
+++ b/clients/amqp-common/src/test/java/org/eclipse/hono/client/amqp/AbstractRequestResponseServiceClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.eclipse.hono.client.amqp.config.RequestResponseClientConfigProperties;
@@ -81,7 +82,13 @@ class AbstractRequestResponseServiceClientTest {
                     final Buffer payload,
                     final CacheDirective cacheDirective,
                     final ApplicationProperties applicationProperties) {
-                return SimpleRequestResponseResult.from(status, payload, cacheDirective, applicationProperties);
+                return SimpleRequestResponseResult.from(
+                        status,
+                        payload,
+                        cacheDirective,
+                        Optional.ofNullable(applicationProperties)
+                            .map(ApplicationProperties::getValue)
+                            .orElse(null));
             }
 
             @Override

--- a/clients/amqp-common/src/test/java/org/eclipse/hono/client/amqp/SimpleRequestResponseResult.java
+++ b/clients/amqp-common/src/test/java/org/eclipse/hono/client/amqp/SimpleRequestResponseResult.java
@@ -43,7 +43,7 @@ public final class SimpleRequestResponseResult extends RequestResponseResult<Buf
      * Creates a new instance for a status code and payload.
      *
      * @param status The code indicating the outcome of processing the request.
-     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     * @param payload The payload contained in the response message or {@code null}, if the response does not
      *                contain any payload data.
      * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
      *                       or {@code null} if no restrictions apply.

--- a/clients/amqp-common/src/test/java/org/eclipse/hono/client/amqp/SimpleRequestResponseResult.java
+++ b/clients/amqp-common/src/test/java/org/eclipse/hono/client/amqp/SimpleRequestResponseResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,6 +12,9 @@
  *******************************************************************************/
 
 package org.eclipse.hono.client.amqp;
+
+import java.util.Map;
+import java.util.Optional;
 
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.apache.qpid.proton.message.Message;
@@ -32,27 +35,28 @@ public final class SimpleRequestResponseResult extends RequestResponseResult<Buf
             final int status,
             final Buffer payload,
             final CacheDirective directive,
-            final ApplicationProperties applicationProperties) {
-        super(status, payload, directive, applicationProperties);
+            final Map<String, Object> responseProperties) {
+        super(status, payload, directive, responseProperties);
     }
 
     /**
      * Creates a new instance for a status code and payload.
      *
-     * @param status The status code.
-     * @param payload The payload.
-     * @param cacheDirective Restrictions regarding the caching of the payload by
-     *                       the receiver of the result (may be {@code null}).
-     * @param applicationProperties Arbitrary properties conveyed in the response message's
-     *                              <em>application-properties</em>.
+     * @param status The code indicating the outcome of processing the request.
+     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     *                contain any payload data.
+     * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
+     *                       or {@code null} if no restrictions apply.
+     * @param responseProperties Arbitrary additional properties conveyed in the response message or {@code null}, if
+     *                           the response does not contain additional properties.
      * @return The instance.
      */
     public static SimpleRequestResponseResult from(
             final int status,
             final Buffer payload,
             final CacheDirective cacheDirective,
-            final ApplicationProperties applicationProperties) {
-        return new SimpleRequestResponseResult(status, payload, cacheDirective, applicationProperties);
+            final Map<String, Object> responseProperties) {
+        return new SimpleRequestResponseResult(status, payload, cacheDirective, responseProperties);
     }
 
     /**
@@ -66,7 +70,9 @@ public final class SimpleRequestResponseResult extends RequestResponseResult<Buf
                 MessageHelper.getStatus(message),
                 MessageHelper.getPayload(message),
                 CacheDirective.from(MessageHelper.getCacheDirective(message)),
-                message.getApplicationProperties());
+                Optional.ofNullable(message.getApplicationProperties())
+                    .map(ApplicationProperties::getValue)
+                    .orElse(null));
     }
 
 }

--- a/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommandRouterClient.java
+++ b/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommandRouterClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -163,17 +163,20 @@ public class ProtonBasedCommandRouterClient extends AbstractRequestResponseServi
             final CacheDirective cacheDirective,
             final ApplicationProperties applicationProperties) {
 
+        final var props = Optional.ofNullable(applicationProperties)
+                .map(ApplicationProperties::getValue)
+                .orElse(null);
+
         if (payload == null) {
-            return new RequestResponseResult<>(status, null, null, applicationProperties);
+            return new RequestResponseResult<>(status, null, null, props);
         } else {
             try {
                 // ignoring given cacheDirective param here - command router results shall not be cached
                 return new RequestResponseResult<>(status, new JsonObject(payload),
-                        CacheDirective.noCacheDirective(), applicationProperties);
+                        CacheDirective.noCacheDirective(), props);
             } catch (final DecodeException e) {
                 LOG.warn("received malformed payload from Command Router service", e);
-                return new RequestResponseResult<>(HttpURLConnection.HTTP_INTERNAL_ERROR, null, null,
-                        applicationProperties);
+                return new RequestResponseResult<>(HttpURLConnection.HTTP_INTERNAL_ERROR, null, null, props);
             }
         }
     }

--- a/clients/registry-amqp/src/main/java/org/eclipse/hono/client/registry/amqp/ProtonBasedCredentialsClient.java
+++ b/clients/registry-amqp/src/main/java/org/eclipse/hono/client/registry/amqp/ProtonBasedCredentialsClient.java
@@ -16,6 +16,7 @@ package org.eclipse.hono.client.registry.amqp;
 
 import java.net.HttpURLConnection;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.eclipse.hono.client.ClientErrorException;
@@ -135,19 +136,23 @@ public class ProtonBasedCredentialsClient extends AbstractRequestResponseService
             final CacheDirective cacheDirective,
             final ApplicationProperties applicationProperties) {
 
+        final var props = Optional.ofNullable(applicationProperties)
+                .map(ApplicationProperties::getValue)
+                .orElse(null);
+
         if (isSuccessResponse(status, contentType, payload)) {
             try {
                 return CredentialsResult.from(
                         status,
                         Json.decodeValue(payload, CredentialsObject.class),
                         cacheDirective,
-                        applicationProperties);
+                        props);
             } catch (final DecodeException e) {
                 LOG.warn("received malformed payload from Credentials service", e);
-                return CredentialsResult.from(HttpURLConnection.HTTP_INTERNAL_ERROR, null, null, applicationProperties);
+                return CredentialsResult.from(HttpURLConnection.HTTP_INTERNAL_ERROR, null, null, props);
             }
         } else {
-            return CredentialsResult.from(status, null, null, applicationProperties);
+            return CredentialsResult.from(status, null, null, props);
         }
     }
 

--- a/clients/registry-amqp/src/main/java/org/eclipse/hono/client/registry/amqp/ProtonBasedDeviceRegistrationClient.java
+++ b/clients/registry-amqp/src/main/java/org/eclipse/hono/client/registry/amqp/ProtonBasedDeviceRegistrationClient.java
@@ -17,6 +17,7 @@ package org.eclipse.hono.client.registry.amqp;
 import java.net.HttpURLConnection;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.eclipse.hono.client.ClientErrorException;
@@ -135,15 +136,19 @@ public class ProtonBasedDeviceRegistrationClient extends AbstractRequestResponse
             final CacheDirective cacheDirective,
             final ApplicationProperties applicationProperties) {
 
+        final var props = Optional.ofNullable(applicationProperties)
+                .map(ApplicationProperties::getValue)
+                .orElse(null);
+
         if (isSuccessResponse(status, contentType, payload)) {
             try {
-                return RegistrationResult.from(status, new JsonObject(payload), cacheDirective, applicationProperties);
+                return RegistrationResult.from(status, new JsonObject(payload), cacheDirective, props);
             } catch (final DecodeException e) {
                 LOG.warn("received malformed payload from Device Registration service", e);
-                return RegistrationResult.from(HttpURLConnection.HTTP_INTERNAL_ERROR, null, null, applicationProperties);
+                return RegistrationResult.from(HttpURLConnection.HTTP_INTERNAL_ERROR, null, null, props);
             }
         } else {
-            return RegistrationResult.from(status, null, null, applicationProperties);
+            return RegistrationResult.from(status, null, null, props);
         }
     }
 

--- a/clients/registry-amqp/src/main/java/org/eclipse/hono/client/registry/amqp/ProtonBasedTenantClient.java
+++ b/clients/registry-amqp/src/main/java/org/eclipse/hono/client/registry/amqp/ProtonBasedTenantClient.java
@@ -134,19 +134,23 @@ public final class ProtonBasedTenantClient extends AbstractRequestResponseServic
             final CacheDirective cacheDirective,
             final ApplicationProperties applicationProperties) {
 
+        final var props = Optional.ofNullable(applicationProperties)
+                .map(ApplicationProperties::getValue)
+                .orElse(null);
+
         if (isSuccessResponse(status, contentType, payload)) {
             try {
                 return TenantResult.from(
                         status,
                         Json.decodeValue(payload, TenantObject.class),
                         cacheDirective,
-                        applicationProperties);
+                        props);
             } catch (final DecodeException e) {
                 LOG.warn("received malformed payload from Tenant service", e);
-                return TenantResult.from(HttpURLConnection.HTTP_INTERNAL_ERROR, null, null, applicationProperties);
+                return TenantResult.from(HttpURLConnection.HTTP_INTERNAL_ERROR, null, null, props);
             }
         } else {
-            return TenantResult.from(status, null, null, applicationProperties);
+            return TenantResult.from(status, null, null, props);
         }
     }
 

--- a/core/src/main/java/org/eclipse/hono/util/CredentialsResult.java
+++ b/core/src/main/java/org/eclipse/hono/util/CredentialsResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.util;
 
-import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import java.util.Map;
 
 /**
  * A container for the result returned by Hono's credentials API.
@@ -26,14 +26,14 @@ public final class CredentialsResult<T> extends RequestResponseResult<T> {
             final int status,
             final T payload,
             final CacheDirective cacheDirective,
-            final ApplicationProperties applicationProperties) {
-        super(status, payload, cacheDirective, applicationProperties);
+            final Map<String, Object> responseProperties) {
+        super(status, payload, cacheDirective, responseProperties);
     }
 
     /**
      * Creates a new result for a status code.
      *
-     * @param status The status code indicating the outcome of the request.
+     * @param status The code indicating the outcome of processing the request.
      * @param <T> The type of the payload that is conveyed in the result.
      * @return The result.
      */
@@ -47,8 +47,9 @@ public final class CredentialsResult<T> extends RequestResponseResult<T> {
      * This method simply invokes {@link #from(int, Object, CacheDirective)}
      * with {@link CacheDirective#noCacheDirective()}.
      *
-     * @param status The status code indicating the outcome of the request.
-     * @param payload The payload to convey to the sender of the request.
+     * @param status The code indicating the outcome of processing the request.
+     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     *                contain any payload data.
      * @param <T> The type of the payload that is conveyed in the result.
      * @return The result.
      */
@@ -59,10 +60,11 @@ public final class CredentialsResult<T> extends RequestResponseResult<T> {
     /**
      * Creates a new result for a status code and payload.
      *
-     * @param status The status code indicating the outcome of the request.
-     * @param payload The payload to convey to the sender of the request.
-     * @param cacheDirective Restrictions regarding the caching of the payload by
-     *                       the receiver of the result (may be {@code null}).
+     * @param status The code indicating the outcome of processing the request.
+     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     *                contain any payload data.
+     * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
+     *                       or {@code null} if no restrictions apply.
      * @param <T> The type of the payload that is conveyed in the result.
      * @return The result.
      */
@@ -73,12 +75,13 @@ public final class CredentialsResult<T> extends RequestResponseResult<T> {
     /**
      * Creates a new result for a status code and payload.
      *
-     * @param status The status code indicating the outcome of the request.
-     * @param payload The payload to convey to the sender of the request.
-     * @param cacheDirective Restrictions regarding the caching of the payload by
-     *                       the receiver of the result (may be {@code null}).
-     * @param applicationProperties Arbitrary properties conveyed in the response message's
-     *                              <em>application-properties</em>.
+     * @param status The code indicating the outcome of processing the request.
+     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     *                contain any payload data.
+     * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
+     *                       or {@code null} if no restrictions apply.
+     * @param responseProperties Arbitrary additional properties conveyed in the response message or {@code null}, if
+     *                           the response does not contain additional properties.
      * @param <T> The type of the payload that is conveyed in the result.
      * @return The result.
      */
@@ -86,7 +89,7 @@ public final class CredentialsResult<T> extends RequestResponseResult<T> {
             final int status,
             final T payload,
             final CacheDirective cacheDirective,
-            final ApplicationProperties applicationProperties) {
-        return new CredentialsResult<>(status, payload, cacheDirective, applicationProperties);
+            final Map<String, Object> responseProperties) {
+        return new CredentialsResult<>(status, payload, cacheDirective, responseProperties);
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/CredentialsResult.java
+++ b/core/src/main/java/org/eclipse/hono/util/CredentialsResult.java
@@ -48,7 +48,7 @@ public final class CredentialsResult<T> extends RequestResponseResult<T> {
      * with {@link CacheDirective#noCacheDirective()}.
      *
      * @param status The code indicating the outcome of processing the request.
-     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     * @param payload The payload contained in the response message or {@code null}, if the response does not
      *                contain any payload data.
      * @param <T> The type of the payload that is conveyed in the result.
      * @return The result.
@@ -61,7 +61,7 @@ public final class CredentialsResult<T> extends RequestResponseResult<T> {
      * Creates a new result for a status code and payload.
      *
      * @param status The code indicating the outcome of processing the request.
-     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     * @param payload The payload contained in the response message or {@code null}, if the response does not
      *                contain any payload data.
      * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
      *                       or {@code null} if no restrictions apply.
@@ -76,7 +76,7 @@ public final class CredentialsResult<T> extends RequestResponseResult<T> {
      * Creates a new result for a status code and payload.
      *
      * @param status The code indicating the outcome of processing the request.
-     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     * @param payload The payload contained in the response message or {@code null}, if the response does not
      *                contain any payload data.
      * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
      *                       or {@code null} if no restrictions apply.

--- a/core/src/main/java/org/eclipse/hono/util/RegistrationResult.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistrationResult.java
@@ -45,7 +45,7 @@ public final class RegistrationResult extends RequestResponseResult<JsonObject> 
      * Creates a new result for a status code and a payload.
      *
      * @param status The code indicating the outcome of processing the request.
-     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     * @param payload The payload contained in the response message or {@code null}, if the response does not
      *                contain any payload data.
      * @return The result.
      */
@@ -57,7 +57,7 @@ public final class RegistrationResult extends RequestResponseResult<JsonObject> 
      * Creates a new result for a status code and a payload.
      *
      * @param status The code indicating the outcome of processing the request.
-     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     * @param payload The payload contained in the response message or {@code null}, if the response does not
      *                contain any payload data.
      * @return The result.
      * @throws io.vertx.core.json.DecodeException if the given payload is not valid JSON.
@@ -74,7 +74,7 @@ public final class RegistrationResult extends RequestResponseResult<JsonObject> 
      * Creates a new result for a status code and a payload.
      *
      * @param status The code indicating the outcome of processing the request.
-     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     * @param payload The payload contained in the response message or {@code null}, if the response does not
      *                contain any payload data.
      * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
      *                       or {@code null} if no restrictions apply.
@@ -88,7 +88,7 @@ public final class RegistrationResult extends RequestResponseResult<JsonObject> 
      * Creates a new result for a status code and a payload.
      *
      * @param status The code indicating the outcome of processing the request.
-     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     * @param payload The payload contained in the response message or {@code null}, if the response does not
      *                contain any payload data.
      * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
      *                       or {@code null} if no restrictions apply.

--- a/core/src/main/java/org/eclipse/hono/util/RegistrationResult.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistrationResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,9 +13,8 @@
 
 package org.eclipse.hono.util;
 
-import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import java.util.Map;
 
-import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -28,14 +27,14 @@ public final class RegistrationResult extends RequestResponseResult<JsonObject> 
             final int status,
             final JsonObject payload,
             final CacheDirective cacheDirective,
-            final ApplicationProperties applicationProperties) {
-        super(status, payload, cacheDirective, applicationProperties);
+            final Map<String, Object> responseProperties) {
+        super(status, payload, cacheDirective, responseProperties);
     }
 
     /**
      * Creates a new result for a status code.
      *
-     * @param status The status code.
+     * @param status The code indicating the outcome of processing the request.
      * @return The result.
      */
     public static RegistrationResult from(final int status) {
@@ -45,8 +44,9 @@ public final class RegistrationResult extends RequestResponseResult<JsonObject> 
     /**
      * Creates a new result for a status code and a payload.
      *
-     * @param status The status code.
-     * @param payload The payload to include in the result.
+     * @param status The code indicating the outcome of processing the request.
+     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     *                contain any payload data.
      * @return The result.
      */
     public static RegistrationResult from(final int status, final JsonObject payload) {
@@ -56,11 +56,11 @@ public final class RegistrationResult extends RequestResponseResult<JsonObject> 
     /**
      * Creates a new result for a status code and a payload.
      *
-     * @param status The status code.
-     * @param payload The string representation of the JSON payload
-     *                to include in the result (may be {@code null}).
+     * @param status The code indicating the outcome of processing the request.
+     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     *                contain any payload data.
      * @return The result.
-     * @throws DecodeException if the given payload is not valid JSON.
+     * @throws io.vertx.core.json.DecodeException if the given payload is not valid JSON.
      */
     public static RegistrationResult from(final int status, final String payload) {
         if (payload != null) {
@@ -73,9 +73,11 @@ public final class RegistrationResult extends RequestResponseResult<JsonObject> 
     /**
      * Creates a new result for a status code and a payload.
      *
-     * @param status The status code.
-     * @param payload The payload to include in the result.
-     * @param cacheDirective Restrictions regarding the caching of the payload.
+     * @param status The code indicating the outcome of processing the request.
+     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     *                contain any payload data.
+     * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
+     *                       or {@code null} if no restrictions apply.
      * @return The result.
      */
     public static RegistrationResult from(final int status, final JsonObject payload, final CacheDirective cacheDirective) {
@@ -85,18 +87,20 @@ public final class RegistrationResult extends RequestResponseResult<JsonObject> 
     /**
      * Creates a new result for a status code and a payload.
      *
-     * @param status The status code.
-     * @param payload The payload to include in the result.
-     * @param cacheDirective Restrictions regarding the caching of the payload.
-     * @param applicationProperties Arbitrary properties conveyed in the response message's
-     *                              <em>application-properties</em>.
+     * @param status The code indicating the outcome of processing the request.
+     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     *                contain any payload data.
+     * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
+     *                       or {@code null} if no restrictions apply.
+     * @param responseProperties Arbitrary additional properties conveyed in the response message or {@code null}, if
+     *                           the response does not contain additional properties.
      * @return The result.
      */
     public static RegistrationResult from(
             final int status,
             final JsonObject payload,
             final CacheDirective cacheDirective,
-            final ApplicationProperties applicationProperties) {
-        return new RegistrationResult(status, payload, cacheDirective, applicationProperties);
+            final Map<String, Object> responseProperties) {
+        return new RegistrationResult(status, payload, cacheDirective, responseProperties);
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/RequestResponseResult.java
+++ b/core/src/main/java/org/eclipse/hono/util/RequestResponseResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,10 +13,8 @@
 package org.eclipse.hono.util;
 
 import java.net.HttpURLConnection;
-import java.util.Collections;
 import java.util.Map;
-
-import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import java.util.Optional;
 
 /**
  * A container for the result returned by a Hono API that implements the request response pattern.
@@ -28,32 +26,32 @@ public class RequestResponseResult<T> {
     private final int status;
     private final T payload;
     private final CacheDirective cacheDirective;
-    private final Map<String, Object> applicationProperties;
+    private final Map<String, Object> responseProperties;
 
     /**
      * Creates a new result for a status code and payload.
      *
      * @param status The code indicating the outcome of processing the request.
-     * @param payload The payload to convey to the sender of the request (may be {@code null}).
-     * @param directive Restrictions regarding the caching of the payload by
-     *                       the receiver of the result (may be {@code null}).
-     * @param applicationProperties Arbitrary properties conveyed in the response message's
-     *                              <em>application-properties</em>.
+     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     *                contain any payload data.
+     * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
+     *                       or {@code null} if no restrictions apply.
+     * @param responseProperties Arbitrary additional properties conveyed in the response message or {@code null}, if
+     *                           the response does not contain additional properties.
      */
     public RequestResponseResult(
             final int status,
             final T payload,
-            final CacheDirective directive,
-            final ApplicationProperties applicationProperties) {
+            final CacheDirective cacheDirective,
+            final Map<String, Object> responseProperties) {
 
         this.status = status;
         this.payload = payload;
-        this.cacheDirective = directive;
-        if (applicationProperties == null || applicationProperties.getValue().isEmpty()) {
-            this.applicationProperties = Collections.emptyMap();
-        } else {
-            this.applicationProperties = Collections.unmodifiableMap(applicationProperties.getValue());
-        }
+        this.cacheDirective = cacheDirective;
+        this.responseProperties = Optional.ofNullable(responseProperties)
+                .filter(props -> !props.isEmpty())
+                .map(Map::copyOf)
+                .orElse(Map.of());
     }
 
     /**
@@ -85,31 +83,12 @@ public class RequestResponseResult<T> {
     }
 
     /**
-     * Gets the value of a property conveyed in this response message's
-     * <em>application-properties</em>.
+     * Gets read-only access to the response message's additional properties.
      *
-     * @param <V> The expected value type.
-     * @param key The key of the property.
-     * @param type The expected value type.
-     * @return The value if it is of the expected type or {@code null} otherwise.
+     * @return An unmodifiable view on the (potentially empty) properties.
      */
-    @SuppressWarnings("unchecked")
-    public final <V> V getApplicationProperty(final String key, final Class<V> type) {
-        final Object value = applicationProperties.get(key);
-        if (type.isInstance(value)) {
-            return (V) value;
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * Gets read-only access to the response message's <em>application-properties</em>.
-     *
-     * @return The unmodifiable map of the application properties. Never returns {@code null}.
-     */
-    public final Map<String, Object> getApplicationProperties() {
-        return applicationProperties;
+    public final Map<String, Object> getResponseProperties() {
+        return responseProperties;
     }
 
     /**

--- a/core/src/main/java/org/eclipse/hono/util/RequestResponseResult.java
+++ b/core/src/main/java/org/eclipse/hono/util/RequestResponseResult.java
@@ -32,7 +32,7 @@ public class RequestResponseResult<T> {
      * Creates a new result for a status code and payload.
      *
      * @param status The code indicating the outcome of processing the request.
-     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     * @param payload The payload contained in the response message or {@code null}, if the response does not
      *                contain any payload data.
      * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
      *                       or {@code null} if no restrictions apply.

--- a/core/src/main/java/org/eclipse/hono/util/TenantResult.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,10 +13,9 @@
 
 package org.eclipse.hono.util;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-
-import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 
 /**
  * A container for the result returned by Hono's Tenant API.
@@ -30,14 +29,14 @@ public final class TenantResult<T> extends RequestResponseResult<T> {
             final int status,
             final T payload,
             final CacheDirective cacheDirective,
-            final ApplicationProperties applicationProperties) {
-        super(status, payload, cacheDirective, applicationProperties);
+            final Map<String, Object> responseProperties) {
+        super(status, payload, cacheDirective, responseProperties);
     }
 
     /**
      * Creates a new result for a status code.
      *
-     * @param status The status code indicating the outcome of the request.
+     * @param status The code indicating the outcome of processing the request.
      * @param <T> The type of the payload conveyed in the result.
      * @return The result.
      */
@@ -48,8 +47,9 @@ public final class TenantResult<T> extends RequestResponseResult<T> {
     /**
      * Creates a new result for a status code and payload.
      *
-     * @param status The status code indicating the outcome of the request.
-     * @param payload The payload to convey to the sender of the request.
+     * @param status The code indicating the outcome of processing the request.
+     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     *                contain any payload data.
      * @param <T> The type of the payload conveyed in the result.
      * @return The result.
      */
@@ -60,10 +60,12 @@ public final class TenantResult<T> extends RequestResponseResult<T> {
     /**
      * Creates a new result for a status code and payload.
      *
-     * @param status The status code indicating the outcome of the request.
-     * @param payload The payload to convey to the sender of the request.
+     * @param status The code indicating the outcome of processing the request.
+     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     *                contain any payload data.
+     * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
+     *                       or {@code null} if no restrictions apply.
      * @param <T> The type of the payload conveyed in the result.
-     * @param cacheDirective Restrictions regarding the caching of the payload.
      * @return The result.
      */
     public static <T> TenantResult<T> from(final int status, final T payload, final CacheDirective cacheDirective) {
@@ -73,26 +75,28 @@ public final class TenantResult<T> extends RequestResponseResult<T> {
     /**
      * Creates a new result for a status code and payload.
      *
-     * @param status The status code indicating the outcome of the request.
-     * @param payload The payload to convey to the sender of the request.
+     * @param status The code indicating the outcome of processing the request.
+     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     *                contain any payload data.
+     * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
+     *                       or {@code null} if no restrictions apply.
+     * @param responseProperties Arbitrary additional properties conveyed in the response message or {@code null}, if
+     *                           the response does not contain additional properties.
      * @param <T> The type of the payload conveyed in the result.
-     * @param cacheDirective Restrictions regarding the caching of the payload.
-     * @param applicationProperties Arbitrary properties conveyed in the response message's
-     *                              <em>application-properties</em>.
      * @return The result.
      */
     public static <T> TenantResult<T> from(
             final int status,
             final T payload,
             final CacheDirective cacheDirective,
-            final ApplicationProperties applicationProperties) {
-        return new TenantResult<>(status, payload, cacheDirective, applicationProperties);
+            final Map<String, Object> responseProperties) {
+        return new TenantResult<>(status, payload, cacheDirective, responseProperties);
     }
 
     /**
      * Map the payload type, if set.
      *
-     * @param mapper The mapper to apply, if a payload is set.
+     * @param mapper The mapping function to use for transforming the payload to the target type.
      * @param <U> The target type.
      * @return The mapped result.
      */
@@ -101,7 +105,6 @@ public final class TenantResult<T> extends RequestResponseResult<T> {
                 getStatus(),
                 Optional.ofNullable(getPayload()).map(mapper).orElse(null),
                 getCacheDirective(),
-                new ApplicationProperties(getApplicationProperties())
-        );
+                getResponseProperties());
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/TenantResult.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantResult.java
@@ -48,7 +48,7 @@ public final class TenantResult<T> extends RequestResponseResult<T> {
      * Creates a new result for a status code and payload.
      *
      * @param status The code indicating the outcome of processing the request.
-     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     * @param payload The payload contained in the response message or {@code null}, if the response does not
      *                contain any payload data.
      * @param <T> The type of the payload conveyed in the result.
      * @return The result.
@@ -61,7 +61,7 @@ public final class TenantResult<T> extends RequestResponseResult<T> {
      * Creates a new result for a status code and payload.
      *
      * @param status The code indicating the outcome of processing the request.
-     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     * @param payload The payload contained in the response message or {@code null}, if the response does not
      *                contain any payload data.
      * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
      *                       or {@code null} if no restrictions apply.
@@ -76,7 +76,7 @@ public final class TenantResult<T> extends RequestResponseResult<T> {
      * Creates a new result for a status code and payload.
      *
      * @param status The code indicating the outcome of processing the request.
-     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     * @param payload The payload contained in the response message or {@code null}, if the response does not
      *                contain any payload data.
      * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
      *                       or {@code null} if no restrictions apply.

--- a/service-base/src/main/java/org/eclipse/hono/service/commandrouter/CommandRouterResult.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/commandrouter/CommandRouterResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,7 +13,8 @@
 
 package org.eclipse.hono.service.commandrouter;
 
-import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import java.util.Map;
+
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.RequestResponseResult;
 
@@ -29,14 +30,14 @@ public final class CommandRouterResult extends RequestResponseResult<JsonObject>
             final int status,
             final JsonObject payload,
             final CacheDirective cacheDirective,
-            final ApplicationProperties applicationProperties) {
-        super(status, payload, cacheDirective, applicationProperties);
+            final Map<String, Object> responseProperties) {
+        super(status, payload, cacheDirective, responseProperties);
     }
 
     /**
      * Creates a new result for a status code.
      *
-     * @param status The status code.
+     * @param status The code indicating the outcome of processing the request.
      * @return The result.
      */
     public static CommandRouterResult from(final int status) {
@@ -46,8 +47,9 @@ public final class CommandRouterResult extends RequestResponseResult<JsonObject>
     /**
      * Creates a new result for a status code and a payload.
      *
-     * @param status The status code.
-     * @param payload The payload to include in the result.
+     * @param status The code indicating the outcome of processing the request.
+     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     *                contain any payload data.
      * @return The result.
      */
     public static CommandRouterResult from(final int status, final JsonObject payload) {
@@ -57,9 +59,9 @@ public final class CommandRouterResult extends RequestResponseResult<JsonObject>
     /**
      * Creates a new result for a status code and a payload.
      *
-     * @param status The status code.
-     * @param payload The string representation of the JSON payload
-     *                to include in the result (may be {@code null}).
+     * @param status The code indicating the outcome of processing the request.
+     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     *                contain any payload data.
      * @return The result.
      * @throws io.vertx.core.json.DecodeException if the given payload is not valid JSON.
      */
@@ -74,9 +76,11 @@ public final class CommandRouterResult extends RequestResponseResult<JsonObject>
     /**
      * Creates a new result for a status code and a payload.
      *
-     * @param status The status code.
-     * @param payload The payload to include in the result.
-     * @param cacheDirective Restrictions regarding the caching of the payload.
+     * @param status The code indicating the outcome of processing the request.
+     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     *                contain any payload data.
+     * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
+     *                       or {@code null} if no restrictions apply.
      * @return The result.
      */
     public static CommandRouterResult from(final int status, final JsonObject payload, final CacheDirective cacheDirective) {
@@ -86,18 +90,20 @@ public final class CommandRouterResult extends RequestResponseResult<JsonObject>
     /**
      * Creates a new result for a status code and a payload.
      *
-     * @param status The status code.
-     * @param payload The payload to include in the result.
-     * @param cacheDirective Restrictions regarding the caching of the payload.
-     * @param applicationProperties Arbitrary properties conveyed in the response message's
-     *                              <em>application-properties</em>.
+     * @param status The code indicating the outcome of processing the request.
+     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     *                contain any payload data.
+     * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
+     *                       or {@code null} if no restrictions apply.
+     * @param responseProperties Arbitrary additional properties conveyed in the response message or {@code null}, if
+     *                           the response does not contain additional properties.
      * @return The result.
      */
     public static CommandRouterResult from(
             final int status,
             final JsonObject payload,
             final CacheDirective cacheDirective,
-            final ApplicationProperties applicationProperties) {
-        return new CommandRouterResult(status, payload, cacheDirective, applicationProperties);
+            final Map<String, Object> responseProperties) {
+        return new CommandRouterResult(status, payload, cacheDirective, responseProperties);
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/commandrouter/CommandRouterResult.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/commandrouter/CommandRouterResult.java
@@ -48,7 +48,7 @@ public final class CommandRouterResult extends RequestResponseResult<JsonObject>
      * Creates a new result for a status code and a payload.
      *
      * @param status The code indicating the outcome of processing the request.
-     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     * @param payload The payload contained in the response message or {@code null}, if the response does not
      *                contain any payload data.
      * @return The result.
      */
@@ -60,7 +60,7 @@ public final class CommandRouterResult extends RequestResponseResult<JsonObject>
      * Creates a new result for a status code and a payload.
      *
      * @param status The code indicating the outcome of processing the request.
-     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     * @param payload The payload contained in the response message or {@code null}, if the response does not
      *                contain any payload data.
      * @return The result.
      * @throws io.vertx.core.json.DecodeException if the given payload is not valid JSON.
@@ -77,7 +77,7 @@ public final class CommandRouterResult extends RequestResponseResult<JsonObject>
      * Creates a new result for a status code and a payload.
      *
      * @param status The code indicating the outcome of processing the request.
-     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     * @param payload The payload contained in the response message or {@code null}, if the response does not
      *                contain any payload data.
      * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
      *                       or {@code null} if no restrictions apply.
@@ -91,7 +91,7 @@ public final class CommandRouterResult extends RequestResponseResult<JsonObject>
      * Creates a new result for a status code and a payload.
      *
      * @param status The code indicating the outcome of processing the request.
-     * @param payload The payload to contained in the response message or {@code null}, if the response does not
+     * @param payload The payload contained in the response message or {@code null}, if the response does not
      *                contain any payload data.
      * @param cacheDirective Restrictions regarding the caching of the payload by the receiver of the result
      *                       or {@code null} if no restrictions apply.

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -53,6 +53,8 @@ description = "Information about changes in recent Hono releases. Includes new f
 * Moved `org.eclipse.hono.util.BaseMessageFilter` to service-base module.
 * Moved `org.eclipse.hono.util.AmqpErrorException` to amqp-connection client module.
 * Moved `org.eclipse.hono.util.TimeUntilDisconnectNotification` to application client module.
+* The `org.eclipse.hono.util.RequestResponseResult` class hierarchy's dependency on the Proton-J `ApplicationProperties` class
+  has been removed. Instead, the constructors now accept a standard Map containing the properties.
 
 ## 1.12.1
 


### PR DESCRIPTION
This is a first step towards #3148. I will create several additional PRs ...

The RequestResponseResult supports creating instances from a Proton-J
Message's application properties. The dependency on the
ApplicationProperties class has been removed. Instead, the constructors
now accept a Map containing the properties.
