### PR TITLE
[#3157] Fix setting of common metrics tags in Quarkus based hono-auth and device registry (1.12.x)

### DIFF
--- a/adapters/amqp-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/amqp/quarkus/MetricsFactory.java
+++ b/adapters/amqp-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/amqp/quarkus/MetricsFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -43,6 +43,7 @@ public class MetricsFactory {
             final Vertx vertx,
             final MeterRegistry registry,
             final AmqpAdapterProperties adapterProperties) {
+        // define tags before the first metric gets created in the MicrometerBasedAmqpAdapterMetrics constructor
         registry.config().commonTags(MetricsTags.forProtocolAdapter(Constants.PROTOCOL_ADAPTER_TYPE_AMQP));
         final var metrics = new MicrometerBasedAmqpAdapterMetrics(registry, vertx);
         metrics.setProtocolAdapterProperties(adapterProperties);

--- a/adapters/coap-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/coap/quarkus/MetricsFactory.java
+++ b/adapters/coap-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/coap/quarkus/MetricsFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -43,6 +43,7 @@ public class MetricsFactory {
             final Vertx vertx,
             final MeterRegistry registry,
             final CoapAdapterProperties adapterProperties) {
+        // define tags before the first metric gets created in the MicrometerBasedCoapAdapterMetrics constructor
         registry.config().commonTags(MetricsTags.forProtocolAdapter(Constants.PROTOCOL_ADAPTER_TYPE_COAP));
         final var metrics = new MicrometerBasedCoapAdapterMetrics(registry, vertx);
         metrics.setProtocolAdapterProperties(adapterProperties);

--- a/adapters/http-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/http/quarkus/MetricsFactory.java
+++ b/adapters/http-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/http/quarkus/MetricsFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -43,6 +43,7 @@ public class MetricsFactory {
             final Vertx vertx,
             final MeterRegistry registry,
             final HttpProtocolAdapterProperties adapterProperties) {
+        // define tags before the first metric gets created in the MicrometerBasedHttpAdapterMetrics constructor
         registry.config().commonTags(MetricsTags.forProtocolAdapter(Constants.PROTOCOL_ADAPTER_TYPE_HTTP));
         final var metrics = new MicrometerBasedHttpAdapterMetrics(registry, vertx);
         metrics.setProtocolAdapterProperties(adapterProperties);

--- a/adapters/lora-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/lora/quarkus/MetricsFactory.java
+++ b/adapters/lora-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/lora/quarkus/MetricsFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -45,6 +45,7 @@ public class MetricsFactory {
             final Vertx vertx,
             final MeterRegistry registry,
             final HttpProtocolAdapterProperties adapterProperties) {
+        // define tags before the first metric gets created in the MicrometerBasedHttpAdapterMetrics constructor
         registry.config().commonTags(MetricsTags.forProtocolAdapter(Constants.PROTOCOL_ADAPTER_TYPE_LORA));
         final var metrics = new MicrometerBasedHttpAdapterMetrics(registry, vertx);
         metrics.setProtocolAdapterProperties(adapterProperties);

--- a/adapters/mqtt-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/mqtt/quarkus/MetricsFactory.java
+++ b/adapters/mqtt-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/mqtt/quarkus/MetricsFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -43,6 +43,7 @@ public class MetricsFactory {
             final Vertx vertx,
             final MeterRegistry registry,
             final MqttProtocolAdapterProperties adapterProperties) {
+        // define tags before the first metric gets created in the MicrometerBasedMqttAdapterMetrics constructor
         registry.config().commonTags(MetricsTags.forProtocolAdapter(Constants.PROTOCOL_ADAPTER_TYPE_MQTT));
         final var metrics = new MicrometerBasedMqttAdapterMetrics(registry, vertx);
         metrics.setProtocolAdapterProperties(adapterProperties);

--- a/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/AbstractServiceApplication.java
+++ b/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/AbstractServiceApplication.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -95,6 +95,16 @@ public abstract class AbstractServiceApplication implements ComponentNameProvide
     }
 
     /**
+     * Sets common metrics tags.
+     * <p>
+     * This default implementation does nothing. Subclasses should override this method to set the metrics tags,
+     * if not already set elsewhere.
+     */
+    protected void setCommonMetricsTags() {
+        // nothing done by default
+    }
+
+    /**
      * Enables collection of JVM related metrics.
      * <p>
      * Enables collection of Memory, Thread, GC and Processor metrics.
@@ -139,6 +149,7 @@ public abstract class AbstractServiceApplication implements ComponentNameProvide
      * <p>
      * This implementation
      * <ol>
+     * <li>sets common metrics tags,</li>
      * <li>logs the VM details,</li>
      * <li>enables JVM metrics and</li>
      * <li>invokes {@link #doStart()}.</li>
@@ -148,6 +159,7 @@ public abstract class AbstractServiceApplication implements ComponentNameProvide
      */
     public void onStart(final @Observes StartupEvent ev) {
 
+        setCommonMetricsTags();
         logJvmDetails();
         enableJvmMetrics();
         doStart();

--- a/services/auth-quarkus/src/main/java/org/eclipse/hono/authentication/quarkus/Application.java
+++ b/services/auth-quarkus/src/main/java/org/eclipse/hono/authentication/quarkus/Application.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -73,10 +73,13 @@ public class Application extends AbstractServiceApplication {
     }
 
     @Override
-    protected void doStart() {
-
+    protected void setCommonMetricsTags() {
         LOG.info("adding common tags to meter registry");
         meterRegistry.config().commonTags(MetricsTags.forService(Constants.SERVICE_NAME_AUTH));
+    }
+
+    @Override
+    protected void doStart() {
 
         LOG.info("deploying {} ...", getComponentName());
         final CompletableFuture<Void> startup = new CompletableFuture<>();

--- a/services/device-registry-mongodb-quarkus/src/main/java/org/eclipse/hono/deviceregistry/mongodb/quarkus/Application.java
+++ b/services/device-registry-mongodb-quarkus/src/main/java/org/eclipse/hono/deviceregistry/mongodb/quarkus/Application.java
@@ -58,14 +58,17 @@ public class Application extends AbstractServiceApplication {
     }
 
     @Override
+    protected void setCommonMetricsTags() {
+        LOG.info("adding common tags to meter registry");
+        meterRegistry.config().commonTags(MetricsTags.forService(Constants.SERVICE_NAME_DEVICE_REGISTRY));
+    }
+
+    @Override
     protected void doStart() {
 
         if (!(authenticationService instanceof Verticle)) {
             throw new IllegalStateException("Authentication service must be a vert.x Verticle");
         }
-
-        LOG.info("adding common tags to meter registry");
-        meterRegistry.config().commonTags(MetricsTags.forService(Constants.SERVICE_NAME_DEVICE_REGISTRY));
 
         LOG.info("deploying {} {} instances ...", appConfig.getMaxInstances(), getComponentName());
 

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -14,6 +14,9 @@ description = "Information about changes in recent Hono releases. Includes new f
   with a 500 status code instead of the corresponding 4xx status code. This has been fixed.
 * *HonoConnectionImpl* instances failed to release/close the underlying TCP/TLS connection when its *disconnect* or
   *shutdown* method had been invoked. This has been fixed.
+* In the Quarkus variants of the MongoDB device registry and the Hono auth component, the provided metrics did not
+  contain the default set of tags, as used in the other Hono components (e.g. *host* or *component-name*). This has been
+  fixed.
 
 ## 1.12.1
 


### PR DESCRIPTION
This is for #3157:
Fix setting of common metrics tags. They have to be set before metrics get registered via the corresponding Binders.

This is the fix for 1.12.x. I've deliberately kept it small. 
In the change for master, the `meterRegistry.config().commonTags()` invocation shall be only done in one place - in the `AbstractServiceApplication` base class (using a new service/adapter name getter).