### PR TITLE
Allow sending non-empty commands without content type

### DIFF
--- a/cli/src/main/java/org/eclipse/hono/cli/app/Commander.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/app/Commander.java
@@ -83,8 +83,8 @@ public class Commander extends AbstractApplicationClient {
                     tenantId,
                     deviceId,
                     command.getName(),
-                    command.getContentType(),
                     Buffer.buffer(command.getPayload()),
+                    command.getContentType(),
                     null);
         } else {
             System.out.printf("Command sent to device... [waiting for response for max. %d seconds]", commandTimeOutInSeconds);
@@ -93,8 +93,8 @@ public class Commander extends AbstractApplicationClient {
                     tenantId,
                     deviceId,
                     command.getName(),
-                    command.getContentType(),
                     Buffer.buffer(command.getPayload()),
+                    command.getContentType(),
                     UUID.randomUUID().toString(),
                     Duration.ofSeconds(commandTimeOutInSeconds),
                     null)

--- a/clients/application-kafka/src/test/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSenderTest.java
+++ b/clients/application-kafka/src/test/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSenderTest.java
@@ -144,10 +144,10 @@ public class KafkaBasedCommandSenderTest {
                 tenantId,
                 deviceId,
                 subject,
-                "application/json",
-                new JsonObject().put("value", 20).toBuffer(),
                 correlationId,
-                null,
+                null, // no reply ID required
+                new JsonObject().put("value", 20).toBuffer(),
+                "application/json",
                 null)
             .onComplete(ctx.succeeding(ok -> {
                 ctx.verify(() -> {
@@ -189,8 +189,8 @@ public class KafkaBasedCommandSenderTest {
                 tenantId,
                 deviceId,
                 subject,
-                "application/json",
                 new JsonObject().put("value", 20).toBuffer(),
+                "application/json",
                 NoopSpan.INSTANCE.context())
             .onComplete(ctx.succeeding(ok -> {
                 ctx.verify(() -> {
@@ -229,9 +229,9 @@ public class KafkaBasedCommandSenderTest {
                     tenantId,
                     deviceId,
                     "testCommand",
-                    "text/plain",
                     Buffer.buffer("data"),
-                    null,
+                    "text/plain",
+                    null, // no reply ID required
                     Duration.ofMillis(5),
                     null)
                 .onComplete(ctx.failing(error -> {
@@ -335,7 +335,7 @@ public class KafkaBasedCommandSenderTest {
 
         context.runOnContext(v -> {
             // Send a command to the device
-            commandSender.sendCommand(tenantId, deviceId, command, "text/plain", Buffer.buffer("test"))
+            commandSender.sendCommand(tenantId, deviceId, command, Buffer.buffer("test"), "text/plain")
                     .onComplete(ar -> {
                         ctx.verify(() -> {
                             if (expectSuccess) {
@@ -371,9 +371,17 @@ public class KafkaBasedCommandSenderTest {
         if (status != null) {
             headers.add(new RecordHeader(MessageHelper.APP_PROPERTY_STATUS, String.valueOf(status).getBytes()));
         }
-        return new ConsumerRecord<>(new HonoTopic(HonoTopic.Type.COMMAND_RESPONSE, tenantId).toString(), 0, 0, -1L,
-                TimestampType.NO_TIMESTAMP_TYPE, -1L, -1, -1, deviceId,
-                payload, new RecordHeaders(headers.toArray(Header[]::new)));
+        return new ConsumerRecord<>(
+                new HonoTopic(HonoTopic.Type.COMMAND_RESPONSE, tenantId).toString(),
+                0,
+                0,
+                -1L,
+                TimestampType.NO_TIMESTAMP_TYPE,
+                -1L,
+                -1,
+                -1,
+                deviceId,
+                payload,
+                new RecordHeaders(headers.toArray(Header[]::new)));
     }
-
 }

--- a/examples/hono-client-examples/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleApplicationBase.java
+++ b/examples/hono-client-examples/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleApplicationBase.java
@@ -412,7 +412,7 @@ public class HonoExampleApplicationBase {
             LOG.debug("Sending command [{}] to [{}].", command, ttdNotification.getTenantAndDeviceId());
         }
 
-        client.sendCommand(tenantId, deviceId, command, "application/json", commandBuffer)
+        client.sendCommand(tenantId, deviceId, command, commandBuffer, "application/json")
             .onSuccess(result -> {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Successfully sent command payload: [{}].", commandBuffer.toString());

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -68,6 +68,8 @@ description = "Information about changes in recent Hono releases. Includes new f
   response messages because it was undefined how these properties would be processed by the AMQP protocol adapter.
 * The *application* client module no longer supports including arbitrary properties in command messages
   because it was undefined how these properties would be processed by the Hono components.
+* The order of the method parameters of the `org.eclipse.hono.application.client.CommandSender` interface have been changed
+  so that mandatory parameters come first.
 
 ## 1.12.1
 

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -1207,7 +1207,7 @@ public final class IntegrationTestSupport {
         LOGGER.trace("sending command [name: {}, contentType: {}, payload: {}]", command, contentType, payload);
         // send the command upstream to the device and receive the command response
         final Future<? extends DownstreamMessage<?>> sendCommandTracker = applicationClient
-                .sendCommand(tenantId, deviceId, command, contentType, payload)
+                .sendCommand(tenantId, deviceId, command, payload, contentType)
                 .onComplete(ar -> {
                     vertx.cancelTimer(timerId);
                     timeOutTracker.tryComplete();
@@ -1277,7 +1277,7 @@ public final class IntegrationTestSupport {
 
         // send the one way command upstream to the device
         final Future<Void> sendOneWayCommandTracker = applicationClient
-                .sendOneWayCommand(tenantId, deviceId, command, contentType, payload, NoopSpan.INSTANCE.context())
+                .sendOneWayCommand(tenantId, deviceId, command, payload, contentType, NoopSpan.INSTANCE.context())
                 .onComplete(ar -> {
                     vertx.cancelTimer(timerId);
                     timeOutTracker.tryComplete();


### PR DESCRIPTION
The C&C spec does not require a content type to be set when sending
commands. It also allows for commands that contain a payload but do not
specify a content type.

The CommandSender implementations have been adapted accordingly. Also,
the parameter order of the send methods have been changed so that
mandatory parameters come first.