### PR TITLE
Support sending of failure notification metadata

### DIFF
--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/KafkaCommandSender.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/KafkaCommandSender.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.application.client.kafka;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.eclipse.hono.application.client.CommandSender;
+import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.client.kafka.KafkaRecordHelper;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+
+
+/**
+ * A client for sending commands via a Kafka broker.
+ *
+ */
+public interface KafkaCommandSender extends CommandSender<KafkaMessageContext> {
+
+    /**
+     * Sends a request-response command to a device.
+     * <p>
+     * A device needs to be (successfully) registered before a client can upload any data for it. The device also needs
+     * to be connected to one of Hono's protocol adapters in order for the command to be delivered successfully.
+     * <p>
+     * This method expects a tenant specific response Kafka topic as defined by Hono's
+     * <a href="https://www.eclipse.org/hono/docs/api/command-and-control-kafka/#send-a-requestresponse-command">Kafka
+     * based Command &amp; Control API</a> to exist.
+     * It is the client code's responsibility to correlate any response message(s) sent by the device via that topic
+     * to the request message, e.g. by means of the given <em>correlation ID</em>.
+     *
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The device to send the command to.
+     * @param command The command name.
+     * @param correlationId The identifier to use for correlating the device's response to the request. The identifier
+     *            should ideally be hard to guess in order to prevent malicious devices from creating false responses
+     *            if the same response channel is shared by multiple devices. A good option is to use a
+     *            {@linkplain java.util.UUID#randomUUID() UUID} as the correlation ID.
+     * @param data The command's input data to send to the device or {@code null} if the command requires no input data.
+     * @param contentType The type of the data submitted as part of the command or {@code null} if unknown.
+     * @param failureNotificationMetadata Additional key/value pairs that should be included as headers in a response
+     *         message indicating a failure to forward the command to the device. The keys included in the response will
+     *         be prefixed with {@value KafkaRecordHelper#DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX}{@code .},
+     *         the values will be copied verbatim. This property may be {@code null}.
+     * @param context The currently active OpenTracing span context that is used to trace the execution of this
+     *            operation or {@code null} if no span is currently active.
+     * @return A future indicating the outcome of sending the command message.
+     *         <p>
+     *         The future will be succeeded if the messaging infrastructure has accepted the command for delivery. Note
+     *         that this does not necessarily mean that the device has received and/or processed the command. The latter
+     *         can only be safely determined based on the device's response message.
+     *         <p>
+     *         The future will fail with a {@link ServiceInvocationException} if the messaging infrastructure did not
+     *         accept the command for delivery.
+     * @throws NullPointerException if tenant ID, device ID, command, correlation ID or reply ID are {@code null}.
+     */
+    Future<Void> sendAsyncCommand(
+            String tenantId,
+            String deviceId,
+            String command,
+            String correlationId,
+            Buffer data,
+            String contentType,
+            Map<String, Object> failureNotificationMetadata,
+            SpanContext context);
+
+    /**
+     * Sends a request-response command to a device.
+     * <p>
+     * A device needs to be (successfully) registered before a client can upload any data for it. The device also needs
+     * to be connected to one of Hono's protocol adapters in order for the command to be delivered successfully.
+     * <p>
+     * This method expects a tenant specific response Kafka topic as defined by Hono's
+     * <a href="https://www.eclipse.org/hono/docs/api/command-and-control-kafka/#send-a-requestresponse-command">Kafka
+     * based Command &amp; Control API</a> to exist.
+     *
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The device to send the command to.
+     * @param command The name of the command.
+     * @param data The command's input data to send to the device or {@code null} if the command requires no input data.
+     * @param contentType The type of the data submitted as part of the command or {@code null} if unknown.
+     * @param failureNotificationMetadata Additional key/value pairs that should be included as headers in a response
+     *         message indicating a failure to forward the command to the device. The keys included in the response will
+     *         be prefixed with {@value KafkaRecordHelper#DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX}{@code .},
+     *         the values will be copied verbatim. This property may be {@code null}.
+     * @param timeout The duration after which the send command request times out or {@code null} if a default timeout
+     *                should be used. If the duration is set to 0 then the command request will not time out at all.
+     * @param context The currently active OpenTracing span context that is used to trace the execution of this
+     *            operation or {@code null} if no span is currently active.
+     * @return A future indicating the result of the operation.
+     *         <p>
+     *         The future will be completed with the response message received from the device if it has a status code
+     *         in the 2xx range.
+     *         <p>
+     *         Otherwise, the future will be failed with a {@link ServiceInvocationException} containing an error status
+     *         code as defined in Hono's
+     *         <a href="https://www.eclipse.org/hono/docs/api/command-and-control">Command and Control API</a>.
+     * @throws NullPointerException if any of tenantId, deviceId or command are {@code null}.
+     * @throws IllegalArgumentException if the timeout's duration is negative.
+     */
+    Future<DownstreamMessage<KafkaMessageContext>> sendCommand(
+            String tenantId,
+            String deviceId,
+            String command,
+            Buffer data,
+            String contentType,
+            Map<String, Object> failureNotificationMetadata,
+            Duration timeout,
+            SpanContext context);
+}

--- a/clients/application-kafka/src/test/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSenderTest.java
+++ b/clients/application-kafka/src/test/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSenderTest.java
@@ -374,9 +374,10 @@ public class KafkaBasedCommandSenderTest {
         headers.add(new RecordHeader(MessageHelper.APP_PROPERTY_TENANT_ID, tenantId.getBytes()));
         headers.add(new RecordHeader(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId.getBytes()));
         headers.add(new RecordHeader(MessageHelper.SYS_PROPERTY_CORRELATION_ID, correlationId.getBytes()));
-        Optional.ofNullable(status).ifPresent(s -> headers.add(new RecordHeader(
-                MessageHelper.APP_PROPERTY_STATUS,
-                String.valueOf(s).getBytes())));
+        Optional.ofNullable(status)
+            .ifPresent(s -> headers.add(new RecordHeader(
+                    MessageHelper.APP_PROPERTY_STATUS,
+                    String.valueOf(s).getBytes())));
         return new ConsumerRecord<>(
                 new HonoTopic(HonoTopic.Type.COMMAND_RESPONSE, tenantId).toString(),
                 0,

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommand.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommand.java
@@ -42,11 +42,6 @@ import io.vertx.kafka.client.producer.KafkaHeader;
  */
 public final class KafkaBasedCommand implements Command {
 
-    /**
-     * Prefix of command record headers to be returned in {@link #getDeliveryFailureNotificationProperties()}.
-     */
-    static final String DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX = "delivery-failure-notification-metadata";
-
     private static final Logger LOG = LoggerFactory.getLogger(KafkaBasedCommand.class);
 
     /**
@@ -205,7 +200,8 @@ public final class KafkaBasedCommand implements Command {
      */
     public Map<String, String> getDeliveryFailureNotificationProperties() {
         return record.headers().stream()
-                .filter(header -> header.key().startsWith(DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX))
+                .filter(header -> header.key()
+                        .startsWith(KafkaRecordHelper.DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX))
                 .collect(Collectors.toMap(KafkaHeader::key, header -> header.value().toString(), (v1, v2) -> {
                     LOG.debug("ignoring duplicate delivery notification header with value [{}] for {}", v2, this);
                     return v1;

--- a/clients/command-kafka/src/test/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandTest.java
+++ b/clients/command-kafka/src/test/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandTest.java
@@ -245,18 +245,18 @@ public class KafkaBasedCommandTest {
         final String subject = "doThis";
 
         final List<KafkaHeader> headers = new ArrayList<>(getHeaders(deviceId, subject, correlationId));
-        headers.add(KafkaHeader.header(KafkaBasedCommand.DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX, "v1"));
-        headers.add(KafkaHeader.header(KafkaBasedCommand.DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX, "toBeIgnored"));
-        headers.add(KafkaHeader.header(KafkaBasedCommand.DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX + "-title", "v2"));
+        headers.add(KafkaHeader.header(KafkaRecordHelper.DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX, "v1"));
+        headers.add(KafkaHeader.header(KafkaRecordHelper.DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX, "toBeIgnored"));
+        headers.add(KafkaHeader.header(KafkaRecordHelper.DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX + "-title", "v2"));
         final KafkaConsumerRecord<String, Buffer> commandRecord = getCommandRecord(topic, deviceId,
                 headers);
         final KafkaBasedCommand cmd = KafkaBasedCommand.from(commandRecord);
         final Map<String, String> deliveryFailureNotificationProperties = cmd.getDeliveryFailureNotificationProperties();
         assertThat(deliveryFailureNotificationProperties.size()).isEqualTo(2);
         assertThat(deliveryFailureNotificationProperties
-                .get(KafkaBasedCommand.DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX)).isEqualTo("v1");
+                .get(KafkaRecordHelper.DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX)).isEqualTo("v1");
         assertThat(deliveryFailureNotificationProperties
-                .get(KafkaBasedCommand.DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX + "-title")).isEqualTo("v2");
+                .get(KafkaRecordHelper.DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX + "-title")).isEqualTo("v2");
     }
 
     private List<KafkaHeader> getHeaders(final String deviceId, final String subject) {

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaRecordHelper.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaRecordHelper.java
@@ -34,6 +34,12 @@ import io.vertx.kafka.client.producer.KafkaHeader;
 public final class KafkaRecordHelper {
 
     /**
+     * Prefix to use for marking properties of command messages that should be included in response messages indicating
+     * failure to deliver the command.
+     */
+    public static final String DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX = "delivery-failure-notification-metadata";
+
+    /**
      * The name of the boolean Kafka record header that defines whether a response is required for the command.
      */
     public static final String HEADER_RESPONSE_REQUIRED = "response-required";

--- a/tests/src/test/java/org/eclipse/hono/tests/GenericKafkaSender.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/GenericKafkaSender.java
@@ -64,7 +64,8 @@ public class GenericKafkaSender extends AbstractKafkaBasedMessageSender {
             final String topic,
             final String tenantId,
             final String deviceId,
-            final Buffer payload, final Map<String, Object> properties) {
+            final Buffer payload,
+            final Map<String, Object> properties) {
 
         return super.sendAndWaitForOutcome(topic, tenantId, deviceId, payload, properties, NoopSpan.INSTANCE);
     }
@@ -89,7 +90,8 @@ public class GenericKafkaSender extends AbstractKafkaBasedMessageSender {
             final String topic,
             final String tenantId,
             final String deviceId,
-            final Buffer payload, final List<KafkaHeader> headers) {
+            final Buffer payload,
+            final List<KafkaHeader> headers) {
 
         return super.sendAndWaitForOutcome(topic, tenantId, deviceId, payload, headers, NoopSpan.INSTANCE);
     }


### PR DESCRIPTION
The Kafka specific north bound C&C API supports including *failure notification metadata* to be included in failure response messages created by the command router or adapters. The Kafka based application client has been extended to support including such meta data in command requests.