### PR TITLE
[#3193] Fix tracing of "close consumer" error

### DIFF
--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -720,10 +720,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
             // request and the CommandConsumer from the current request has not been closed yet
             return Optional.ofNullable(commandConsumerTracker.result())
                     .map(consumer -> consumer.close(currentSpan.context())
-                            .otherwise(thr -> {
-                                TracingHelper.logError(currentSpan, thr);
-                                return (Void) null;
-                            }))
+                            .otherwise(thr -> null))
                     .orElseGet(Future::succeededFuture);
         })
         .map(proceed -> {
@@ -794,7 +791,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
             final boolean responseClosedPrematurely = ctx.response().closed();
             final Future<Void> commandConsumerClosedTracker = Optional.ofNullable(commandConsumerTracker.result())
                     .map(consumer -> consumer.close(currentSpan.context())
-                            .onFailure(thr -> TracingHelper.logError(currentSpan, thr)))
+                            .otherwise(thr -> null))
                     .orElseGet(Future::succeededFuture);
             final CommandContext commandContext = ctx.get(CommandContext.KEY_COMMAND_CONTEXT);
             if (commandContext != null) {
@@ -885,7 +882,6 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                 cancelCommandReceptionTimer(ctx);
                 // close command consumer
                 messageConsumer.close(currentSpan.context())
-                        .onFailure(thr -> TracingHelper.logError(currentSpan, thr))
                         .onComplete(r -> {
                             currentSpan.finish();
                             logResponseGettingClosedPrematurely(ctx);
@@ -1000,9 +996,8 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                 .buildChildSpan(tracer, uploadMessageSpan.context(),
                         "create consumer and wait for command", getTypeName())
                 .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
-                .withTag(TracingHelper.TAG_TENANT_ID, tenantObject.getTenantId())
-                .withTag(TracingHelper.TAG_DEVICE_ID, deviceId)
                 .start();
+        TracingHelper.setDeviceTags(waitForCommandSpan, tenantObject.getTenantId(), deviceId);
 
         final Handler<CommandContext> commandHandler = commandContext -> {
 
@@ -1010,11 +1005,10 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                     .buildFollowsFromSpan(tracer, waitForCommandSpan.context(), "process received command")
                     .withTag(Tags.COMPONENT.getKey(), getTypeName())
                     .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
-                    .withTag(TracingHelper.TAG_TENANT_ID, tenantObject.getTenantId())
-                    .withTag(TracingHelper.TAG_DEVICE_ID, deviceId)
                     // add reference to the trace started in the command router when the command was first received
                     .addReference(References.FOLLOWS_FROM, commandContext.getTracingContext())
                     .start();
+            TracingHelper.setDeviceTags(processCommandSpan, tenantObject.getTenantId(), deviceId);
 
             Tags.COMPONENT.set(commandContext.getTracingSpan(), getTypeName());
             commandContext.logCommandToSpan(processCommandSpan);
@@ -1104,18 +1098,16 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                         // if the request was not responded already, add a timer for triggering an empty response
                         addCommandReceptionTimer(ctx, requestProcessed, responseReady, ttdSecs, waitForCommandSpan);
                     }
-                    // wrap the consumer so that when it is closed, a separate FOLLOWS_FROM span is created
-                    // for unregistering the command consumer (which is something the parent request span doesn't wait for)
+                    // wrap the consumer to be able to create a separate span on closing the consumer (errors should just be logged on that span, not the parent)
                     return new CommandConsumer() {
                         @Override
-                        public Future<Void> close(final SpanContext ignored) {
+                        public Future<Void> close(final SpanContext spanContext) {
                             final Span closeConsumerSpan = TracingHelper
-                                    .buildFollowsFromSpan(tracer, waitForCommandSpan.context(), "close consumer")
-                                    .withTag(Tags.COMPONENT.getKey(), getTypeName())
+                                    .buildChildSpan(tracer, spanContext, "close command consumer",
+                                            getTypeName())
                                     .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
-                                    .withTag(TracingHelper.TAG_TENANT_ID, tenantObject.getTenantId())
-                                    .withTag(TracingHelper.TAG_DEVICE_ID, deviceId)
                                     .start();
+                            TracingHelper.setDeviceTags(closeConsumerSpan, tenantObject.getTenantId(), deviceId);
                             return consumer.close(closeConsumerSpan.context())
                                     .onFailure(thr -> TracingHelper.logError(closeConsumerSpan, thr))
                                     .onComplete(ar -> closeConsumerSpan.finish());


### PR DESCRIPTION
This fixes #3193.
Don't set error tag on parent "upload telemetry/event" span in case of a "close consumer" error.
Also create "close consumer" span as direct child of "upload telemetry/event" span. This corresponds to the change a while back that made "upload telemetry/event" wait on the "close consumer" completion (https://github.com/eclipse/hono/commit/5d49e20cd9fc08db80ce79364d5380514df84080#diff-8a5c90291d6bfbbcbd7ae69c43de9a5a5e77532137e677c23fd3e655545d67c5R719).