### PR TITLE
Fix synchronization issue in event bus notification sender method

### DIFF
--- a/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
+++ b/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
@@ -603,10 +603,9 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
             notificationConfig.setServerRole("Notification");
             notificationReceiver = new ProtonBasedNotificationReceiver(HonoConnection.newConnection(vertx, notificationConfig, tracer));
         }
+        final var notificationSender = NotificationEventBusSupport.getNotificationSender(vertx);
         NotificationConstants.DEVICE_REGISTRY_NOTIFICATION_TYPES.forEach(notificationType ->
-            notificationReceiver.registerConsumer(
-                    notificationType,
-                    notification -> NotificationEventBusSupport.sendNotification(vertx, notification)));
+            notificationReceiver.registerConsumer(notificationType, notificationSender::handle));
         return notificationReceiver;
     }
 

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -1017,7 +1017,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
         }).when(endpoint).close();
 
         // WHEN a notification is sent about the tenant/device having been deleted or disabled
-        NotificationEventBusSupport.sendNotification(vertx, notification);
+        NotificationEventBusSupport.getNotificationSender(vertx).handle(notification);
 
         // THEN the MQTT endpoint representing the device connection is closed
         endpointClosedPromise.future()

--- a/clients/notification/src/test/java/org/eclipse/hono/notification/NotificationEventBusSupportTest.java
+++ b/clients/notification/src/test/java/org/eclipse/hono/notification/NotificationEventBusSupportTest.java
@@ -58,7 +58,7 @@ public class NotificationEventBusSupportTest {
             });
         }
 
-        NotificationEventBusSupport.sendNotification(vertx, notification);
+        NotificationEventBusSupport.getNotificationSender(vertx).handle(notification);
     }
 
 }

--- a/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/quarkus/Application.java
+++ b/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/quarkus/Application.java
@@ -421,10 +421,9 @@ public class Application extends AbstractServiceApplication {
             notificationConfig.setServerRole("Notification");
             notificationReceiver = new ProtonBasedNotificationReceiver(HonoConnection.newConnection(vertx, notificationConfig, tracer));
         }
+        final var notificationSender = NotificationEventBusSupport.getNotificationSender(vertx);
         NotificationConstants.DEVICE_REGISTRY_NOTIFICATION_TYPES.forEach(notificationType -> {
-            notificationReceiver.registerConsumer(notificationType, notification -> {
-                NotificationEventBusSupport.sendNotification(vertx, notification);
-            });
+            notificationReceiver.registerConsumer(notificationType, notificationSender::handle);
         });
         return notificationReceiver;
     }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AbstractDeviceManagementService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AbstractDeviceManagementService.java
@@ -26,6 +26,7 @@ import org.eclipse.hono.client.util.StatusCodeMapper;
 import org.eclipse.hono.deviceregistry.service.tenant.NoopTenantInformationService;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
 import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
+import org.eclipse.hono.notification.AbstractNotification;
 import org.eclipse.hono.notification.NotificationEventBusSupport;
 import org.eclipse.hono.notification.deviceregistry.AllDevicesOfTenantDeletedNotification;
 import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
@@ -46,6 +47,7 @@ import io.opentracing.Span;
 import io.opentracing.log.Fields;
 import io.opentracing.tag.Tags;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 
 /**
@@ -60,6 +62,8 @@ public abstract class AbstractDeviceManagementService implements DeviceManagemen
     protected final Vertx vertx;
     protected TenantInformationService tenantInformationService = new NoopTenantInformationService();
 
+    private final Handler<AbstractNotification> notificationSender;
+
     /**
      * Creates a new AbstractDeviceManagementService.
      *
@@ -68,6 +72,7 @@ public abstract class AbstractDeviceManagementService implements DeviceManagemen
      */
     protected AbstractDeviceManagementService(final Vertx vertx) {
         this.vertx = Objects.requireNonNull(vertx);
+        this.notificationSender = NotificationEventBusSupport.getNotificationSender(vertx);
     }
 
     /**
@@ -277,9 +282,8 @@ public abstract class AbstractDeviceManagementService implements DeviceManagemen
                                 result.getStatus(),
                                 "tenant does not exist"))
                         : processCreateDevice(DeviceKey.from(result.getPayload(), deviceIdValue), device, span))
-                .onSuccess(result -> NotificationEventBusSupport.sendNotification(vertx,
-                        new DeviceChangeNotification(LifecycleChange.CREATE, tenantId, deviceIdValue, Instant.now(),
-                                device.isEnabled())))
+                .onSuccess(result -> notificationSender.handle(new DeviceChangeNotification(LifecycleChange.CREATE,
+                        tenantId, deviceIdValue, Instant.now(), device.isEnabled())))
                 .recover(t -> DeviceRegistryUtils.mapError(t, tenantId));
     }
 
@@ -323,9 +327,8 @@ public abstract class AbstractDeviceManagementService implements DeviceManagemen
                                 result.getStatus(),
                                 "tenant does not exist"))
                         : processUpdateDevice(DeviceKey.from(result.getPayload(), deviceId), device, resourceVersion, span))
-                .onSuccess(result -> NotificationEventBusSupport.sendNotification(vertx,
-                        new DeviceChangeNotification(LifecycleChange.UPDATE, tenantId, deviceId, Instant.now(),
-                                device.isEnabled())))
+                .onSuccess(result -> notificationSender.handle(new DeviceChangeNotification(LifecycleChange.UPDATE,
+                        tenantId, deviceId, Instant.now(), device.isEnabled())))
                 .recover(t -> DeviceRegistryUtils.mapError(t, tenantId));
     }
 
@@ -362,7 +365,7 @@ public abstract class AbstractDeviceManagementService implements DeviceManagemen
                     }
                     return processDeleteDevice(DeviceKey.from(tenantId, deviceId), resourceVersion, span);
                 })
-                .onSuccess(result -> NotificationEventBusSupport.sendNotification(vertx,
+                .onSuccess(result -> notificationSender.handle(
                         new DeviceChangeNotification(LifecycleChange.DELETE, tenantId, deviceId, Instant.now(), false)))
                 .recover(t -> DeviceRegistryUtils.mapError(t, tenantId));
     }
@@ -393,8 +396,8 @@ public abstract class AbstractDeviceManagementService implements DeviceManagemen
                     }
                     return processDeleteDevicesOfTenant(tenantId, span);
                 })
-                .onSuccess(result -> NotificationEventBusSupport.sendNotification(vertx,
-                        new AllDevicesOfTenantDeletedNotification(tenantId, Instant.now())))
+                .onSuccess(result -> notificationSender
+                        .handle(new AllDevicesOfTenantDeletedNotification(tenantId, Instant.now())))
                 .recover(t -> DeviceRegistryUtils.mapError(t, tenantId));
     }
 

--- a/tests/src/test/java/org/eclipse/hono/tests/client/KafkaBasedEventSenderIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/client/KafkaBasedEventSenderIT.java
@@ -172,8 +172,8 @@ public class KafkaBasedEventSenderIT {
         });
 
         // WHEN sending a tenant-deleted notification for that tenant
-        NotificationEventBusSupport.sendNotification(vertx,
-                new TenantChangeNotification(LifecycleChange.DELETE, tenantId, Instant.now(), false));
+        NotificationEventBusSupport.getNotificationSender(vertx)
+                .handle(new TenantChangeNotification(LifecycleChange.DELETE, tenantId, Instant.now(), false));
 
         vertx.runOnContext(v -> {
             // THEN the metrics of the underlying producer don't contain any metrics regarding that topic


### PR DESCRIPTION
Access to the static `WeakHashMap` in `NotificationEventBusSupport` has to be synchronized. This mainly applies to unit tests, where multiple Vertx instances are used.

This should fix unit test failures like this one:
```
23:16:39.831 [vert.x-eventloop-thread-0] WARN  i.n.u.c.AbstractEventExecutor - A task raised an exception. Task: io.vertx.core.impl.future.FutureBase$$Lambda$760/0x0000000800550c40@454a5444
java.lang.IllegalStateException: Already a codec registered with name NotificationEventBusContainerLocalCodec
	at io.vertx.core.eventbus.impl.CodecManager.registerCodec(CodecManager.java:116)
	at io.vertx.core.eventbus.impl.EventBusImpl.registerCodec(EventBusImpl.java:184)
	at org.eclipse.hono.notification.NotificationEventBusSupport.sendNotification(NotificationEventBusSupport.java:85)
	at org.eclipse.hono.deviceregistry.service.credentials.AbstractCredentialsManagementService.lambda$updateCredentials$3(AbstractCredentialsManagementService.java:167)
	at io.vertx.core.impl.future.FutureImpl$1.onSuccess(FutureImpl.java:91)
	at io.vertx.core.impl.future.FutureImpl$ListenerArray.onSuccess(FutureImpl.java:262)
[...]
[ERROR] Tests run: 16, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 42.586 s <<< FAILURE! - in org.eclipse.hono.deviceregistry.jdbc.impl.JdbcBasedCredentialsServiceTest
[ERROR] testUpdateCredentialsFailsForWrongResourceVersion{VertxTestContext}  Time elapsed: 17.022 s  <<< ERROR!
java.util.concurrent.TimeoutException: 
The test execution timed out. Make sure your asynchronous code includes calls to either VertxTestContext#completeNow(), VertxTestContext#failNow() or Checkpoint#flag()
```
This error occurred in the JDBC Device Registry module, where parallel test execution leads to many potentially concurrent invocations of the `NotificationEventBusSupport` method with different `vertx` instances.

The fix here also decouples the check for the event bus codec by introducing a `getNotificationSender` method.

