### PR TITLE
[#3162] Do not send message properties to north bound C&C API

### DIFF
--- a/cli/src/main/java/org/eclipse/hono/cli/app/Commander.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/app/Commander.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -79,15 +79,27 @@ public class Commander extends AbstractApplicationClient {
         final Future<Void> sendResult;
         if (command.isOneWay()) {
             System.out.println("Command sent to device.");
-            sendResult = client.sendOneWayCommand(tenantId, deviceId, command.getName(), command.getContentType(),
-                    Buffer.buffer(command.getPayload()), null, null);
+            sendResult = client.sendOneWayCommand(
+                    tenantId,
+                    deviceId,
+                    command.getName(),
+                    command.getContentType(),
+                    Buffer.buffer(command.getPayload()),
+                    null);
         } else {
             System.out.printf("Command sent to device... [waiting for response for max. %d seconds]", commandTimeOutInSeconds);
             System.out.println();
-            sendResult = client.sendCommand(tenantId, deviceId, command.getName(), command.getContentType(),
-                    Buffer.buffer(command.getPayload()), UUID.randomUUID().toString(), null,
-                    Duration.ofSeconds(commandTimeOutInSeconds), null)
-                    .map(this::printResponse);
+            sendResult = client.sendCommand(
+                    tenantId,
+                    deviceId,
+                    command.getName(),
+                    command.getContentType(),
+                    Buffer.buffer(command.getPayload()),
+                    UUID.randomUUID().toString(),
+                    Duration.ofSeconds(commandTimeOutInSeconds),
+                    null)
+                .onSuccess(this::printResponse)
+                .mapEmpty();
         }
 
         return sendResult.otherwise(error -> {
@@ -102,11 +114,10 @@ public class Commander extends AbstractApplicationClient {
         });
     }
 
-    private Void printResponse(final DownstreamMessage<?> result) {
+    private void printResponse(final DownstreamMessage<?> result) {
         System.out.printf("Received Command response: %s",
                 Optional.ofNullable(result.getPayload()).orElseGet(Buffer::buffer));
         System.out.println();
-        return null;
     }
 
     private Future<Command> getCommandFromUser() {

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedDownstreamMessage.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedDownstreamMessage.java
@@ -180,7 +180,7 @@ public final class ProtonBasedDownstreamMessage implements DownstreamMessage<Amq
      */
     @Override
     public String getCorrelationId() {
-        return Optional.ofNullable(MessageHelper.getCorrelationId(message))
+        return Optional.ofNullable(message.getCorrelationId())
                 .filter(String.class::isInstance)
                 .map(String.class::cast)
                 .orElse(null);

--- a/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedCommandSenderTest.java
+++ b/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedCommandSenderTest.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.qpid.proton.amqp.messaging.Accepted;
 import org.apache.qpid.proton.message.Message;
-import org.eclipse.hono.client.amqp.connection.AmqpUtils;
 import org.eclipse.hono.client.amqp.connection.HonoConnection;
 import org.eclipse.hono.client.amqp.connection.SendMessageSampler;
 import org.eclipse.hono.client.amqp.test.AmqpClientUnitTestHelper;

--- a/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedCommandSenderTest.java
+++ b/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedCommandSenderTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.when;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -105,14 +104,13 @@ public class ProtonBasedCommandSenderTest {
         final String tenantId = UUID.randomUUID().toString();
         final String deviceId = UUID.randomUUID().toString();
         final String subject = "setVolume";
-        final Map<String, Object> applicationProperties = Map.of("appKey", "appValue");
         final ArgumentCaptor<Handler<ProtonDelivery>> dispositionHandlerCaptor = VertxMockSupport.argumentCaptorHandler();
         final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
 
         // WHEN sending a one-way command with some application properties and payload
         final Future<Void> sendCommandFuture = commandSender
                 .sendOneWayCommand(tenantId, deviceId, subject, null, Buffer.buffer("{\"value\": 20}"),
-                        applicationProperties, NoopSpan.INSTANCE.context())
+                        NoopSpan.INSTANCE.context())
                 .onComplete(ctx.succeedingThenComplete());
 
         // VERIFY that the command is being sent
@@ -128,7 +126,6 @@ public class ProtonBasedCommandSenderTest {
         final Message message = messageCaptor.getValue();
         assertThat(MessageHelper.getDeviceId(message)).isEqualTo(deviceId);
         assertThat(message.getSubject()).isEqualTo(subject);
-        assertThat(AmqpUtils.getApplicationProperty(message, "appKey", String.class)).isEqualTo("appValue");
         assertThat(sendCommandFuture.isComplete()).isTrue();
     }
 
@@ -144,14 +141,13 @@ public class ProtonBasedCommandSenderTest {
         final String subject = "setVolume";
         final String correlationId = UUID.randomUUID().toString();
         final String replyId = "reply-id";
-        final Map<String, Object> applicationProperties = Map.of("appKey", "appValue");
         final ArgumentCaptor<Handler<ProtonDelivery>> dispositionHandlerCaptor = VertxMockSupport.argumentCaptorHandler();
         final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
 
         // WHEN sending a one-way command with some application properties and payload
         final Future<Void> sendCommandFuture = commandSender
                 .sendAsyncCommand(tenantId, deviceId, subject, null, Buffer.buffer("{\"value\": 20}"),
-                        correlationId, replyId, applicationProperties, NoopSpan.INSTANCE.context())
+                        correlationId, replyId, NoopSpan.INSTANCE.context())
                 .onComplete(ctx.succeedingThenComplete());
 
         // VERIFY that the command is being sent
@@ -167,8 +163,7 @@ public class ProtonBasedCommandSenderTest {
         final Message message = messageCaptor.getValue();
         assertThat(MessageHelper.getDeviceId(message)).isEqualTo(deviceId);
         assertThat(message.getSubject()).isEqualTo(subject);
-        assertThat(MessageHelper.getCorrelationId(message)).isEqualTo(correlationId);
-        assertThat(AmqpUtils.getApplicationProperty(message, "appKey", String.class)).isEqualTo("appValue");
+        assertThat(message.getCorrelationId()).isEqualTo(correlationId);
         assertThat(sendCommandFuture.isComplete()).isTrue();
     }
 

--- a/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedRequestResponseCommandClientTest.java
+++ b/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedRequestResponseCommandClientTest.java
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
-import org.eclipse.hono.client.amqp.connection.AmqpUtils;
 import org.eclipse.hono.client.amqp.connection.HonoConnection;
 import org.eclipse.hono.client.amqp.connection.SendMessageSampler;
 import org.eclipse.hono.client.amqp.test.AmqpClientUnitTestHelper;

--- a/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedRequestResponseCommandClientTest.java
+++ b/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedRequestResponseCommandClientTest.java
@@ -23,8 +23,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -104,7 +102,6 @@ public class ProtonBasedRequestResponseCommandClientTest {
     public void testSendCommandSucceeds(final VertxTestContext ctx) {
         final String subject = "setVolume";
         final String replyId = UUID.randomUUID().toString();
-        final Map<String, Object> properties = Map.of("appKey", "appValue");
         final int commandStatus = HttpURLConnection.HTTP_OK;
         final String responseContentType = MessageHelper.CONTENT_TYPE_APPLICATION_JSON;
         final String responsePayload = "{\"status\": 1}";
@@ -112,7 +109,7 @@ public class ProtonBasedRequestResponseCommandClientTest {
         // WHEN sending a command with some application properties and payload
         requestResponseCommandClient
                 .sendCommand(tenantId, deviceId, subject, null, Buffer.buffer("{\"value\": 20}"), replyId,
-                        properties, null, NoopSpan.INSTANCE.context())
+                        null, NoopSpan.INSTANCE.context())
                 .onComplete(ctx.succeeding(response -> {
                     ctx.verify(() -> {
                         // VERIFY the properties of the received response.
@@ -127,7 +124,6 @@ public class ProtonBasedRequestResponseCommandClientTest {
         final Message sentMessage = AmqpClientUnitTestHelper.assertMessageHasBeenSent(sender);
         assertThat(sentMessage.getSubject()).isEqualTo(subject);
         assertThat(sentMessage.getReplyTo()).endsWith(replyId);
-        assertThat(AmqpUtils.getApplicationProperty(sentMessage, "appKey", String.class)).isEqualTo("appValue");
 
         final Message response = ProtonHelper.message();
         response.setCorrelationId(sentMessage.getMessageId());
@@ -147,14 +143,13 @@ public class ProtonBasedRequestResponseCommandClientTest {
     public void testSendCommandFailsForErrorStatusResponse(final VertxTestContext ctx) {
         final String subject = "setVolume";
         final String replyId = UUID.randomUUID().toString();
-        final Map<String, Object> properties = Map.of("appKey", "appValue");
         final int commandStatus = HttpURLConnection.HTTP_BAD_REQUEST;
         final String responsePayload = "Unsupported command";
 
         // WHEN sending a command with some application properties and payload
         requestResponseCommandClient
                 .sendCommand(tenantId, deviceId, subject, null, Buffer.buffer("{\"value\": 20}"), replyId,
-                        properties, null, NoopSpan.INSTANCE.context())
+                        null, NoopSpan.INSTANCE.context())
                 .onComplete(ctx.failing(thr -> {
                     ctx.verify(() -> {
                         // VERIFY the returned exception
@@ -169,7 +164,6 @@ public class ProtonBasedRequestResponseCommandClientTest {
         final Message sentMessage = AmqpClientUnitTestHelper.assertMessageHasBeenSent(sender);
         assertThat(sentMessage.getSubject()).isEqualTo(subject);
         assertThat(sentMessage.getReplyTo()).endsWith(replyId);
-        assertThat(AmqpUtils.getApplicationProperty(sentMessage, "appKey", String.class)).isEqualTo("appValue");
 
         final Message response = ProtonHelper.message();
         response.setCorrelationId(sentMessage.getMessageId());
@@ -194,12 +188,16 @@ public class ProtonBasedRequestResponseCommandClientTest {
     @Test
     public void testSendCommandSetsProperties() {
         final String replyId = UUID.randomUUID().toString();
-        final Map<String, Object> applicationProperties = new HashMap<>();
-        applicationProperties.put("appKey", "appValue");
 
-        requestResponseCommandClient
-                .sendCommand(tenantId, deviceId, "doSomething", "text/plain", Buffer.buffer("payload"), replyId,
-                        applicationProperties, null, NoopSpan.INSTANCE.context());
+        requestResponseCommandClient.sendCommand(
+                tenantId,
+                deviceId,
+                "doSomething",
+                "text/plain",
+                Buffer.buffer("payload"),
+                replyId,
+                Duration.ofSeconds(10),
+                NoopSpan.INSTANCE.context());
 
         final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
         verify(sender).send(messageCaptor.capture(), VertxMockSupport.anyHandler());
@@ -210,8 +208,6 @@ public class ProtonBasedRequestResponseCommandClientTest {
         assertThat(messageCaptor.getValue().getSubject()).isEqualTo("doSomething");
         assertNotNull(messageCaptor.getValue().getMessageId());
         assertThat(messageCaptor.getValue().getContentType()).isEqualTo("text/plain");
-        assertNotNull(messageCaptor.getValue().getApplicationProperties());
-        assertThat(messageCaptor.getValue().getApplicationProperties().getValue().get("appKey")).isEqualTo("appValue");
     }
 
     /**
@@ -223,7 +219,6 @@ public class ProtonBasedRequestResponseCommandClientTest {
     void testSendCommandAndReceiveResponseTimesOut(final VertxTestContext ctx) {
         final String subject = "sendCommandTimesOut";
         final String replyId = UUID.randomUUID().toString();
-        final Map<String, Object> properties = Map.of("appKey", "appValue");
 
         // Run the timer immediately to simulate the time out.
         VertxMockSupport.runTimersImmediately(vertx);
@@ -231,7 +226,7 @@ public class ProtonBasedRequestResponseCommandClientTest {
         // WHEN sending a command with some application properties and payload
         requestResponseCommandClient
                 .sendCommand(tenantId, deviceId, subject, null, Buffer.buffer("test"), replyId,
-                        properties, Duration.ofMillis(1), NoopSpan.INSTANCE.context())
+                        Duration.ofMillis(1), NoopSpan.INSTANCE.context())
                 .onComplete(ctx.failing(error -> {
                     ctx.verify(() -> {
                         // VERIFY the error code.

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
@@ -145,14 +145,13 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
             final Buffer data,
             final String correlationId,
             final String replyId,
-            final Map<String, Object> properties,
             final SpanContext context) {
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(command);
         Objects.requireNonNull(correlationId);
 
-        return sendCommand(tenantId, deviceId, command, contentType, data, correlationId, properties, true,
+        return sendCommand(tenantId, deviceId, command, contentType, data, correlationId, true,
                 "send command", context);
     }
 
@@ -163,13 +162,12 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
             final String command,
             final String contentType,
             final Buffer data,
-            final Map<String, Object> properties,
             final SpanContext context) {
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(command);
 
-        return sendCommand(tenantId, deviceId, command, contentType, data, null, properties, false,
+        return sendCommand(tenantId, deviceId, command, contentType, data, null, false,
                 "send one-way command", context);
     }
 
@@ -191,7 +189,6 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
             final String contentType,
             final Buffer data,
             final String replyId,
-            final Map<String, Object> properties,
             final Duration timeout,
             final SpanContext context) {
         Objects.requireNonNull(tenantId);
@@ -227,7 +224,7 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
                     // Store the correlation id and the expiring command promise
                     pendingCommandResponses.computeIfAbsent(tenantId, k -> new ConcurrentHashMap<>())
                             .put(correlationId, expiringCommandPromise);
-                    return sendCommand(tenantId, deviceId, command, contentType, data, correlationId, properties,
+                    return sendCommand(tenantId, deviceId, command, contentType, data, correlationId,
                             true, "send command", span.context())
                                     .onSuccess(sent -> {
                                         LOGGER.debug("sent command [correlation-id: {}], waiting for response", correlationId);
@@ -264,14 +261,20 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
         this.correlationIdSupplier = Objects.requireNonNull(correlationIdSupplier);
     }
 
-    private Future<Void> sendCommand(final String tenantId, final String deviceId, final String command,
-            final String contentType, final Buffer data, final String correlationId,
-            final Map<String, Object> properties, final boolean responseRequired, final String spanOperationName,
+    private Future<Void> sendCommand(
+            final String tenantId,
+            final String deviceId,
+            final String command,
+            final String contentType,
+            final Buffer data,
+            final String correlationId,
+            final boolean responseRequired,
+            final String spanOperationName,
             final SpanContext context) {
 
         final HonoTopic topic = new HonoTopic(HonoTopic.Type.COMMAND, tenantId);
         final Map<String, Object> headerProperties = getHeaderProperties(deviceId, command, contentType, correlationId,
-                responseRequired, properties);
+                responseRequired);
         final String topicName = topic.toString();
         final Span currentSpan = startChildSpan(spanOperationName, topicName, tenantId, deviceId, context);
         return sendAndWaitForOutcome(
@@ -285,12 +288,9 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
     }
 
     private Map<String, Object> getHeaderProperties(final String deviceId, final String subject,
-            final String contentType, final String correlationId, final boolean responseRequired,
-            final Map<String, Object> properties) {
+            final String contentType, final String correlationId, final boolean responseRequired) {
 
-        final Map<String, Object> props = Optional.ofNullable(properties)
-                .map(HashMap::new)
-                .orElseGet(HashMap::new);
+        final Map<String, Object> props = new HashMap<>();
 
         props.put(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId);
         props.put(MessageHelper.SYS_PROPERTY_SUBJECT, subject);

--- a/clients/application/src/main/java/org/eclipse/hono/application/client/CommandSender.java
+++ b/clients/application/src/main/java/org/eclipse/hono/application/client/CommandSender.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,7 +13,6 @@
 package org.eclipse.hono.application.client;
 
 import java.time.Duration;
-import java.util.Map;
 
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.util.Lifecycle;
@@ -88,7 +87,6 @@ public interface CommandSender<T extends MessageContext> extends Lifecycle {
      * @param replyId An arbitrary string which will be used to create the reply-to address to be included in commands
      *            sent to devices of the tenant. If the messaging network specific Command &amp; Control implementation does
      *            not require a replyId, the specified value will be ignored.
-     * @param properties The headers to include in the command message.
      * @return A future indicating the result of the operation.
      *         <p>
      *         If the command was accepted, the future will succeed.
@@ -106,10 +104,8 @@ public interface CommandSender<T extends MessageContext> extends Lifecycle {
             final String contentType,
             final Buffer data,
             final String correlationId,
-            final String replyId,
-            final Map<String, Object> properties) {
-        return sendAsyncCommand(tenantId, deviceId, command, contentType, data, correlationId, replyId, properties,
-                null);
+            final String replyId) {
+        return sendAsyncCommand(tenantId, deviceId, command, contentType, data, correlationId, replyId, null);
     }
 
     /**
@@ -131,7 +127,6 @@ public interface CommandSender<T extends MessageContext> extends Lifecycle {
      * @param replyId An arbitrary string which will be used to create the reply-to address to be included in commands
      *            sent to devices of the tenant. If the messaging network specific Command &amp; Control implementation does
      *            not require a replyId, the specified value will be ignored.
-     * @param properties The headers to include in the command message.
      * @param context The currently active OpenTracing span context that is used to trace the execution of this
      *            operation or {@code null} if no span is currently active.
      * @return A future indicating the result of the operation.
@@ -152,7 +147,6 @@ public interface CommandSender<T extends MessageContext> extends Lifecycle {
             Buffer data,
             String correlationId,
             String replyId,
-            Map<String, Object> properties,
             SpanContext context);
 
     /**
@@ -179,7 +173,7 @@ public interface CommandSender<T extends MessageContext> extends Lifecycle {
             final String deviceId,
             final String command,
             final Buffer data) {
-        return sendOneWayCommand(tenantId, deviceId, command, null, data, null, null);
+        return sendOneWayCommand(tenantId, deviceId, command, null, data, null);
     }
 
     /**
@@ -194,7 +188,6 @@ public interface CommandSender<T extends MessageContext> extends Lifecycle {
      * @param command The name of the command.
      * @param contentType The type of the data submitted as part of the one-way command or {@code null} if unknown.
      * @param data The input data to the command or {@code null} if the command has no input data.
-     * @param properties The headers to include in the one-way command message.
      * @param context The currently active OpenTracing span context that is used to trace the execution of this
      *            operation or {@code null} if no span is currently active.
      * @return A future indicating the result of the operation:
@@ -211,7 +204,6 @@ public interface CommandSender<T extends MessageContext> extends Lifecycle {
             String command,
             String contentType,
             Buffer data,
-            Map<String, Object> properties,
             SpanContext context);
 
     /**
@@ -240,7 +232,7 @@ public interface CommandSender<T extends MessageContext> extends Lifecycle {
             final String deviceId,
             final String command,
             final Buffer data) {
-        return sendCommand(tenantId, deviceId, command, null, data, null);
+        return sendCommand(tenantId, deviceId, command, null, data);
     }
 
     /**
@@ -255,7 +247,6 @@ public interface CommandSender<T extends MessageContext> extends Lifecycle {
      * @param command The name of the command.
      * @param contentType The type of the data submitted as part of the command or {@code null} if unknown.
      * @param data The command data to send to the device or {@code null} if the command has no input data.
-     * @param properties The headers to include in the command message.
      * @return A future indicating the result of the operation.
      *         <p>
      *         The future will succeed if a response with status 2xx has been received from the device.
@@ -271,9 +262,8 @@ public interface CommandSender<T extends MessageContext> extends Lifecycle {
             final String deviceId,
             final String command,
             final String contentType,
-            final Buffer data,
-            final Map<String, Object> properties) {
-        return sendCommand(tenantId, deviceId, command, contentType, data, null, properties, null, null);
+            final Buffer data) {
+        return sendCommand(tenantId, deviceId, command, contentType, data, null, null, null);
     }
 
     /**
@@ -291,7 +281,6 @@ public interface CommandSender<T extends MessageContext> extends Lifecycle {
      * @param replyId An arbitrary string which will be used to create the reply-to address to be included in commands
      *                sent to devices of the tenant. If the messaging network specific Command &amp; Control 
      *                implementation does not require a replyId, the specified value will be ignored.
-     * @param properties The headers to include in the command message.
      * @param timeout The duration after which the send command request times out.
      *                If the timeout duration is set to 0 then the send command request never times out.
      * @param context The currently active OpenTracing span context that is used to trace the execution of this
@@ -314,7 +303,6 @@ public interface CommandSender<T extends MessageContext> extends Lifecycle {
             String contentType,
             Buffer data,
             String replyId,
-            Map<String, Object> properties,
             Duration timeout,
             SpanContext context);
 }

--- a/examples/hono-client-examples/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleApplicationBase.java
+++ b/examples/hono-client-examples/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleApplicationBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -412,7 +412,7 @@ public class HonoExampleApplicationBase {
             LOG.debug("Sending command [{}] to [{}].", command, ttdNotification.getTenantAndDeviceId());
         }
 
-        client.sendCommand(tenantId, deviceId, command, "application/json", commandBuffer, buildCommandProperties())
+        client.sendCommand(tenantId, deviceId, command, "application/json", commandBuffer)
             .onSuccess(result -> {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Successfully sent command payload: [{}].", commandBuffer.toString());
@@ -463,17 +463,6 @@ public class HonoExampleApplicationBase {
                     LOG.debug("Could not send one-way command : {}.", t.getMessage());
                 }
             });
-    }
-
-    /**
-     * Provides an application property that is suitable to be sent with the command upstream.
-     *
-     * @return Map The application property map.
-     */
-    private static Map<String, Object> buildCommandProperties() {
-        final Map<String, Object> applicationProperties = new HashMap<>(1);
-        applicationProperties.put("appId", "example#1");
-        return applicationProperties;
     }
 
     private static Buffer buildCommandPayload() {

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -63,6 +63,8 @@ description = "Information about changes in recent Hono releases. Includes new f
 * Moved `org.eclipse.hono.util.TelemetryExecutionContext` to adapter-base module.
 * The *amqp-device* client module no longer supports including arbitrary properties in telemetry, event and command
   response messages because it was undefined how these properties would be processed by the AMQP protocol adapter.
+* The *application* client module no longer supports including arbitrary properties in command messages
+  because it was undefined how these properties would be processed by the Hono components.
 
 ## 1.12.1
 

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -1207,7 +1207,7 @@ public final class IntegrationTestSupport {
         LOGGER.trace("sending command [name: {}, contentType: {}, payload: {}]", command, contentType, payload);
         // send the command upstream to the device and receive the command response
         final Future<? extends DownstreamMessage<?>> sendCommandTracker = applicationClient
-                .sendCommand(tenantId, deviceId, command, contentType, payload, null)
+                .sendCommand(tenantId, deviceId, command, contentType, payload)
                 .onComplete(ar -> {
                     vertx.cancelTimer(timerId);
                     timeOutTracker.tryComplete();
@@ -1277,8 +1277,7 @@ public final class IntegrationTestSupport {
 
         // send the one way command upstream to the device
         final Future<Void> sendOneWayCommandTracker = applicationClient
-                .sendOneWayCommand(tenantId, deviceId, command, contentType, payload, null,
-                        NoopSpan.INSTANCE.context())
+                .sendOneWayCommand(tenantId, deviceId, command, contentType, payload, NoopSpan.INSTANCE.context())
                 .onComplete(ar -> {
                     vertx.cancelTimer(timerId);
                     timeOutTracker.tryComplete();


### PR DESCRIPTION
Hono's north bound C&C API does not support including arbitrary
properties in command message. The application client module's
CommandSender's send methods, however, accept a Map of properties. It is
unclear, if and how these properties are forwarded to upstream devices.
The Map typed parameter has therefore been removed.

Fixes #3162