### PR TITLE
[#3214] Decouple readiness checks from verticle deployment

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
@@ -782,20 +782,20 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
     @Override
     public void registerReadinessChecks(final HealthCheckHandler handler) {
 
-        if (commandConsumerFactory instanceof ServiceClient) {
-            ((ServiceClient) commandConsumerFactory).registerReadinessChecks(handler);
+        if (commandConsumerFactory instanceof ServiceClient client) {
+            client.registerReadinessChecks(handler);
         }
-        if (tenantClient instanceof ServiceClient) {
-            ((ServiceClient) tenantClient).registerReadinessChecks(handler);
+        if (tenantClient instanceof ServiceClient client) {
+            client.registerReadinessChecks(handler);
         }
-        if (registrationClient instanceof ServiceClient) {
-            ((ServiceClient) registrationClient).registerReadinessChecks(handler);
+        if (registrationClient instanceof ServiceClient client) {
+            client.registerReadinessChecks(handler);
         }
-        if (credentialsClient instanceof ServiceClient) {
-            ((ServiceClient) credentialsClient).registerReadinessChecks(handler);
+        if (credentialsClient instanceof ServiceClient client) {
+            client.registerReadinessChecks(handler);
         }
-        if (commandRouterClient instanceof ServiceClient) {
-            ((ServiceClient) commandRouterClient).registerReadinessChecks(handler);
+        if (commandRouterClient instanceof ServiceClient client) {
+            client.registerReadinessChecks(handler);
         }
         messagingClientProviders.registerReadinessChecks(handler);
     }
@@ -810,20 +810,20 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
     public void registerLivenessChecks(final HealthCheckHandler handler) {
         registerEventLoopBlockedCheck(handler);
 
-        if (commandConsumerFactory instanceof ServiceClient) {
-            ((ServiceClient) commandConsumerFactory).registerLivenessChecks(handler);
+        if (commandConsumerFactory instanceof ServiceClient client) {
+            client.registerLivenessChecks(handler);
         }
-        if (tenantClient instanceof ServiceClient) {
-            ((ServiceClient) tenantClient).registerLivenessChecks(handler);
+        if (tenantClient instanceof ServiceClient client) {
+            client.registerLivenessChecks(handler);
         }
-        if (registrationClient instanceof ServiceClient) {
-            ((ServiceClient) registrationClient).registerLivenessChecks(handler);
+        if (registrationClient instanceof ServiceClient client) {
+            client.registerLivenessChecks(handler);
         }
-        if (credentialsClient instanceof ServiceClient) {
-            ((ServiceClient) credentialsClient).registerLivenessChecks(handler);
+        if (credentialsClient instanceof ServiceClient client) {
+            client.registerLivenessChecks(handler);
         }
-        if (commandRouterClient instanceof ServiceClient) {
-            ((ServiceClient) commandRouterClient).registerLivenessChecks(handler);
+        if (commandRouterClient instanceof ServiceClient client) {
+            client.registerLivenessChecks(handler);
         }
         messagingClientProviders.registerLivenessChecks(handler);
     }

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
@@ -112,17 +112,16 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender<Buf
     @SuppressWarnings("rawtypes")
     @Override
     public Future<Void> stop() {
-        // assemble futures for closing the command response consumers
-        final List<Future> stopKafkaClientsTracker = commandResponseConsumers.values().stream()
-                .map(HonoKafkaConsumer::stop)
-                .collect(Collectors.toList());
-        commandResponseConsumers.clear();
 
-        // add future for closing command producer
-        stopKafkaClientsTracker.add(super.stop());
-
-        return CompositeFuture.join(stopKafkaClientsTracker)
-                .mapEmpty();
+        return super.stop()
+                .compose(ok -> {
+                    // assemble futures for closing the command response consumers
+                    final List<Future> stopKafkaClientsTracker = commandResponseConsumers.values().stream()
+                            .map(HonoKafkaConsumer::stop)
+                            .collect(Collectors.toList());
+                    commandResponseConsumers.clear();
+                    return CompositeFuture.join(stopKafkaClientsTracker).mapEmpty();
+                });
     }
 
     /**
@@ -424,11 +423,14 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender<Buf
             getCommandResponseHandler(tenantId)
                     .handle(new KafkaDownstreamMessage(record));
         };
+        final Promise<Void> readyTracker = Promise.promise();
         final HonoKafkaConsumer<Buffer> consumer = new HonoKafkaConsumer<>(vertx, Set.of(topic), recordHandler, consumerConfig);
         consumer.setPollTimeout(Duration.ofMillis(this.consumerConfig.getPollTimeout()));
         Optional.ofNullable(kafkaConsumerSupplier)
                 .ifPresent(consumer::setKafkaConsumerSupplier);
+        consumer.addOnKafkaConsumerReadyHandler(readyTracker);
         return consumer.start()
+                .compose(ok -> readyTracker.future())
                 .recover(error -> {
                     LOGGER.debug("error creating command response consumer for tenant [{}]", tenantId, error);
                     TracingHelper.logError(span, "error creating command response consumer", error);

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
@@ -113,11 +113,6 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender<Buf
     @Override
     public Future<Void> stop() {
 
-        if (lifecycleStatus.isStopped()) {
-            // nothing to do
-            return Future.succeededFuture();
-        }
-
         return lifecycleStatus.runStopAttempt(() -> {
             // assemble futures for closing the command response consumers
             final List<Future> stopConsumersTracker = commandResponseConsumers.values().stream()

--- a/clients/application-kafka/src/test/resources/logback-test.xml
+++ b/clients/application-kafka/src/test/resources/logback-test.xml
@@ -28,4 +28,7 @@
     <appender-ref ref="STDOUT" />
   </root>
 
+  <logger name="org.apache.kafka" level="ERROR"/>
+  <logger name="org.eclipse.hono" level="INFO"/>
+
 </configuration>

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumer.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumer.java
@@ -367,11 +367,6 @@ public class KafkaBasedInternalCommandConsumer implements InternalCommandConsume
     @Override
     public Future<Void> stop() {
 
-        if (lifecycleStatus.isStopped()) {
-            // nothing to do
-            return Future.succeededFuture();
-        }
-
         return lifecycleStatus.runStopAttempt(() -> {
             retryCreateTopic.set(false);
             vertx.cancelTimer(retryCreateTopicTimerId);

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumer.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumer.java
@@ -372,14 +372,13 @@ public class KafkaBasedInternalCommandConsumer implements InternalCommandConsume
             return Future.succeededFuture();
         }
 
-        final var result = lifecycleStatus.newStopAttempt();
-        retryCreateTopic.set(false);
-        vertx.cancelTimer(retryCreateTopicTimerId);
+        return lifecycleStatus.runStopAttempt(() -> {
+            retryCreateTopic.set(false);
+            vertx.cancelTimer(retryCreateTopicTimerId);
 
-        CompositeFuture.all(closeAdminClient(), closeConsumer())
-            .map((Void) null)
-            .onSuccess(ok -> lifecycleStatus.setStopped());
-        return result.future();
+            return CompositeFuture.all(closeAdminClient(), closeConsumer())
+                .mapEmpty();
+        });
     }
 
     private Future<Void> closeAdminClient() {

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumer.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumer.java
@@ -46,15 +46,18 @@ import org.eclipse.hono.client.kafka.tracing.KafkaTracingHelper;
 import org.eclipse.hono.client.registry.TenantClient;
 import org.eclipse.hono.client.registry.TenantDisabledOrNotRegisteredException;
 import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.LifecycleStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -84,12 +87,14 @@ public class KafkaBasedInternalCommandConsumer implements InternalCommandConsume
     private final Tracer tracer;
     private final CommandResponseSender commandResponseSender;
     private final TenantClient tenantClient;
-    private final AtomicBoolean isTopicCreated = new AtomicBoolean(false);
     private final AtomicBoolean retryCreateTopic = new AtomicBoolean(true);
     /**
      * Key is the tenant id, value is a Map with partition index as key and offset as value.
      */
     private final Map<String, Map<Integer, Long>> lastHandledPartitionOffsetsPerTenant = new HashMap<>();
+//    private final Promise<Void> kafkaConsumerReadyTracker = Promise.promise();
+//    private final AtomicBoolean keepTryingToCreateKafkaClients = new AtomicBoolean(true);
+    private final LifecycleStatus lifecycleStatus = new LifecycleStatus();
 
     private KafkaConsumer<String, Buffer> consumer;
     private Admin adminClient;
@@ -136,6 +141,7 @@ public class KafkaBasedInternalCommandConsumer implements InternalCommandConsume
         final KafkaClientFactory kafkaClientFactory = new KafkaClientFactory(vertx);
         kafkaAdminClientCreator = () -> kafkaClientFactory.createClientWithRetries(
                 () -> Admin.create(new HashMap<>(adminClientConfig)),
+                lifecycleStatus::isStarting,
                 bootstrapServersConfig,
                 KafkaClientFactory.UNLIMITED_RETRIES_DURATION);
 
@@ -148,6 +154,7 @@ public class KafkaBasedInternalCommandConsumer implements InternalCommandConsume
         this.clientId = consumerConfig.get(ConsumerConfig.CLIENT_ID_CONFIG);
         consumerCreator = () -> kafkaClientFactory.createClientWithRetries(
                 () -> KafkaConsumer.create(vertx, consumerConfig),
+                lifecycleStatus::isStarting,
                 consumerConfig.get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG),
                 KafkaClientFactory.UNLIMITED_RETRIES_DURATION);
     }
@@ -204,8 +211,39 @@ public class KafkaBasedInternalCommandConsumer implements InternalCommandConsume
         return this;
     }
 
+    /**
+     * Adds a handler to be invoked with a succeeded future once the Kafka consumer is ready to be used.
+     *
+     * @param handler The handler to invoke. The handler will never be invoked with a failed future.
+     */
+    public final void addOnKafkaConsumerReadyHandler(final Handler<AsyncResult<Void>> handler) {
+        if (handler != null) {
+            lifecycleStatus.addOnStartedHandler(handler);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This methods triggers the creation of the internal command topic and a corresponding Kafka consumer in the
+     * background. A new attempt to create the topic and the consumer is made periodically until creation succeeds
+     * or the {@link #stop()} method has been invoked.
+     * <p>
+     * Client code may {@linkplain #addOnKafkaConsumerReadyHandler(Handler) register a dedicated handler}
+     * to be notified once the consumer is up and running.
+     *
+     * @return A succeeded future. Note that the successful completion of the returned future does not
+     *         mean that the consumer will be ready to receive messages from the broker.
+     */
     @Override
     public Future<Void> start() {
+
+        if (lifecycleStatus.isStarting()) {
+            return Future.succeededFuture();
+        } else if (!lifecycleStatus.setStarting()) {
+            return Future.failedFuture(new IllegalStateException("consumer is already started/stopping"));
+        }
+
         if (context == null) {
             context = Vertx.currentContext();
             if (context == null) {
@@ -213,33 +251,32 @@ public class KafkaBasedInternalCommandConsumer implements InternalCommandConsume
             }
         }
         // trigger creation of admin client, adapter specific topic and consumer
-        return kafkaAdminClientCreator.get()
-                .onFailure(thr -> LOG.error("admin client creation failed", thr))
-                .compose(client -> {
-                    adminClient = client;
-                    return createTopic();
-                })
-                .recover(e -> retryCreateTopic())
-                .compose(v -> {
-                    isTopicCreated.set(true);
-                    // create consumer
-                    return consumerCreator.get()
-                            .onFailure(thr -> LOG.error("consumer creation failed", thr));
-                })
-                .compose(client -> {
-                    consumer = client;
-                    Optional.ofNullable(metricsSupport).ifPresent(ms -> ms.registerKafkaConsumer(consumer.unwrap()));
-                    return subscribeToTopic();
-                });
+        kafkaAdminClientCreator.get()
+            .onFailure(thr -> LOG.error("admin client creation failed", thr))
+            .compose(client -> {
+                adminClient = client;
+                return createTopic();
+            })
+            .recover(e -> retryCreateTopic())
+            .compose(v -> consumerCreator.get()
+                    .onFailure(thr -> LOG.error("consumer creation failed", thr)))
+            .compose(client -> {
+                consumer = client;
+                Optional.ofNullable(metricsSupport).ifPresent(ms -> ms.registerKafkaConsumer(consumer.unwrap()));
+                return subscribeToTopic();
+            })
+            .onSuccess(ok -> lifecycleStatus.setStarted());
+
+        return Future.succeededFuture();
     }
 
     @Override
     public void registerReadinessChecks(final HealthCheckHandler readinessHandler) {
         LOG.trace("registering readiness check using kafka based internal command consumer [adapter instance id: {}]",
                 adapterInstanceId);
-        readinessHandler.register(String.format("internal-command-consumer[%s]-readiness", adapterInstanceId),
+        readinessHandler.register("internal-command-consumer[%s]-readiness".formatted(adapterInstanceId),
                 status -> {
-                    if (isTopicCreated.get()) {
+                    if (lifecycleStatus.isStarted()) {
                         status.tryComplete(Status.OK());
                     } else {
                         LOG.debug("readiness check failed [internal command topic is not created]");
@@ -321,20 +358,43 @@ public class KafkaBasedInternalCommandConsumer implements InternalCommandConsume
         return new HonoTopic(HonoTopic.Type.COMMAND_INTERNAL, adapterInstanceId).toString();
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Closes the Kafka admin client and consumer.
+     *
+     * @return A future indicating the outcome of the operation.
+     *         The future will be succeeded once this component is stopped.
+     */
     @Override
     public Future<Void> stop() {
+
+        if (lifecycleStatus.isStopped()) {
+            // nothing to do
+            return Future.succeededFuture();
+        }
+
+        final Promise<Void> result = Promise.promise();
+        lifecycleStatus.addOnStoppedHandler(result);
+        if (lifecycleStatus.isStopping()) {
+            return result.future();
+        }
+
+        lifecycleStatus.setStopping();
         retryCreateTopic.set(false);
         vertx.cancelTimer(retryCreateTopicTimerId);
 
-        if (consumer == null) {
-            return Future.failedFuture("not started");
-        }
-
-        return CompositeFuture.all(closeAdminClient(), closeConsumer())
-                .mapEmpty();
+        lifecycleStatus.addOnStoppedHandler(result);
+        CompositeFuture.all(closeAdminClient(), closeConsumer())
+            .map((Void) null)
+            .onSuccess(ok -> lifecycleStatus.setStopped());
+        return result.future();
     }
 
     private Future<Void> closeAdminClient() {
+        if (adminClient == null) {
+            return Future.succeededFuture();
+        }
         final Promise<Void> adminClientClosePromise = Promise.promise();
         LOG.debug("stop: close admin client");
         context.executeBlocking(future -> {
@@ -346,14 +406,14 @@ public class KafkaBasedInternalCommandConsumer implements InternalCommandConsume
     }
 
     private Future<Void> closeConsumer() {
-        final Promise<Void> consumerClosePromise = Promise.promise();
+        if (consumer == null) {
+            return Future.succeededFuture();
+        }
         LOG.debug("stop: close consumer");
-        consumer.close(consumerClosePromise);
-        consumerClosePromise.future().onComplete(ar -> {
+        return consumer.close().onComplete(ar -> {
             LOG.debug("consumer closed");
             Optional.ofNullable(metricsSupport).ifPresent(ms -> ms.unregisterKafkaConsumer(consumer.unwrap()));
         });
-        return consumerClosePromise.future();
     }
 
     void handleCommandMessage(final KafkaConsumerRecord<String, Buffer> record) {

--- a/clients/command-kafka/src/test/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSenderTest.java
+++ b/clients/command-kafka/src/test/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSenderTest.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopSpan;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.EventBus;
@@ -99,75 +100,79 @@ public class KafkaBasedCommandResponseSenderTest {
                 status);
         commandResponse.setAdditionalProperties(additionalProperties);
 
+        final TenantObject tenant = TenantObject.from(tenantId);
+        tenant.setResourceLimits(new ResourceLimits().setMaxTtlCommandResponse(10L));
         final Span span = TracingMockSupport.mockSpan();
         final Tracer tracer = TracingMockSupport.mockTracer(span);
         final var mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);
         final var factory = CachingKafkaProducerFactory
                 .testFactory(vertx, (n, c) -> KafkaClientUnitTestHelper.newKafkaProducer(mockProducer));
+        final Promise<Void> readyTracker = Promise.promise();
         final var sender = new KafkaBasedCommandResponseSender(vertx, factory, kafkaProducerConfig, tracer);
-        final TenantObject tenant = TenantObject.from(tenantId);
-        tenant.setResourceLimits(new ResourceLimits().setMaxTtlCommandResponse(10L));
+        sender.addOnKafkaProducerReadyHandler(readyTracker);
 
         // WHEN sending a command response
-        sender.sendCommandResponse(
+        sender.start()
+            .compose(ok -> readyTracker.future())
+            .compose(ok -> sender.sendCommandResponse(
                 tenant,
                 new RegistrationAssertion(deviceId),
-                commandResponse, NoopSpan.INSTANCE.context())
-                .onComplete(ctx.succeeding(t -> {
-                    ctx.verify(() -> {
-                        // THEN the producer record is created from the given values...
-                        final ProducerRecord<String, Buffer> record = mockProducer.history().get(0);
+                commandResponse, NoopSpan.INSTANCE.context()))
+            .onComplete(ctx.succeeding(t -> {
+                ctx.verify(() -> {
+                    // THEN the producer record is created from the given values...
+                    final ProducerRecord<String, Buffer> record = mockProducer.history().get(0);
 
-                        assertThat(record.key()).isEqualTo(deviceId);
-                        assertThat(record.topic())
-                                .isEqualTo(new HonoTopic(HonoTopic.Type.COMMAND_RESPONSE, tenantId).toString());
-                        assertThat(record.value().toString()).isEqualTo(payload);
+                    assertThat(record.key()).isEqualTo(deviceId);
+                    assertThat(record.topic())
+                            .isEqualTo(new HonoTopic(HonoTopic.Type.COMMAND_RESPONSE, tenantId).toString());
+                    assertThat(record.value().toString()).isEqualTo(payload);
 
-                        //Verify if the record contains the necessary headers.
-                        final Headers headers = record.headers();
-                        KafkaClientUnitTestHelper.assertUniqueHeaderWithExpectedValue(
-                                headers,
-                                MessageHelper.APP_PROPERTY_TENANT_ID,
-                                tenantId);
-                        KafkaClientUnitTestHelper.assertUniqueHeaderWithExpectedValue(
-                                headers,
-                                MessageHelper.APP_PROPERTY_DEVICE_ID,
-                                deviceId);
-                        KafkaClientUnitTestHelper.assertUniqueHeaderWithExpectedValue(
-                                headers,
-                                MessageHelper.SYS_PROPERTY_CORRELATION_ID,
-                                correlationId);
-                        KafkaClientUnitTestHelper.assertUniqueHeaderWithExpectedValue(
-                                headers,
-                                MessageHelper.APP_PROPERTY_STATUS,
-                                status);
-                        KafkaClientUnitTestHelper.assertUniqueHeaderWithExpectedValue(
-                                headers,
-                                MessageHelper.SYS_PROPERTY_CONTENT_TYPE,
-                                contentType);
+                    //Verify if the record contains the necessary headers.
+                    final Headers headers = record.headers();
+                    KafkaClientUnitTestHelper.assertUniqueHeaderWithExpectedValue(
+                            headers,
+                            MessageHelper.APP_PROPERTY_TENANT_ID,
+                            tenantId);
+                    KafkaClientUnitTestHelper.assertUniqueHeaderWithExpectedValue(
+                            headers,
+                            MessageHelper.APP_PROPERTY_DEVICE_ID,
+                            deviceId);
+                    KafkaClientUnitTestHelper.assertUniqueHeaderWithExpectedValue(
+                            headers,
+                            MessageHelper.SYS_PROPERTY_CORRELATION_ID,
+                            correlationId);
+                    KafkaClientUnitTestHelper.assertUniqueHeaderWithExpectedValue(
+                            headers,
+                            MessageHelper.APP_PROPERTY_STATUS,
+                            status);
+                    KafkaClientUnitTestHelper.assertUniqueHeaderWithExpectedValue(
+                            headers,
+                            MessageHelper.SYS_PROPERTY_CONTENT_TYPE,
+                            contentType);
 
-                        final var creationTimeHeader = headers.headers(MessageHelper.SYS_PROPERTY_CREATION_TIME);
-                        assertThat(creationTimeHeader).hasSize(1);
-                        final Long creationTimeMillis = Json.decodeValue(
-                                Buffer.buffer(creationTimeHeader.iterator().next().value()),
-                                Long.class);
-                        assertThat(creationTimeMillis).isGreaterThan(0L);
-                        KafkaClientUnitTestHelper.assertUniqueHeaderWithExpectedValue(
-                                headers,
-                                MessageHelper.SYS_HEADER_PROPERTY_TTL,
-                                10000L);
-                        KafkaClientUnitTestHelper.assertUniqueHeaderWithExpectedValue(
-                                headers,
-                                additionalHeader1Name,
-                                additionalHeader1Value);
-                        KafkaClientUnitTestHelper.assertUniqueHeaderWithExpectedValue(
-                                headers,
-                                additionalHeader2Name,
-                                additionalHeader2Value);
-                        verify(span).finish();
-                    });
-                    ctx.completeNow();
-                }));
+                    final var creationTimeHeader = headers.headers(MessageHelper.SYS_PROPERTY_CREATION_TIME);
+                    assertThat(creationTimeHeader).hasSize(1);
+                    final Long creationTimeMillis = Json.decodeValue(
+                            Buffer.buffer(creationTimeHeader.iterator().next().value()),
+                            Long.class);
+                    assertThat(creationTimeMillis).isGreaterThan(0L);
+                    KafkaClientUnitTestHelper.assertUniqueHeaderWithExpectedValue(
+                            headers,
+                            MessageHelper.SYS_HEADER_PROPERTY_TTL,
+                            10000L);
+                    KafkaClientUnitTestHelper.assertUniqueHeaderWithExpectedValue(
+                            headers,
+                            additionalHeader1Name,
+                            additionalHeader1Value);
+                    KafkaClientUnitTestHelper.assertUniqueHeaderWithExpectedValue(
+                            headers,
+                            additionalHeader2Name,
+                            additionalHeader2Value);
+                    verify(span).finish();
+                });
+                ctx.completeNow();
+            }));
     }
 
     /**

--- a/clients/kafka-common/pom.xml
+++ b/clients/kafka-common/pom.xml
@@ -50,6 +50,10 @@
       <artifactId>micrometer-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-health</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-core</artifactId>
       <optional>true</optional>

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AsyncHandlingAutoCommitKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AsyncHandlingAutoCommitKafkaConsumer.java
@@ -327,9 +327,10 @@ public class AsyncHandlingAutoCommitKafkaConsumer<V> extends HonoKafkaConsumer<V
 
     @Override
     public Future<Void> start() {
-        return super.start().onComplete(v -> {
+        addOnKafkaConsumerReadyHandler(ready -> {
             periodicCommitTimerId = vertx.setPeriodic(commitIntervalMillis, tid -> doPeriodicCommit());
         });
+        return super.start();
     }
 
     @Override

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumer.java
@@ -963,13 +963,7 @@ public class HonoKafkaConsumer<V> implements Lifecycle, ServiceClient {
             return Future.succeededFuture();
         }
 
-        final Promise<Void> result = Promise.promise();
-        lifecycleStatus.addOnStoppedHandler(result);
-        if (lifecycleStatus.isStopping()) {
-            return result.future();
-        }
-
-        lifecycleStatus.setStopping();
+        final var result = lifecycleStatus.newStopAttempt();
         if (pollPauseTimeoutTimerId != null) {
             vertx.cancelTimer(pollPauseTimeoutTimerId);
             pollPauseTimeoutTimerId = null;

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumer.java
@@ -33,6 +33,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
@@ -42,19 +43,25 @@ import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.kafka.KafkaClientFactory;
 import org.eclipse.hono.client.kafka.KafkaRecordHelper;
 import org.eclipse.hono.client.kafka.metrics.KafkaClientMetricsSupport;
+import org.eclipse.hono.client.util.ServiceClient;
 import org.eclipse.hono.util.Futures;
 import org.eclipse.hono.util.Lifecycle;
+import org.eclipse.hono.util.LifecycleStatus;
 import org.eclipse.hono.util.Pair;
+import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.ext.healthchecks.HealthCheckHandler;
+import io.vertx.ext.healthchecks.Status;
 import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.common.impl.Helper;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
@@ -71,7 +78,7 @@ import io.vertx.kafka.client.consumer.impl.KafkaReadStreamImpl;
  * @param <V> The type of record payload this consumer supports.
  */
 @RegisterForReflection(targets = io.vertx.kafka.client.consumer.impl.KafkaReadStreamImpl.class)
-public class HonoKafkaConsumer<V> implements Lifecycle {
+public class HonoKafkaConsumer<V> implements Lifecycle, ServiceClient {
 
     /**
      * The default timeout to use when polling the broker for messages.
@@ -102,11 +109,14 @@ public class HonoKafkaConsumer<V> implements Lifecycle {
      * The pattern of topic names that this consumer subscribes to.
      */
     protected final Pattern topicPattern;
+    /**
+     * This component's current life cycle state.
+     */
+    protected final LifecycleStatus lifecycleStatus = new LifecycleStatus();
 
     private final AtomicReference<Pair<Promise<Void>, Promise<Void>>> subscriptionUpdatedAndPartitionsAssignedPromiseRef = new AtomicReference<>();
     private final AtomicBoolean pollingPaused = new AtomicBoolean();
     private final AtomicBoolean recordFetchingPaused = new AtomicBoolean();
-    private final AtomicBoolean stopCalled = new AtomicBoolean();
 
     private Handler<KafkaConsumerRecord<String, V>> recordHandler;
     private KafkaConsumer<String, V> kafkaConsumer;
@@ -225,7 +235,7 @@ public class HonoKafkaConsumer<V> implements Lifecycle {
      */
     public final void setRecordHandler(final Handler<KafkaConsumerRecord<String, V>> handler) {
         Objects.requireNonNull(handler);
-        if (isStarted()) {
+        if (!lifecycleStatus.isStopped()) {
             throw new IllegalStateException("Record handler can only be set if consumer has not been started yet");
         }
         this.recordHandler = handler;
@@ -239,13 +249,24 @@ public class HonoKafkaConsumer<V> implements Lifecycle {
      * @throws IllegalStateException if this consumer is already started.
      */
     protected final void addTopic(final String topicName) {
-        Objects.requireNonNull(topics);
-        if (isStarted()) {
+        Objects.requireNonNull(topicName);
+        if (!lifecycleStatus.isStopped()) {
             throw new IllegalStateException("Topics can only be set if consumer has not been started yet");
         } else if (topics == null) {
             throw new IllegalStateException("Cannot add topic on consumer which has been created with a topic pattern");
         }
         this.topics.add(topicName);
+    }
+
+    /**
+     * Adds a handler to be invoked with a succeeded future once the Kafka consumer is ready to be used.
+     *
+     * @param handler The handler to invoke. The handler will never be invoked with a failed future.
+     */
+    public final void addOnKafkaConsumerReadyHandler(final Handler<AsyncResult<Void>> handler) {
+        if (handler != null) {
+            lifecycleStatus.addOnStartedHandler(handler);
+        }
     }
 
     /**
@@ -492,74 +513,132 @@ public class HonoKafkaConsumer<V> implements Lifecycle {
     }
 
     /**
-     * Checks if this consumer has been started already.
-     *
-     * @return {@code true} if this consumer's start method has been invoked already.
+     * {@inheritDoc}
+     * <p>
+     * Does nothing.
      */
-    protected final boolean isStarted() {
-        return context != null;
+    @Override
+    public void registerLivenessChecks(final HealthCheckHandler livenessHandler) {
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Registers a check for the Kafka consumer being ready to be used.
+     */
+    @Override
+    public void registerReadinessChecks(final HealthCheckHandler readinessHandler) {
+        readinessHandler.register(
+                "notification-kafka-consumer-creation-%s".formatted(UUID.randomUUID()),
+                status -> status.tryComplete(new Status().setOk(lifecycleStatus.isStarted())));
+    }
+
+    /**
+     * Checks if this consumer is ready to be used.
+     *
+     * @return A response indicating if this consumer is ready to be used (UP) or not (DOWN).
+     */
+    public final HealthCheckResponse checkReadiness() {
+        return HealthCheckResponse.builder()
+                .name("kafka-consumer-status")
+                .status(lifecycleStatus.isStarted())
+                .build();
+    }
+
+    private Future<KafkaConsumer<String, V>> initConsumer(final KafkaConsumer<String, V> consumer) {
+
+        final Promise<KafkaConsumer<String, V>> initResult = Promise.promise();
+
+        Optional.ofNullable(metricsSupport).ifPresent(ms -> ms.registerKafkaConsumer(consumer.unwrap()));
+        consumer.handler(record -> {
+            if (!initResult.future().isComplete()) {
+                LOG.debug("""
+                        postponing record handling until consumer has been initialized \
+                        [topic: {}, partition: {}, offset: {}]
+                        """,
+                        record.topic(), record.partition(), record.offset());
+            }
+            initResult.future().onSuccess(ok -> {
+                if (respectTtl && KafkaRecordHelper.isTtlElapsed(record.headers())) {
+                    onRecordHandlerSkippedForExpiredRecord(record);
+                } else {
+                    try {
+                        recordHandler.handle(record);
+                    } catch (final Exception e) {
+                        LOG.warn("error handling record [topic: {}, partition: {}, offset: {}, headers: {}]",
+                                record.topic(), record.partition(), record.offset(), record.headers(), e);
+                    }
+                }
+            });
+        });
+        consumer.batchHandler(this::onBatchOfRecordsReceived);
+        consumer.exceptionHandler(error -> LOG.error("consumer error occurred [client-id: {}]", getClientId(), error));
+        installRebalanceListeners();
+        // let polls finish quickly until initConsumer() is completed
+        consumer.asStream().pollTimeout(Duration.ofMillis(10));
+        // subscribe and wait for re-balance to make sure that when initConsumer() completes,
+        // the consumer is actually ready to receive records already
+        subscribeAndWaitForRebalance()
+                .onSuccess(ok -> {
+                    consumer.asStream().pollTimeout(pollTimeout);
+                    logSubscribedTopicsWhenConsumerIsReady();
+                    initResult.complete(consumer);
+                })
+                .onFailure(initResult::fail);
+        return initResult.future();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This methods triggers the creation of a Kafka consumer in the background. A new attempt to create the
+     * consumer is made periodically until creation succeeds or the {@link #stop()} method has been invoked.
+     * <p>
+     * Client code may {@linkplain #addOnKafkaConsumerReadyHandler(Handler) register a dedicated handler}
+     * to be notified once the consumer is up and running.
+     *
+     * @return A future indicating the outcome of the operation.
+     *         The future will be failed with an {@link IllegalStateException} if the record handler is not set
+     *         or if this component is already started or is in the process of being stopped.
+     *         Note that the successful completion of the returned future does not mean that the consumer will be
+     *         ready to receive messages from the broker.
+     */
     @Override
     public Future<Void> start() {
+
         if (recordHandler == null) {
             throw new IllegalStateException("Record handler must be set");
         }
+        if (lifecycleStatus.isStarting()) {
+            LOG.debug("already starting consumer");
+            return Future.succeededFuture();
+        } else if (!lifecycleStatus.setStarting()) {
+            return Future.failedFuture(new IllegalStateException("consumer is already started/stopping"));
+        }
+
         context = vertx.getOrCreateContext();
-        final Promise<Void> startPromise = Promise.promise();
+        final Supplier<KafkaConsumer<String, V>> consumerSupplier = () -> Optional.ofNullable(kafkaConsumerSupplier)
+                .map(s -> KafkaConsumer.create(vertx, s.get()))
+                .orElseGet(() -> KafkaConsumer.create(vertx, consumerConfig));
+
         runOnContext(v -> {
-            // create KafkaConsumer here so that it is created in the Vert.x context of the start() method (KafkaConsumer uses vertx.getOrCreateContext())
-            Optional.ofNullable(kafkaConsumerSupplier)
-                    .map(supplier -> Future.succeededFuture(KafkaConsumer.create(vertx, supplier.get())))
-                    .orElseGet(() -> {
-                        final KafkaClientFactory kafkaClientFactory = new KafkaClientFactory(vertx);
-                        return kafkaClientFactory.createKafkaConsumerWithRetries(consumerConfig,
-                                consumerCreationRetriesTimeout);
-                    })
-                    .onFailure(thr -> {
-                        LOG.error("error creating consumer [client-id: {}]", getClientId(), thr);
-                        startPromise.fail(thr);
-                    })
-                    .onSuccess(consumer -> {
-                        kafkaConsumer = consumer;
-                        Optional.ofNullable(metricsSupport).ifPresent(ms -> ms.registerKafkaConsumer(kafkaConsumer.unwrap()));
-                        kafkaConsumer.handler(record -> {
-                            if (!startPromise.future().isComplete()) {
-                                LOG.debug("postponing record handling until start() is completed [topic: {}, partition: {}, offset: {}]",
-                                        record.topic(), record.partition(), record.offset());
-                            }
-                            startPromise.future().onSuccess(v2 -> {
-                                if (respectTtl && KafkaRecordHelper.isTtlElapsed(record.headers())) {
-                                    onRecordHandlerSkippedForExpiredRecord(record);
-                                } else {
-                                    try {
-                                        recordHandler.handle(record);
-                                    } catch (final Exception e) {
-                                        LOG.warn("error handling record [topic: {}, partition: {}, offset: {}, headers: {}]",
-                                                record.topic(), record.partition(), record.offset(), record.headers(), e);
-                                    }
-                                }
-                            });
-                        });
-                        kafkaConsumer.batchHandler(this::onBatchOfRecordsReceived);
-                        kafkaConsumer.exceptionHandler(error -> LOG.error("consumer error occurred [client-id: {}]",
-                                getClientId(), error));
-                        installRebalanceListeners();
-                        // subscribe and wait for rebalance to make sure that when start() completes,
-                        // the consumer is actually ready to receive records already
-                        kafkaConsumer.asStream().pollTimeout(Duration.ofMillis(10)); // let polls finish quickly until start() is completed
-                        subscribeAndWaitForRebalance()
-                                .onSuccess(v2 -> {
-                                    kafkaConsumer.asStream().pollTimeout(pollTimeout);
-                                    logSubscribedTopicsOnStartComplete();
-                                })
-                                .onComplete(startPromise);
-                    });
+            // create KafkaConsumer here so that it is created in the Vert.x context of the start() method
+            // (KafkaConsumer uses vertx.getOrCreateContext())
+            final KafkaClientFactory kafkaClientFactory = new KafkaClientFactory(vertx);
+            kafkaClientFactory.createClientWithRetries(
+                    consumerSupplier,
+                    lifecycleStatus::isStarting,
+                    consumerConfig.get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG),
+                    consumerCreationRetriesTimeout)
+                .onFailure(t -> LOG.error("error creating consumer [client-id: {}]", getClientId(), t))
+                .onSuccess(consumer -> kafkaConsumer = consumer)
+                .compose(this::initConsumer)
+                .onSuccess(c -> lifecycleStatus.setStarted());
         });
-        return startPromise.future();
+        return Future.succeededFuture();
     }
 
-    private void logSubscribedTopicsOnStartComplete() {
+    private void logSubscribedTopicsWhenConsumerIsReady() {
         if (topicPattern != null) {
             if (subscribedTopicPatternTopics.size() <= 5) {
                 LOG.debug("consumer started, subscribed to topic pattern [{}], matching topics: {}", topicPattern,
@@ -753,7 +832,7 @@ public class HonoKafkaConsumer<V> implements Lifecycle {
     }
 
     private Future<Void> subscribeAndWaitForRebalance() {
-        if (stopCalled.get()) {
+        if (lifecycleStatus.isStopping() || lifecycleStatus.isStopped()) {
             return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "already stopped"));
         }
         final Promise<Void> partitionAssignmentDone = Promise.promise();
@@ -868,21 +947,44 @@ public class HonoKafkaConsumer<V> implements Lifecycle {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Closes the Kafka consumer.
+     *
+     * @return A future indicating the outcome of the operation.
+     *         The future will be succeeded once this component is stopped.
+     */
     @Override
     public Future<Void> stop() {
+
+        if (lifecycleStatus.isStopped()) {
+            // nothing to do
+            return Future.succeededFuture();
+        }
+
+        final Promise<Void> result = Promise.promise();
+        lifecycleStatus.addOnStoppedHandler(result);
+        if (lifecycleStatus.isStopping()) {
+            return result.future();
+        }
+
+        lifecycleStatus.setStopping();
         if (pollPauseTimeoutTimerId != null) {
             vertx.cancelTimer(pollPauseTimeoutTimerId);
             pollPauseTimeoutTimerId = null;
         }
-        if (kafkaConsumer == null) {
-            return Future.failedFuture("not started");
-        } else if (!stopCalled.compareAndSet(false, true)) {
-            LOG.trace("stop already called");
-            return Future.succeededFuture();
-        }
-        return kafkaConsumer.close()
-                .onComplete(ar -> Optional.ofNullable(metricsSupport)
-                        .ifPresent(ms -> ms.unregisterKafkaConsumer(kafkaConsumer.unwrap())));
+
+        Optional.ofNullable(kafkaConsumer)
+            .map(consumer -> consumer.close()
+                    .onComplete(ar -> {
+                        Optional.ofNullable(metricsSupport)
+                            .ifPresent(ms -> ms.unregisterKafkaConsumer(kafkaConsumer.unwrap()));
+                    }))
+            .orElseGet(Future::succeededFuture)
+            .onFailure(t -> LOG.info("error stopping Kafka consumer", t))
+            .onSuccess(ok -> lifecycleStatus.setStopped());
+        return result.future();
     }
 
     /**
@@ -915,9 +1017,9 @@ public class HonoKafkaConsumer<V> implements Lifecycle {
         if (kafkaConsumerWorker == null) {
             throw new IllegalStateException(MSG_CONSUMER_NOT_INITIALIZED_STARTED);
         }
-        if (!stopCalled.get()) {
+        if (lifecycleStatus.isStarted()) {
             kafkaConsumerWorker.submit(() -> {
-                if (!stopCalled.get()) {
+                if (lifecycleStatus.isStarted()) {
                     try {
                         handler.handle(null);
                     } catch (final Exception ex) {
@@ -996,10 +1098,8 @@ public class HonoKafkaConsumer<V> implements Lifecycle {
         } else if (!topicPattern.matcher(topic).find()) {
             throw new IllegalArgumentException("topic doesn't match pattern");
         }
-        if (kafkaConsumer == null) {
+        if (!lifecycleStatus.isStarted()) {
             return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, "not started"));
-        } else if (stopCalled.get()) {
-            return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "already stopped"));
         }
         // check whether topic exists and its existence has been applied to the wildcard subscription yet;
         // use previously updated topics list (less costly than invoking kafkaConsumer.subscription() here)

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumer.java
@@ -958,11 +958,6 @@ public class HonoKafkaConsumer<V> implements Lifecycle, ServiceClient {
     @Override
     public Future<Void> stop() {
 
-        if (lifecycleStatus.isStopped()) {
-            // nothing to do
-            return Future.succeededFuture();
-        }
-
         return lifecycleStatus.runStopAttempt(() -> {
             if (pollPauseTimeoutTimerId != null) {
                 vertx.cancelTimer(pollPauseTimeoutTimerId);

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/AbstractKafkaBasedMessageSender.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/AbstractKafkaBasedMessageSender.java
@@ -45,7 +45,6 @@ import io.opentracing.tag.Tags;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.json.EncodeException;
 import io.vertx.core.json.Json;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
@@ -188,13 +187,7 @@ public abstract class AbstractKafkaBasedMessageSender<V> implements MessagingCli
             return Future.succeededFuture();
         }
 
-        final Promise<Void> result = Promise.promise();
-        lifecycleStatus.addOnStoppedHandler(result);
-        if (lifecycleStatus.isStopping()) {
-            return result.future();
-        }
-
-        lifecycleStatus.setStopping();
+        final var result = lifecycleStatus.newStopAttempt();
         producerFactory.closeProducer(producerName)
             .onSuccess(ok -> lifecycleStatus.setStopped());
         return result.future();

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/AbstractKafkaBasedMessageSender.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/AbstractKafkaBasedMessageSender.java
@@ -182,11 +182,6 @@ public abstract class AbstractKafkaBasedMessageSender<V> implements MessagingCli
     @Override
     public Future<Void> stop() {
 
-        if (lifecycleStatus.isStopped()) {
-            // nothing to do
-            return Future.succeededFuture();
-        }
-
         return lifecycleStatus.runStopAttempt(this::stopProducer);
     }
 

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/AbstractKafkaBasedMessageSender.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/AbstractKafkaBasedMessageSender.java
@@ -29,6 +29,7 @@ import org.eclipse.hono.client.kafka.tracing.KafkaTracingHelper;
 import org.eclipse.hono.client.util.ServiceClient;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Lifecycle;
+import org.eclipse.hono.util.LifecycleStatus;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.MessagingClient;
 import org.eclipse.hono.util.MessagingType;
@@ -41,7 +42,10 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.json.EncodeException;
 import io.vertx.core.json.Json;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
@@ -53,6 +57,8 @@ import io.vertx.kafka.client.producer.RecordMetadata;
 
 /**
  * A client for publishing messages to a Kafka cluster.
+ * <p>
+ * Wraps a vert.x Kafka producer that is created during startup.
  *
  * @param <V> The type of payload supported by this sender.
  */
@@ -67,13 +73,14 @@ public abstract class AbstractKafkaBasedMessageSender<V> implements MessagingCli
      * An OpenTracing tracer to be shared with subclasses.
      */
     protected final Tracer tracer;
+    /**
+     * This component's current life cycle state.
+     */
+    protected final LifecycleStatus lifecycleStatus = new LifecycleStatus();
 
     private final KafkaProducerConfigProperties config;
     private final KafkaProducerFactory<String, V> producerFactory;
     private final String producerName;
-
-    private boolean stopped = false;
-    private boolean producerCreated = false;
 
     /**
      * Creates a new Kafka-based message sender.
@@ -106,47 +113,91 @@ public abstract class AbstractKafkaBasedMessageSender<V> implements MessagingCli
     }
 
     /**
+     * Adds a handler to be invoked with a succeeded future once the Kafka producer is ready to be used.
+     *
+     * @param handler The handler to invoke. The handler will never be invoked with a failed future.
+     */
+    public final void addOnKafkaProducerReadyHandler(final Handler<AsyncResult<Void>> handler) {
+        if (handler != null) {
+            lifecycleStatus.addOnStartedHandler(handler);
+        }
+    }
+
+    /**
      * {@inheritDoc}
      * <p>
-     * Starts the producer.
+     * Registers a procedure for checking if this client's initial Kafka client creation succeeded.
+     */
+    @Override
+    public void registerReadinessChecks(final HealthCheckHandler readinessHandler) {
+        // verify that client creation succeeded
+        readinessHandler.register(
+                "%s-kafka-producer-creation-%s".formatted(producerName, UUID.randomUUID()),
+                status -> status.tryComplete(new Status().setOk(lifecycleStatus.isStarted())));
+    }
+
+    @Override
+    public void registerLivenessChecks(final HealthCheckHandler livenessHandler) {
+        // no liveness checks to be added
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This methods triggers the creation of a Kafka producer in the background. A new attempt to create the
+     * producer is made once a second until creation succeeds or the {@link #stop()} method has been invoked.
+     * <p>
+     * Client code may {@linkplain #addOnKafkaProducerReadyHandler(Handler) register a dedicated handler}
+     * to be notified once the producer has been created successfully.
+     *
+     * @return A succeeded future. Note that the successful completion of the returned future does not
+     *         mean that the producer will be ready to send messages to the broker.
      */
     @Override
     public Future<Void> start() {
-        stopped = false;
 
-        return Future.succeededFuture()
-                .map(v -> getOrCreateProducer()) // enclosed in map() to catch exceptions
-                .onSuccess(v -> producerCreated = true)
-                .recover(thr -> {
-                    if (KafkaClientFactory.isRetriableClientCreationError(thr, config.getBootstrapServers())) {
-                        // retry client creation in the background
-                        getOrCreateProducerWithRetries()
-                                .onSuccess(v -> producerCreated = true);
-                        return Future.succeededFuture();
-                    }
-                    return Future.failedFuture(thr);
-                })
-                .mapEmpty();
+        if (lifecycleStatus.isStarting()) {
+            return Future.succeededFuture();
+        } else if (!lifecycleStatus.setStarting()) {
+            return Future.failedFuture(new IllegalStateException("sender is already started/stopping"));
+        }
+
+        producerFactory.getOrCreateProducerWithRetries(
+                producerName,
+                config,
+                lifecycleStatus::isStarting,
+                KafkaClientFactory.UNLIMITED_RETRIES_DURATION)
+            .onSuccess(producer -> lifecycleStatus.setStarted());
+
+        return Future.succeededFuture();
     }
 
     /**
      * {@inheritDoc}
      * <p>
      * Closes the producer.
+     *
+     * @return A future indicating the outcome of the operation.
+     *         The future will be succeeded once this component is stopped.
      */
     @Override
     public Future<Void> stop() {
-        stopped = true;
-        return producerFactory.closeProducer(producerName);
-    }
 
-    /**
-     * Checks if this sender has been stopped.
-     *
-     * @return {@code true} if this sender's {@link #stop()} method has been called already.
-     */
-    protected final boolean isStopped() {
-        return stopped;
+        if (lifecycleStatus.isStopped()) {
+            // nothing to do
+            return Future.succeededFuture();
+        }
+
+        final Promise<Void> result = Promise.promise();
+        lifecycleStatus.addOnStoppedHandler(result);
+        if (lifecycleStatus.isStopping()) {
+            return result.future();
+        }
+
+        lifecycleStatus.setStopping();
+        producerFactory.closeProducer(producerName)
+            .onSuccess(ok -> lifecycleStatus.setStopped());
+        return result.future();
     }
 
     /**
@@ -220,8 +271,8 @@ public abstract class AbstractKafkaBasedMessageSender<V> implements MessagingCli
         Objects.requireNonNull(headers);
         Objects.requireNonNull(currentSpan);
 
-        if (isStopped()) {
-            return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "sender already stopped"));
+        if (!lifecycleStatus.isStarted()) {
+            return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "sender not started"));
         }
         final KafkaProducerRecord<String, V> record = KafkaProducerRecord.create(topic, deviceId, payload);
 
@@ -247,29 +298,6 @@ public abstract class AbstractKafkaBasedMessageSender<V> implements MessagingCli
      */
     protected final KafkaProducer<String, V> getOrCreateProducer() {
         return producerFactory.getOrCreateProducer(producerName, config);
-    }
-
-    private Future<KafkaProducer<String, V>> getOrCreateProducerWithRetries() {
-        return producerFactory.getOrCreateProducerWithRetries(producerName, config,
-                KafkaClientFactory.UNLIMITED_RETRIES_DURATION);
-    }
-
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Registers a procedure for checking if this client's initial Kafka client creation succeeded.
-     */
-    @Override
-    public void registerReadinessChecks(final HealthCheckHandler readinessHandler) {
-        // verify that client creation succeeded
-        readinessHandler.register(
-                String.format("%s-kafka-client-creation-%s", producerName, UUID.randomUUID()),
-                status -> status.tryComplete(producerCreated ? Status.OK() : Status.KO()));
-    }
-
-    @Override
-    public void registerLivenessChecks(final HealthCheckHandler livenessHandler) {
-        // no liveness checks to be added
     }
 
     /**

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/AbstractKafkaBasedMessageSender.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/AbstractKafkaBasedMessageSender.java
@@ -187,10 +187,7 @@ public abstract class AbstractKafkaBasedMessageSender<V> implements MessagingCli
             return Future.succeededFuture();
         }
 
-        final var result = lifecycleStatus.newStopAttempt();
-        producerFactory.closeProducer(producerName)
-            .onSuccess(ok -> lifecycleStatus.setStopped());
-        return result.future();
+        return lifecycleStatus.runStopAttempt(this::stopProducer);
     }
 
     /**
@@ -291,6 +288,15 @@ public abstract class AbstractKafkaBasedMessageSender<V> implements MessagingCli
      */
     protected final KafkaProducer<String, V> getOrCreateProducer() {
         return producerFactory.getOrCreateProducer(producerName, config);
+    }
+
+    /**
+     * Closes the producer used for sending records.
+     *
+     * @return The outcome of the attempt to close the producer.
+     */
+    protected final Future<Void> stopProducer() {
+        return producerFactory.closeProducer(producerName);
     }
 
     /**

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/KafkaProducerFactory.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/KafkaProducerFactory.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.client.kafka.producer;
 
 import java.time.Duration;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.eclipse.hono.client.kafka.metrics.KafkaClientMetricsSupport;
@@ -82,12 +83,18 @@ public interface KafkaProducerFactory<K, V> {
      *
      * @param producerName The name to identify the producer.
      * @param config The Kafka configuration with which the producer is to be created.
+     * @param keepTrying A guard condition that controls whether another attempt to create the producer should be
+     *                     started. Client code can set this to {@code false} in order to prevent any further attempts.
      * @param retriesTimeout The maximum time for which retries are done. Using a negative duration or {@code null}
      *                       here is interpreted as an unlimited timeout value.
      * @return A future with an existing or new producer.
+     * @throws NullPointerException if any of the parameters except retries timeout are {@code null}.
      */
-    Future<KafkaProducer<K, V>> getOrCreateProducerWithRetries(String producerName,
-            KafkaProducerConfigProperties config, Duration retriesTimeout);
+    Future<KafkaProducer<K, V>> getOrCreateProducerWithRetries(
+            String producerName,
+            KafkaProducerConfigProperties config,
+            Supplier<Boolean> keepTrying,
+            Duration retriesTimeout);
 
     /**
      * Closes the producer with the given producer name if it exists.

--- a/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/kafka/KafkaBasedNotificationReceiver.java
+++ b/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/kafka/KafkaBasedNotificationReceiver.java
@@ -72,8 +72,8 @@ public class KafkaBasedNotificationReceiver extends HonoKafkaConsumer<JsonObject
             final NotificationType<T> notificationType,
             final Handler<T> consumer) {
 
-        if (isStarted()) {
-            throw new IllegalStateException("consumers cannot be added when receiver is already started.");
+        if (!lifecycleStatus.isStopped()) {
+            throw new IllegalStateException("consumers cannot be added when receiver is already started");
         }
 
         addTopic(NotificationTopicHelper.getTopicName(notificationType));

--- a/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/kafka/KafkaBasedNotificationSender.java
+++ b/clients/notification-kafka/src/main/java/org/eclipse/hono/client/notification/kafka/KafkaBasedNotificationSender.java
@@ -56,9 +56,9 @@ public class KafkaBasedNotificationSender extends AbstractKafkaBasedMessageSende
 
         Objects.requireNonNull(notification);
 
-        if (isStopped()) {
+        if (!lifecycleStatus.isStarted()) {
             return Future.failedFuture(
-                    new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "sender already stopped"));
+                    new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "sender not started"));
         }
 
         return createProducerRecord(notification)

--- a/core/src/main/java/org/eclipse/hono/util/LifecycleStatus.java
+++ b/core/src/main/java/org/eclipse/hono/util/LifecycleStatus.java
@@ -140,6 +140,29 @@ public final class LifecycleStatus {
     }
 
     /**
+     * Prepares an attempt to stop the component.
+     *
+     * @return A promise for conveying the outcome of stopping the component to client code. The promise will
+     *         succeed once the {@link #setStopped()} method has been invoked.
+     * @throws IllegalStateException if this component is already in state {@link Status#STOPPED}.
+     */
+    public synchronized Promise<Void> newStopAttempt() {
+
+        if (isStopped()) {
+            throw new IllegalStateException("component is already stopped");
+        }
+
+        final Promise<Void> result = Promise.promise();
+        addOnStoppedHandler(result);
+        if (isStopping()) {
+            return result;
+        }
+
+        setStopping();
+        return result;
+    }
+
+    /**
      * Checks if the component is in the process of shutting down.
      *
      * @return {@code true} if the current status is {@link Status#STOPPING}.

--- a/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/InternalKafkaTopicCleanupService.java
+++ b/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/InternalKafkaTopicCleanupService.java
@@ -231,11 +231,6 @@ public class InternalKafkaTopicCleanupService extends AbstractVerticle {
     @Override
     public void stop(final Promise<Void> stopResult) {
 
-        if (lifecycleStatus.isStopped()) {
-            stopResult.tryComplete();
-            return;
-        }
-
         lifecycleStatus.runStopAttempt(() -> Optional.ofNullable(adminClient)
                 .map(KafkaAdminClient::close)
                 .orElseGet(Future::succeededFuture)

--- a/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -277,13 +277,7 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
             return Future.succeededFuture();
         }
 
-        final Promise<Void> result = Promise.promise();
-        lifecycleStatus.addOnStoppedHandler(result);
-        if (lifecycleStatus.isStopping()) {
-            return result.future();
-        }
-
-        lifecycleStatus.setStopping();
+        final var result = lifecycleStatus.newStopAttempt();
         CompositeFuture.join(kafkaConsumer.stop(), commandHandler.stop())
             .onSuccess(ok -> lifecycleStatus.setStopped());
         return result.future();

--- a/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -277,10 +277,8 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
             return Future.succeededFuture();
         }
 
-        final var result = lifecycleStatus.newStopAttempt();
-        CompositeFuture.join(kafkaConsumer.stop(), commandHandler.stop())
-            .onSuccess(ok -> lifecycleStatus.setStopped());
-        return result.future();
+        return lifecycleStatus.runStopAttempt(() -> CompositeFuture.join(kafkaConsumer.stop(), commandHandler.stop())
+                .mapEmpty());
     }
 
     @Override

--- a/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -272,11 +272,6 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
     @Override
     public Future<Void> stop() {
 
-        if (lifecycleStatus.isStopped()) {
-            // nothing to be done
-            return Future.succeededFuture();
-        }
-
         return lifecycleStatus.runStopAttempt(() -> CompositeFuture.join(kafkaConsumer.stop(), commandHandler.stop())
                 .mapEmpty());
     }

--- a/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.commandrouter.impl.kafka;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -34,7 +35,9 @@ import org.eclipse.hono.commandrouter.CommandConsumerFactory;
 import org.eclipse.hono.commandrouter.CommandRouterMetrics;
 import org.eclipse.hono.commandrouter.CommandTargetMapper;
 import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.LifecycleStatus;
 import org.eclipse.hono.util.MessagingType;
+import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,12 +45,16 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
+import io.vertx.ext.healthchecks.Status;
 import io.vertx.kafka.client.common.impl.Helper;
 
 /**
@@ -76,7 +83,7 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
     private final KafkaBasedInternalCommandSender internalCommandSender;
     private final KafkaBasedCommandResponseSender kafkaBasedCommandResponseSender;
     private final KafkaClientMetricsSupport kafkaClientMetricsSupport;
-
+    private final LifecycleStatus lifecycleStatus = new LifecycleStatus();
     private String groupId = DEFAULT_GROUP_ID;
     private KafkaBasedMappingAndDelegatingCommandHandler commandHandler;
     private AsyncHandlingAutoCommitKafkaConsumer<Buffer> kafkaConsumer;
@@ -96,7 +103,7 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
      * @param metrics The component to use for reporting metrics.
      * @param kafkaClientMetricsSupport The Kafka metrics support.
      * @param tracer The tracer instance.
-     * @throws NullPointerException if any of the parameters except internalKafkaTopicCleanupService is {@code null}.
+     * @throws NullPointerException if any of the parameters are {@code null}.
      */
     public KafkaBasedCommandConsumerFactoryImpl(
             final Vertx vertx,
@@ -133,6 +140,17 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
     }
 
     /**
+     * Adds a handler to be invoked with a succeeded future once this factory is ready to be used.
+     *
+     * @param handler The handler to invoke. The handler will never be invoked with a failed future.
+     */
+    public final void addOnFactoryReadyHandler(final Handler<AsyncResult<Void>> handler) {
+        if (handler != null) {
+            lifecycleStatus.addOnStartedHandler(handler);
+        }
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -148,6 +166,17 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
     public void registerReadinessChecks(final HealthCheckHandler readinessHandler) {
         internalCommandSender.registerReadinessChecks(readinessHandler);
         kafkaBasedCommandResponseSender.registerReadinessChecks(readinessHandler);
+        readinessHandler.register(
+                "command-consumer-factory-kafka-consumer-%s".formatted(UUID.randomUUID()),
+                status -> {
+                    if (kafkaConsumer == null) {
+                        // this factory has not been started yet
+                        status.tryComplete(Status.KO());
+                    } else {
+                        final var response = kafkaConsumer.checkReadiness();
+                        status.tryComplete(new Status().setOk(response.getStatus() == HealthCheckResponse.Status.UP));
+                    }
+                });
     }
 
     /**
@@ -177,25 +206,46 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
     /**
      * {@inheritDoc}
      *
-     * @return The combined outcome of starting the Kafka consumer, the command handler and the internal Kafka
-     * topic cleanup service.
+     * @return The combined outcome of starting the Kafka consumer and the command handler.
      */
     @Override
     public Future<Void> start() {
+        if (lifecycleStatus.isStarting()) {
+            return Future.succeededFuture();
+        } else if (!lifecycleStatus.setStarting()) {
+            return Future.failedFuture(new IllegalStateException("factory is already started/stopping"));
+        }
         final Context context = Vertx.currentContext();
         if (context == null) {
             return Future.failedFuture(new IllegalStateException("factory must be started in a Vert.x context"));
         }
-        final KafkaCommandProcessingQueue commandQueue = new KafkaCommandProcessingQueue(context);
-        commandHandler = new KafkaBasedMappingAndDelegatingCommandHandler(vertx, tenantClient, commandQueue,
-                commandTargetMapper, internalCommandSender, kafkaBasedCommandResponseSender, metrics, tracer);
+        final var commandQueue = new KafkaCommandProcessingQueue(context);
+        final Promise<Void> internalCommandSenderTracker = Promise.promise();
+        internalCommandSender.addOnKafkaProducerReadyHandler(internalCommandSenderTracker);
+        final Promise<Void> commandResponseSenderTracker = Promise.promise();
+        kafkaBasedCommandResponseSender.addOnKafkaProducerReadyHandler(commandResponseSenderTracker);
+        commandHandler = new KafkaBasedMappingAndDelegatingCommandHandler(
+                vertx,
+                tenantClient,
+                commandQueue,
+                commandTargetMapper,
+                internalCommandSender,
+                kafkaBasedCommandResponseSender,
+                metrics,
+                tracer);
 
         final Map<String, String> consumerConfig = kafkaConsumerConfig.getConsumerConfig("command");
         consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         consumerConfig.putIfAbsent(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, CooperativeStickyAssignor.class.getName());
         consumerConfig.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        kafkaConsumer = new AsyncHandlingAutoCommitKafkaConsumer<>(vertx, COMMANDS_TOPIC_PATTERN,
-                commandHandler::mapAndDelegateIncomingCommandMessage, consumerConfig);
+
+        final Promise<Void> consumerTracker = Promise.promise();
+        kafkaConsumer = new AsyncHandlingAutoCommitKafkaConsumer<>(
+                vertx,
+                COMMANDS_TOPIC_PATTERN,
+                commandHandler::mapAndDelegateIncomingCommandMessage,
+                consumerConfig);
+        kafkaConsumer.addOnKafkaConsumerReadyHandler(consumerTracker);
         kafkaConsumer.setPollTimeout(Duration.ofMillis(kafkaConsumerConfig.getPollTimeout()));
         kafkaConsumer.setConsumerCreationRetriesTimeout(KafkaClientFactory.UNLIMITED_RETRIES_DURATION);
         kafkaConsumer.setMetricsSupport(kafkaClientMetricsSupport);
@@ -204,20 +254,39 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
         kafkaConsumer.setOnPartitionsLostHandler(
                 partitions -> commandQueue.setRevokedPartitions(Helper.to(partitions)));
 
-        return CompositeFuture.all(commandHandler.start(), kafkaConsumer.start())
-                .mapEmpty();
+        CompositeFuture.all(
+                internalCommandSenderTracker.future(),
+                commandResponseSenderTracker.future(),
+                consumerTracker.future())
+            .onSuccess(ok -> lifecycleStatus.setStarted());
+
+        return CompositeFuture.all(commandHandler.start(), kafkaConsumer.start()).mapEmpty();
     }
 
     /**
      * {@inheritDoc}
      *
-     * @return The combined outcome of stopping the Kafka consumer, the command handler and the internal Kafka
-     * topic cleanup service.
+     * @return A future indicating the combined outcome of stopping the Kafka consumer and the command handler.
+     *         The future will be succeeded once this component is stopped.
      */
     @Override
     public Future<Void> stop() {
-        return CompositeFuture.join(kafkaConsumer.stop(), commandHandler.stop())
-                .mapEmpty();
+
+        if (lifecycleStatus.isStopped()) {
+            // nothing to be done
+            return Future.succeededFuture();
+        }
+
+        final Promise<Void> result = Promise.promise();
+        lifecycleStatus.addOnStoppedHandler(result);
+        if (lifecycleStatus.isStopping()) {
+            return result.future();
+        }
+
+        lifecycleStatus.setStopping();
+        CompositeFuture.join(kafkaConsumer.stop(), commandHandler.stop())
+            .onSuccess(ok -> lifecycleStatus.setStopped());
+        return result.future();
     }
 
     @Override

--- a/tests/src/test/java/org/eclipse/hono/tests/client/HonoKafkaConsumerIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/client/HonoKafkaConsumerIT.java
@@ -164,7 +164,8 @@ public class HonoKafkaConsumerIT {
     @ParameterizedTest
     @MethodSource("partitionAssignmentStrategies")
     @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
-    public void testConsumerReadsLatestRecordsPublishedAfterStart(final String partitionAssignmentStrategy,
+    public void testConsumerReadsLatestRecordsPublishedAfterStart(
+            final String partitionAssignmentStrategy,
             final VertxTestContext ctx) throws InterruptedException {
         final int numTopics = 2;
         final int numPartitions = 5;
@@ -200,10 +201,14 @@ public class HonoKafkaConsumerIT {
         };
         kafkaConsumer = new HonoKafkaConsumer<>(vertx, topics, recordHandler, consumerConfig);
         // start consumer
-        kafkaConsumer.start().onComplete(ctx.succeeding(v -> {
-            LOG.debug("consumer started, publish record to be received by the consumer");
-            publish(publishTestTopic, publishedAfterStartRecordKey, Buffer.buffer("testPayload"));
-        }));
+        final Promise<Void> readyTracker = Promise.promise();
+        kafkaConsumer.addOnKafkaConsumerReadyHandler(readyTracker);
+        kafkaConsumer.start()
+            .compose(ok -> readyTracker.future())
+            .onComplete(ctx.succeeding(v -> {
+                LOG.debug("consumer started, publish record to be received by the consumer");
+                publish(publishTestTopic, publishedAfterStartRecordKey, Buffer.buffer("testPayload"));
+            }));
 
         if (!ctx.awaitCompletion(9, TimeUnit.SECONDS)) {
             ctx.failNow(new IllegalStateException("timeout waiting for record to be received"));
@@ -220,7 +225,9 @@ public class HonoKafkaConsumerIT {
      */
     @Test
     @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
-    public void testConsumerReadsLatestRecordsPublishedAfterOutOfRangeOffsetReset(final VertxTestContext ctx) throws InterruptedException {
+    public void testConsumerReadsLatestRecordsPublishedAfterOutOfRangeOffsetReset(final VertxTestContext ctx)
+            throws InterruptedException {
+
         final int numTopics = 1;
         final int numTestRecordsPerTopicPerRound = 20;
         final int numPartitions = 1; // has to be 1 here because we expect partition 0 to contain *all* the records published for a topic
@@ -274,13 +281,19 @@ public class HonoKafkaConsumerIT {
 
         kafkaConsumer = new HonoKafkaConsumer<>(vertx, topics, recordHandler, consumerConfig);
         // first start of consumer, letting it commit offsets
-        kafkaConsumer.start().onComplete(ctx.succeeding(v -> {
-            LOG.trace("consumer started, publish first round of records to be received by the consumer (so that it has offsets to commit)");
-            publishRecords(numTestRecordsPerTopicPerRound, "round1_", topics);
-        }));
+        final Promise<Void> readyTracker = Promise.promise();
+        kafkaConsumer.addOnKafkaConsumerReadyHandler(readyTracker);
+        kafkaConsumer.start()
+            .compose(ok -> readyTracker.future())
+            .onComplete(ctx.succeeding(v -> {
+                LOG.trace("consumer started, publish first round of records to be received by the consumer (so that it has offsets to commit)");
+                publishRecords(numTestRecordsPerTopicPerRound, "round1_", topics);
+            }));
 
-        assertThat(firstConsumerInstanceStartedAndStopped.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(),
-                TimeUnit.SECONDS)).isTrue();
+        assertThat(firstConsumerInstanceStartedAndStopped.awaitCompletion(
+                IntegrationTestSupport.getTestSetupTimeout(),
+                TimeUnit.SECONDS))
+            .isTrue();
         if (firstConsumerInstanceStartedAndStopped.failed()) {
             ctx.failNow(firstConsumerInstanceStartedAndStopped.causeOfFailure());
             return;
@@ -420,30 +433,34 @@ public class HonoKafkaConsumerIT {
         };
         kafkaConsumer = new HonoKafkaConsumer<>(vertx, topicPattern, recordHandler, consumerConfig);
         // start consumer
-        kafkaConsumer.start().onComplete(ctx.succeeding(v -> {
-            ctx.verify(() -> {
-                assertThat(receivedRecords.size()).isEqualTo(0);
-            });
-            final Promise<Void> nextRecordReceivedPromise = Promise.promise();
-            nextRecordReceivedPromiseRef.set(nextRecordReceivedPromise);
-
-            LOG.debug("consumer started, create new topic implicitly by invoking ensureTopicIsAmongSubscribedTopicPatternTopics()");
-            final String newTopic = patternPrefix + "new";
-            final String recordKey = "addedAfterStartKey";
-            kafkaConsumer.ensureTopicIsAmongSubscribedTopicPatternTopics(newTopic)
-                    .onComplete(ctx.succeeding(v2 -> {
-                        LOG.debug("publish record to be received by the consumer");
-                        publish(newTopic, recordKey, Buffer.buffer("testPayload"));
-                    }));
-
-            nextRecordReceivedPromise.future().onComplete(ar -> {
+        final Promise<Void> readyTracker = Promise.promise();
+        kafkaConsumer.addOnKafkaConsumerReadyHandler(readyTracker);
+        kafkaConsumer.start()
+            .compose(ok -> readyTracker.future())
+            .onComplete(ctx.succeeding(v -> {
                 ctx.verify(() -> {
-                    assertThat(receivedRecords.size()).isEqualTo(1);
-                    assertThat(receivedRecords.get(0).key()).isEqualTo(recordKey);
+                    assertThat(receivedRecords.size()).isEqualTo(0);
                 });
-                ctx.completeNow();
-            });
-        }));
+                final Promise<Void> nextRecordReceivedPromise = Promise.promise();
+                nextRecordReceivedPromiseRef.set(nextRecordReceivedPromise);
+
+                LOG.debug("consumer started, create new topic implicitly by invoking ensureTopicIsAmongSubscribedTopicPatternTopics()");
+                final String newTopic = patternPrefix + "new";
+                final String recordKey = "addedAfterStartKey";
+                kafkaConsumer.ensureTopicIsAmongSubscribedTopicPatternTopics(newTopic)
+                        .onComplete(ctx.succeeding(v2 -> {
+                            LOG.debug("publish record to be received by the consumer");
+                            publish(newTopic, recordKey, Buffer.buffer("testPayload"));
+                        }));
+
+                nextRecordReceivedPromise.future().onComplete(ar -> {
+                    ctx.verify(() -> {
+                        assertThat(receivedRecords.size()).isEqualTo(1);
+                        assertThat(receivedRecords.get(0).key()).isEqualTo(recordKey);
+                    });
+                    ctx.completeNow();
+                });
+            }));
     }
 
     /**
@@ -480,28 +497,32 @@ public class HonoKafkaConsumerIT {
 
         kafkaConsumer = new HonoKafkaConsumer<>(vertx, topicPattern, recordHandler, consumerConfig);
         // start consumer
-        kafkaConsumer.start().onComplete(ctx.succeeding(v -> {
-            ctx.verify(() -> {
-                assertThat(receivedRecords.size()).isEqualTo(0);
-            });
-            LOG.debug("consumer started, create new topics implicitly by invoking ensureTopicIsAmongSubscribedTopicPatternTopics()");
-            final String recordKey = "addedAfterStartKey";
-            for (int i = 0; i < numTopicsAndRecords; i++) {
-                final String topic = patternPrefix + i;
-                kafkaConsumer.ensureTopicIsAmongSubscribedTopicPatternTopics(topic)
-                        .onComplete(ctx.succeeding(v2 -> {
-                            LOG.debug("publish record to be received by the consumer");
-                            publish(topic, recordKey, Buffer.buffer("testPayload"));
-                        }));
-            }
-            allRecordsReceivedPromise.future().onComplete(ar -> {
+        final Promise<Void> readyTracker = Promise.promise();
+        kafkaConsumer.addOnKafkaConsumerReadyHandler(readyTracker);
+        kafkaConsumer.start()
+            .compose(ok -> readyTracker.future())
+            .onComplete(ctx.succeeding(v -> {
                 ctx.verify(() -> {
-                    assertThat(receivedRecords.size()).isEqualTo(numTopicsAndRecords);
-                    receivedRecords.forEach(record -> assertThat(record.key()).isEqualTo(recordKey));
+                    assertThat(receivedRecords.size()).isEqualTo(0);
                 });
-                ctx.completeNow();
-            });
-        }));
+                LOG.debug("consumer started, create new topics implicitly by invoking ensureTopicIsAmongSubscribedTopicPatternTopics()");
+                final String recordKey = "addedAfterStartKey";
+                for (int i = 0; i < numTopicsAndRecords; i++) {
+                    final String topic = patternPrefix + i;
+                    kafkaConsumer.ensureTopicIsAmongSubscribedTopicPatternTopics(topic)
+                            .onComplete(ctx.succeeding(v2 -> {
+                                LOG.debug("publish record to be received by the consumer");
+                                publish(topic, recordKey, Buffer.buffer("testPayload"));
+                            }));
+                }
+                allRecordsReceivedPromise.future().onComplete(ar -> {
+                    ctx.verify(() -> {
+                        assertThat(receivedRecords.size()).isEqualTo(numTopicsAndRecords);
+                        receivedRecords.forEach(record -> assertThat(record.key()).isEqualTo(recordKey));
+                    });
+                    ctx.completeNow();
+                });
+            }));
         if (!ctx.awaitCompletion(9, TimeUnit.SECONDS)) {
             ctx.failNow(new IllegalStateException(String.format(
                     "timeout waiting for expected number of records (%d) to be received; received records: %d",
@@ -554,17 +575,21 @@ public class HonoKafkaConsumerIT {
         };
         kafkaConsumer = new HonoKafkaConsumer<>(vertx, topics, recordHandler, consumerConfig);
         // start consumer
-        kafkaConsumer.start().onComplete(ctx.succeeding(v -> {
-            ctx.verify(() -> {
-                assertThat(receivedRecords.size()).isEqualTo(0);
-            });
-            allRecordsReceivedPromise.future().onComplete(ar -> {
+        final Promise<Void> readyTracker = Promise.promise();
+        kafkaConsumer.addOnKafkaConsumerReadyHandler(readyTracker);
+        kafkaConsumer.start()
+            .compose(ok -> readyTracker.future())
+            .onComplete(ctx.succeeding(v -> {
                 ctx.verify(() -> {
-                    assertThat(receivedRecords.size()).isEqualTo(totalExpectedMessages);
+                    assertThat(receivedRecords.size()).isEqualTo(0);
                 });
-                ctx.completeNow();
-            });
-        }));
+                allRecordsReceivedPromise.future().onComplete(ar -> {
+                    ctx.verify(() -> {
+                        assertThat(receivedRecords.size()).isEqualTo(totalExpectedMessages);
+                    });
+                    ctx.completeNow();
+                });
+            }));
     }
 
     /**
@@ -597,25 +622,29 @@ public class HonoKafkaConsumerIT {
         topicsToDeleteAfterTests.add(topic);
         kafkaConsumer = new HonoKafkaConsumer<>(vertx, Set.of(topic), recordHandler, consumerConfig);
         // start consumer
-        kafkaConsumer.start().onComplete(ctx.succeeding(v -> {
-            ctx.verify(() -> {
-                assertThat(receivedRecords.size()).isEqualTo(0);
-            });
-            final Promise<Void> nextRecordReceivedPromise = Promise.promise();
-            nextRecordReceivedPromiseRef.set(nextRecordReceivedPromise);
-
-            LOG.debug("consumer started, publish record to be received by the consumer");
-            final String recordKey = "addedAfterStartKey";
-            publish(topic, recordKey, Buffer.buffer("testPayload"));
-
-            nextRecordReceivedPromise.future().onComplete(ar -> {
+        final Promise<Void> readyTracker = Promise.promise();
+        kafkaConsumer.addOnKafkaConsumerReadyHandler(readyTracker);
+        kafkaConsumer.start()
+            .compose(ok -> readyTracker.future())
+            .onComplete(ctx.succeeding(v -> {
                 ctx.verify(() -> {
-                    assertThat(receivedRecords.size()).isEqualTo(1);
-                    assertThat(receivedRecords.get(0).key()).isEqualTo(recordKey);
+                    assertThat(receivedRecords.size()).isEqualTo(0);
                 });
-                ctx.completeNow();
-            });
-        }));
+                final Promise<Void> nextRecordReceivedPromise = Promise.promise();
+                nextRecordReceivedPromiseRef.set(nextRecordReceivedPromise);
+
+                LOG.debug("consumer started, publish record to be received by the consumer");
+                final String recordKey = "addedAfterStartKey";
+                publish(topic, recordKey, Buffer.buffer("testPayload"));
+
+                nextRecordReceivedPromise.future().onComplete(ar -> {
+                    ctx.verify(() -> {
+                        assertThat(receivedRecords.size()).isEqualTo(1);
+                        assertThat(receivedRecords.get(0).key()).isEqualTo(recordKey);
+                    });
+                    ctx.completeNow();
+                });
+            }));
     }
 
     private static Future<Void> createTopics(final Collection<String> topicNames, final int numPartitions) {


### PR DESCRIPTION
The Kafka based clients have been adapted to provide a readiness check
that is independent from the clients' startup. This is to better
resemble the behavior of Hono's other components and also to not block
the deployment of verticles during startup of Hono services and
adapters.

Fixes #3214