### PR TITLE
[#3199] Allow gateways to omit tenant ID with HTTP adapter

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/HttpContext.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/HttpContext.java
@@ -46,8 +46,8 @@ public final class HttpContext implements TelemetryExecutionContext {
 
     private HttpContext(final RoutingContext routingContext) {
         this.routingContext = Objects.requireNonNull(routingContext);
-        this.requestedResource = Optional.ofNullable(routingContext.request().uri())
-                .map(uri -> ResourceIdentifier.fromString(uri.substring(1)))
+        this.requestedResource = Optional.ofNullable(routingContext.request().path())
+                .map(path -> ResourceIdentifier.fromString(path.substring(1)))
                 .orElseThrow(() -> new IllegalArgumentException("HTTP request contains no URI"));
 
         this.eventEndpoint = EventConstants.isEventEndpoint(requestedResource.getEndpoint());

--- a/adapter-base/src/test/java/org/eclipse/hono/adapter/HttpContextTest.java
+++ b/adapter-base/src/test/java/org/eclipse/hono/adapter/HttpContextTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.eclipse.hono.adapter.HttpContext;
 import org.eclipse.hono.util.Constants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,8 +39,9 @@ public class HttpContextTest {
      */
     @BeforeEach
     public void setUp() {
-        routingContext = mock(RoutingContext.class);
         httpServerRequest = mock(HttpServerRequest.class);
+        when(httpServerRequest.uri()).thenReturn("/telemetry");
+        routingContext = mock(RoutingContext.class);
         when(routingContext.request()).thenReturn(httpServerRequest);
 
     }

--- a/adapter-base/src/test/java/org/eclipse/hono/adapter/HttpContextTest.java
+++ b/adapter-base/src/test/java/org/eclipse/hono/adapter/HttpContextTest.java
@@ -40,7 +40,7 @@ public class HttpContextTest {
     @BeforeEach
     public void setUp() {
         httpServerRequest = mock(HttpServerRequest.class);
-        when(httpServerRequest.uri()).thenReturn("/telemetry");
+        when(httpServerRequest.path()).thenReturn("/telemetry");
         routingContext = mock(RoutingContext.class);
         when(routingContext.request()).thenReturn(httpServerRequest);
 
@@ -100,7 +100,7 @@ public class HttpContextTest {
     @Test
     public void testGetTimeToLiveUsesHeader() {
 
-        when(httpServerRequest.uri()).thenReturn("/event");
+        when(httpServerRequest.path()).thenReturn("/event");
         final HttpContext httpContext = HttpContext.from(routingContext);
 
         // GIVEN a time to live in seconds
@@ -120,7 +120,7 @@ public class HttpContextTest {
     @Test
     public void testGetTimeToLiveUsesQueryParam() {
 
-        when(httpServerRequest.uri()).thenReturn("/event");
+        when(httpServerRequest.path()).thenReturn("/event");
         final HttpContext httpContext = HttpContext.from(routingContext);
 
         // GIVEN a time to live in seconds

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -52,6 +52,7 @@ import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.TelemetryConstants;
 import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.TenantObject;
 import org.junit.jupiter.api.BeforeEach;
@@ -227,9 +228,13 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
 
         // WHEN a device that belongs to "my-tenant" publishes a telemetry message
         final Buffer payload = Buffer.buffer("some payload");
-        final HttpContext ctx = newHttpContext(payload);
+        final HttpContext ctx = newHttpContext(
+                payload,
+                "application/text",
+                newTelemetryRequest(),
+                mock(HttpServerResponse.class));
 
-        adapter.uploadTelemetryMessage(ctx, "my-tenant", "the-device", payload, "application/text");
+        adapter.doUploadMessage(ctx, "my-tenant", "the-device");
 
         // THEN the device gets a 403
         assertContextFailedWithClientError(ctx, HttpURLConnection.HTTP_FORBIDDEN);
@@ -273,11 +278,11 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
             .thenReturn(Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND)));
         final Buffer payload = Buffer.buffer("some payload");
         final HttpServerResponse response = mock(HttpServerResponse.class);
-        final HttpServerRequest request = mock(HttpServerRequest.class);
+        final HttpServerRequest request = newTelemetryRequest();
         when(request.getHeader(eq(Constants.HEADER_TIME_TILL_DISCONNECT))).thenReturn("5");
         final HttpContext ctx = newHttpContext(payload, "application/text", request, response);
 
-        adapter.uploadTelemetryMessage(ctx, "my-tenant", "unknown-device", payload, "application/text");
+        adapter.doUploadMessage(ctx, "my-tenant", "unknown-device");
 
         // THEN the device gets a 404
         assertContextFailedWithClientError(ctx, HttpURLConnection.HTTP_NOT_FOUND);
@@ -321,7 +326,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
             return 0;
         });
 
-        adapter.uploadEventMessage(ctx, "tenant", "device");
+        adapter.doUploadMessage(ctx, "tenant", "device");
         assertEventHasBeenSentDownstream("tenant", "device", "application/text");
         // THEN the device does not get a response
         verify(response, never()).end();
@@ -365,9 +370,13 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
 
         // WHEN a device publishes an event that is not accepted by the peer
         final Buffer payload = Buffer.buffer("some payload");
-        final HttpContext ctx = newHttpContext(payload, newEventRequest(), mock(HttpServerResponse.class));
+        final HttpContext ctx = newHttpContext(
+                payload,
+                "application/text",
+                newEventRequest(),
+                mock(HttpServerResponse.class));
 
-        adapter.uploadEventMessage(ctx, "tenant", "device", payload, "application/text");
+        adapter.doUploadMessage(ctx, "tenant", "device");
         assertEventHasBeenSentDownstream("tenant", "device", "application/text");
         outcome.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, "malformed message"));
 
@@ -408,7 +417,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
             return 0;
         });
 
-        adapter.uploadEventMessage(ctx, "tenant", "device");
+        adapter.doUploadMessage(ctx, "tenant", "device");
 
         // verifies that the downstream message contains the time to live value
         assertEventHasBeenSentDownstream("tenant", "device", "text/plain", 10L);
@@ -429,7 +438,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
         // WHEN a device publishes a command response
         final Buffer payload = Buffer.buffer("some payload");
         final HttpServerResponse response = mock(HttpServerResponse.class);
-        final HttpContext ctx = newHttpContext(payload, "application/text", mock(HttpServerRequest.class), response);
+        final HttpContext ctx = newHttpContext(payload, "application/text", newCommandResponseRequest(), response);
         when(ctx.getRoutingContext().addBodyEndHandler(VertxMockSupport.anyHandler())).thenAnswer(invocation -> {
             final Handler<Void> handler = invocation.getArgument(0);
             handler.handle(null);
@@ -475,7 +484,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
         // WHEN a device publishes a command response with an empty payload
         final Buffer payload = null;
         final HttpServerResponse response = mock(HttpServerResponse.class);
-        final HttpContext ctx = newHttpContext(payload, "application/text", mock(HttpServerRequest.class), response);
+        final HttpContext ctx = newHttpContext(payload, "application/text", newCommandResponseRequest(), response);
         when(ctx.getRoutingContext().addBodyEndHandler(VertxMockSupport.anyHandler())).thenAnswer(invocation -> {
             final Handler<Void> handler = invocation.getArgument(0);
             handler.handle(null);
@@ -512,7 +521,11 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
 
         // WHEN a device publishes a command response
         final Buffer payload = Buffer.buffer("some payload");
-        final HttpContext ctx = newHttpContext(payload, "application/text", mock(HttpServerRequest.class), mock(HttpServerResponse.class));
+        final HttpContext ctx = newHttpContext(
+                payload,
+                "application/text",
+                newCommandResponseRequest(),
+                mock(HttpServerResponse.class));
 
         adapter.uploadCommandResponseMessage(ctx, "tenant", "device", CMD_REQ_ID, 200);
 
@@ -537,7 +550,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
 
         givenAnAdapter(properties);
         final Buffer payload = Buffer.buffer("some payload");
-        final HttpContext ctx = newHttpContext(payload, "application/text", mock(HttpServerRequest.class),
+        final HttpContext ctx = newHttpContext(payload, "application/text", newCommandResponseRequest(),
                 mock(HttpServerResponse.class));
         final TenantObject to = TenantObject.from("tenant", true);
 
@@ -581,7 +594,11 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
 
         // WHEN a device publishes a command response that is not accepted by the application
         final Buffer payload = Buffer.buffer("some payload");
-        final HttpContext ctx = newHttpContext(payload, "application/text", mock(HttpServerRequest.class), mock(HttpServerResponse.class));
+        final HttpContext ctx = newHttpContext(
+                payload,
+                "application/text",
+                newCommandResponseRequest(),
+                mock(HttpServerResponse.class));
 
         adapter.uploadCommandResponseMessage(ctx, "tenant", "device", CMD_REQ_ID, 200);
         outcome.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, "malformed message"));
@@ -612,14 +629,14 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
         // WHEN a device publishes a telemetry message
         final Buffer payload = Buffer.buffer("some payload");
         final HttpServerResponse response = mock(HttpServerResponse.class);
-        final HttpContext ctx = newHttpContext(payload, "application/text", mock(HttpServerRequest.class), response);
+        final HttpContext ctx = newHttpContext(payload, "application/text", newTelemetryRequest(), response);
         when(ctx.getRoutingContext().addBodyEndHandler(VertxMockSupport.anyHandler())).thenAnswer(invocation -> {
             final Handler<Void> handler = invocation.getArgument(0);
             handler.handle(null);
             return 0;
         });
 
-        adapter.uploadTelemetryMessage(ctx, "tenant", "device");
+        adapter.doUploadMessage(ctx, "tenant", "device");
 
         // THEN the device receives a 202 response immediately
         verify(response).setStatusCode(202);
@@ -657,7 +674,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
         // WHEN a device publishes a telemetry message with a TTD
         final Buffer payload = Buffer.buffer("some payload");
         final HttpServerResponse response = mock(HttpServerResponse.class);
-        final HttpServerRequest request = mock(HttpServerRequest.class);
+        final HttpServerRequest request = newTelemetryRequest();
         when(request.getHeader(eq(Constants.HEADER_TIME_TILL_DISCONNECT))).thenReturn("10");
         final HttpContext ctx = newHttpContext(payload, "text/plain", request, response);
         when(ctx.getRoutingContext().addBodyEndHandler(VertxMockSupport.anyHandler())).thenAnswer(invocation -> {
@@ -670,7 +687,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
         when(commandConsumerFactory.createCommandConsumer(anyString(), anyString(), VertxMockSupport.anyHandler(), any(), any()))
                 .thenReturn(commandConsumerPromise.future());
 
-        adapter.uploadTelemetryMessage(ctx, "tenant", "device");
+        adapter.doUploadMessage(ctx, "tenant", "device");
         commandConsumerPromise.complete(commandConsumer);
 
         // THEN the request fails immediately
@@ -711,11 +728,11 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
         // and includes a TTD value of 40 in its request
         final Buffer payload = Buffer.buffer("some payload");
         final HttpServerResponse response = mock(HttpServerResponse.class);
-        final HttpServerRequest request = mock(HttpServerRequest.class);
+        final HttpServerRequest request = newTelemetryRequest();
         when(request.getHeader(eq(Constants.HEADER_TIME_TILL_DISCONNECT))).thenReturn("40");
         final HttpContext ctx = newHttpContext(payload, "text/plain", request, response);
 
-        adapter.uploadTelemetryMessage(ctx, "tenant", "device");
+        adapter.doUploadMessage(ctx, "tenant", "device");
 
         // THEN the device receives a 202 response immediately
         verify(response).setStatusCode(202);
@@ -743,13 +760,17 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
         givenATelemetrySenderForAnyTenant();
 
         final Buffer payload = Buffer.buffer("some payload");
-        final HttpContext routingContext = newHttpContext(payload);
+        final HttpContext routingContext = newHttpContext(
+                payload,
+                "application/text",
+                newTelemetryRequest(),
+                mock(HttpServerResponse.class));
 
         // WHEN the message limit exceeds
         when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.TRUE));
         // WHEN a device that belongs to "my-tenant" publishes a telemetry message
-        adapter.uploadTelemetryMessage(routingContext, "my-tenant", "the-device", payload, "application/text");
+        adapter.doUploadMessage(routingContext, "my-tenant", "the-device");
 
         // THEN the device gets a 429
         assertContextFailedWithClientError(routingContext, HttpUtils.HTTP_TOO_MANY_REQUESTS);
@@ -778,13 +799,17 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
         givenAnEventSenderForAnyTenant();
 
         final Buffer payload = Buffer.buffer("some payload");
-        final HttpContext routingContext = newHttpContext(payload);
+        final HttpContext routingContext = newHttpContext(
+                payload,
+                "application/text",
+                newEventRequest(),
+                mock(HttpServerResponse.class));
 
         // WHEN the message limit exceeds
         when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.TRUE));
         // WHEN a device that belongs to "my-tenant" publishes an event message
-        adapter.uploadEventMessage(routingContext, "my-tenant", "the-device", payload, "application/text");
+        adapter.doUploadMessage(routingContext, "my-tenant", "the-device");
 
         // THEN the device gets a 429
         assertContextFailedWithClientError(routingContext, HttpUtils.HTTP_TOO_MANY_REQUESTS);
@@ -818,7 +843,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
         // WHEN a device publishes a command response
         final Buffer payload = Buffer.buffer("some payload");
         final HttpServerResponse response = mock(HttpServerResponse.class);
-        final HttpContext ctx = newHttpContext(payload, "application/text", mock(HttpServerRequest.class),
+        final HttpContext ctx = newHttpContext(payload, "application/text", newCommandResponseRequest(),
                 response);
         when(ctx.getRoutingContext().addBodyEndHandler(VertxMockSupport.anyHandler())).thenAnswer(invocation -> {
             final Handler<Void> handler = invocation.getArgument(0);
@@ -840,18 +865,22 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
                 any());
     }
 
-    private HttpServerRequest newEventRequest() {
+    private HttpServerRequest newCommandResponseRequest() {
         final HttpServerRequest request = mock(HttpServerRequest.class);
-        when(request.uri()).thenReturn("/event");
+        when(request.uri()).thenReturn("/" + CommandConstants.COMMAND_RESPONSE_ENDPOINT);
         return request;
     }
 
-    private HttpContext newHttpContext(final Buffer payload) {
-        return newHttpContext(payload, mock(HttpServerResponse.class));
+    private HttpServerRequest newTelemetryRequest() {
+        final HttpServerRequest request = mock(HttpServerRequest.class);
+        when(request.uri()).thenReturn("/" + TelemetryConstants.TELEMETRY_ENDPOINT);
+        return request;
     }
 
-    private HttpContext newHttpContext(final Buffer payload, final HttpServerResponse response) {
-        return newHttpContext(payload, mock(HttpServerRequest.class), response);
+    private HttpServerRequest newEventRequest() {
+        final HttpServerRequest request = mock(HttpServerRequest.class);
+        when(request.uri()).thenReturn("/" + EventConstants.EVENT_ENDPOINT);
+        return request;
     }
 
     private HttpContext newHttpContext(

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -407,8 +407,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
         // WHEN a device publishes an event with a time to live value as a header
         final Buffer payload = Buffer.buffer("some payload");
         final HttpServerResponse response = mock(HttpServerResponse.class);
-        final HttpServerRequest request = mock(HttpServerRequest.class);
-        when(request.uri()).thenReturn("/" + EventConstants.EVENT_ENDPOINT);
+        final HttpServerRequest request = newEventRequest();
         when(request.getHeader(eq(Constants.HEADER_TIME_TO_LIVE))).thenReturn("10");
         final HttpContext ctx = newHttpContext(payload, "text/plain", request, response);
         when(ctx.getRoutingContext().addBodyEndHandler(VertxMockSupport.anyHandler())).thenAnswer(invocation -> {
@@ -867,28 +866,20 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
 
     private HttpServerRequest newCommandResponseRequest() {
         final HttpServerRequest request = mock(HttpServerRequest.class);
-        when(request.uri()).thenReturn("/" + CommandConstants.COMMAND_RESPONSE_ENDPOINT);
+        when(request.path()).thenReturn("/" + CommandConstants.COMMAND_RESPONSE_ENDPOINT);
         return request;
     }
 
     private HttpServerRequest newTelemetryRequest() {
         final HttpServerRequest request = mock(HttpServerRequest.class);
-        when(request.uri()).thenReturn("/" + TelemetryConstants.TELEMETRY_ENDPOINT);
+        when(request.path()).thenReturn("/" + TelemetryConstants.TELEMETRY_ENDPOINT);
         return request;
     }
 
     private HttpServerRequest newEventRequest() {
         final HttpServerRequest request = mock(HttpServerRequest.class);
-        when(request.uri()).thenReturn("/" + EventConstants.EVENT_ENDPOINT);
+        when(request.path()).thenReturn("/" + EventConstants.EVENT_ENDPOINT);
         return request;
-    }
-
-    private HttpContext newHttpContext(
-            final Buffer payload,
-            final HttpServerRequest request,
-            final HttpServerResponse response) {
-
-        return newHttpContext(payload, null, request, response);
     }
 
     private HttpContext newHttpContext(

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/HonoBasicAuthHandlerTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/HonoBasicAuthHandlerTest.java
@@ -67,7 +67,7 @@ public class HonoBasicAuthHandlerTest {
     @BeforeEach
     void setUp() {
         req = mock(HttpServerRequest.class);
-        when(req.uri()).thenReturn("/" + TelemetryConstants.TELEMETRY_ENDPOINT);
+        when(req.path()).thenReturn("/" + TelemetryConstants.TELEMETRY_ENDPOINT);
         resp = mock(HttpServerResponse.class);
         ctx = mock(RoutingContext.class);
         when(ctx.request()).thenReturn(req);

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
@@ -410,7 +410,7 @@ public class VertxBasedHttpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     }
 
     /**
-     * Verifies that a request to upload eventsusing PUT fails if the request contains a malformed URI.
+     * Verifies that a request to upload events using PUT fails if the request contains a malformed URI.
      *
      * @param uri The request URI.
      * @param expectedErrorCode The HTTP status code expected in the HTTP response.

--- a/adapters/lora-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/lora/LoraProtocolAdapter.java
+++ b/adapters/lora-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/lora/LoraProtocolAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -357,7 +357,7 @@ public final class LoraProtocolAdapter extends AbstractVertxBasedHttpProtocolAda
 
     private void handleCommand(final CommandContext commandContext) {
         Tags.COMPONENT.set(commandContext.getTracingSpan(), getTypeName());
-        final Sample timer = metrics.startTimer();
+        final Sample timer = getMetrics().startTimer();
         final Command command = commandContext.getCommand();
 
         if (command.getGatewayId() == null) {
@@ -395,7 +395,7 @@ public final class LoraProtocolAdapter extends AbstractVertxBasedHttpProtocolAda
                 .onSuccess(aVoid -> {
                     addMicrometerSample(commandContext, timer);
                     commandContext.accept();
-                    metrics.reportCommand(
+                    getMetrics().reportCommand(
                             command.isOneWay() ? Direction.ONE_WAY : Direction.REQUEST,
                             tenant,
                             tenantTracker.result(),
@@ -406,7 +406,7 @@ public final class LoraProtocolAdapter extends AbstractVertxBasedHttpProtocolAda
                 .onFailure(t -> {
                     LOG.debug("error sending command", t);
                     commandContext.release(t);
-                    metrics.reportCommand(
+                    getMetrics().reportCommand(
                             command.isOneWay() ? Direction.ONE_WAY : Direction.REQUEST,
                             tenant,
                             tenantTracker.result(),

--- a/adapters/lora-vertx-quarkus/src/test/java/org/eclipse/hono/adapter/lora/LoraProtocolAdapterTest.java
+++ b/adapters/lora-vertx-quarkus/src/test/java/org/eclipse/hono/adapter/lora/LoraProtocolAdapterTest.java
@@ -426,7 +426,7 @@ public class LoraProtocolAdapterTest extends ProtocolAdapterTestSupport<HttpProt
         metaData.setFunctionPort(TEST_FUNCTION_PORT);
 
         final HttpServerRequest request = mock(HttpServerRequest.class);
-        when(request.uri()).thenReturn("/lora");
+        when(request.path()).thenReturn("/lora");
 
         final RoutingContext context = mock(RoutingContext.class);
         when(context.getBody()).thenReturn(Buffer.buffer());

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
@@ -154,7 +154,6 @@ public final class SigfoxProtocolAdapter
 
         final String deviceId = ctx.getRoutingContext().queryParams().get(SIGFOX_PARAM_DEVICE_ID);
         final String strData = ctx.getRoutingContext().queryParams().get(SIGFOX_PARAM_DATA);
-        final Buffer data = decodeData(strData);
 
         LOG.debug("{} handler - deviceTenant: {}, requestTenant: {}, deviceId: {}, data: {}",
                 ctx.request().method(), deviceTenant, requestTenant, deviceId, strData);
@@ -171,6 +170,7 @@ public final class SigfoxProtocolAdapter
             return;
         }
 
+        final Buffer data = decodeData(strData);
         final String contentType = Optional.ofNullable(data)
                 .map(d -> CONTENT_TYPE_OCTET_STREAM)
                 .orElse(EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION);
@@ -196,7 +196,7 @@ public final class SigfoxProtocolAdapter
 
     private static Buffer decodeData(final String data) {
         if (data == null) {
-            return Buffer.buffer();
+            return null;
         }
         return Buffer.buffer(BaseEncoding.base16().decode(data.toUpperCase()));
     }

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
@@ -159,20 +159,21 @@ public final class SigfoxProtocolAdapter
         LOG.debug("{} handler - deviceTenant: {}, requestTenant: {}, deviceId: {}, data: {}",
                 ctx.request().method(), deviceTenant, requestTenant, deviceId, strData);
 
-        if ( requestTenant == null ) {
-            ctx.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST,
+        if (requestTenant == null) {
+            ctx.fail(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND,
                     "missing the tenant information in the request URL"));
             return;
         }
 
         if (!requestTenant.equals(deviceTenant)) {
-            ctx.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST,
+            ctx.fail(new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN,
                     "tenant information mismatch"));
             return;
         }
 
-        final String contentType = (data != null) ? CONTENT_TYPE_OCTET_STREAM
-                : EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION;
+        final String contentType = Optional.ofNullable(data)
+                .map(d -> CONTENT_TYPE_OCTET_STREAM)
+                .orElse(EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION);
 
         uploadHandler.upload(ctx, deviceTenant, deviceId, data, contentType);
     }

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapterProperties.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapterProperties.java
@@ -43,7 +43,7 @@ public class SigfoxProtocolAdapterProperties extends HttpProtocolAdapterProperti
     }
 
     /**
-     * Set a custom TTD value which is being used when an ack is required.
+     * Sets a custom TTD value which is being used when an ack is required.
      * <p>
      * This defaults to the Sigfox default of 20 seconds. Only change this when you know what you are doing.
      *
@@ -58,6 +58,13 @@ public class SigfoxProtocolAdapterProperties extends HttpProtocolAdapterProperti
         this.ttdWhenAckRequired = ttdWhenAckRequired;
     }
 
+    /**
+     * Gets the TTD value which is being used when an ack is required.
+     * <p>
+     * This defaults to the Sigfox default of 20 seconds. Only change this when you know what you are doing.
+     *
+     * @return The custom value to set the TTD to.
+     */
     public int getTtdWhenAckRequired() {
         return ttdWhenAckRequired;
     }

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpUtils.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpUtils.java
@@ -89,6 +89,20 @@ public final class HttpUtils {
     }
 
     /**
+     * Fails a routing context with HTTP status code 404 (Not Found) and an optional message.
+     *
+     * @param ctx The vert.x routing context to fail.
+     * @param msg The message to write to the response's body (may be {@code null}).
+     * @throws NullPointerException if routing context is {@code null}.
+     */
+    public static void notFound(final RoutingContext ctx, final String msg) {
+        failWithHeaders(
+                ctx,
+                new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND, msg),
+                null);
+    }
+
+    /**
      * Fails a routing context with HTTP status code 500 (Internal Error) and an optional message.
      *
      * @param ctx The vert.x routing context to fail.

--- a/site/documentation/content/user-guide/http-adapter.md
+++ b/site/documentation/content/user-guide/http-adapter.md
@@ -251,7 +251,7 @@ content-length: 23
 
 ## Publish Telemetry Data (authenticated Gateway)
 
-* URI: `/telemetry/${tenantId}/${deviceId}`
+* URI: `/telemetry/${tenantId}/${deviceId}` or `/telemetry//${deviceId}`
 * Method: `PUT`
 * Request Headers:
   * (optional) *authorization*: The gateway's *auth-id* and plain text password encoded according to the
@@ -318,28 +318,29 @@ retrieving a *registration assertion* for the device from the configured
 
 **Examples**
 
-Publish some JSON data for device `4712`:
+Publish some JSON data on behalf of device `4712`:
 
 ~~~sh
-curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'content-type: application/json' --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry/DEFAULT_TENANT/4712
+curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'content-type: application/json' --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry//4712
 
 HTTP/1.1 202 Accepted
 content-length: 0
 ~~~
 
-Publish some JSON data for device `4712` using *at least once* QoS:
+Publish some JSON data on behalf of device `4712` using *at least once* QoS:
 
 ~~~sh
-curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'content-type: application/json' -H 'qos-level: 1' --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry/DEFAULT_TENANT/4712
+curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'content-type: application/json' -H 'qos-level: 1' --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry//4712
 
 HTTP/1.1 202 Accepted
 content-length: 0
 ~~~
 
-Publish some JSON data for device `4712`, indicating that the gateway will wait for 10 seconds to receive the response:
+Publish some JSON data on behalf of device `4712`, indicating that the gateway will wait for 10 seconds to receive the
+response:
 
 ~~~sh
-curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'content-type: application/json' -H 'hono-ttd: 10' --data-binary '{"temp": 5}' http://localhost:8080/telemetry/DEFAULT_TENANT/4712
+curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'content-type: application/json' -H 'hono-ttd: 10' --data-binary '{"temp": 5}' http://localhost:8080/telemetry//4712
 
 HTTP/1.1 200 OK
 hono-command: set
@@ -351,8 +352,10 @@ content-length: 23
 }
 ~~~
 
-**NB** The example above assumes that a gateway device has been registered with `hashed-password` credentials with
+{{% notice info %}}
+The example above assumes that a gateway device has been registered with `hashed-password` credentials with
 *auth-id* `gw` and password `gw-secret` which is authorized to publish data *on behalf of* device `4712`.
+{{% /notice %}}
 
 ## Publish an Event (authenticated Device)
 
@@ -469,7 +472,7 @@ content-length: 0
 
 ## Publish an Event (authenticated Gateway)
 
-* URI: `/event/${tenantId}/${deviceId}`
+* URI: `/event/${tenantId}/${deviceId}` or `/event//${deviceId}`
 * Method: `PUT`
 * Request Headers:
   * (optional) *authorization*: The gateway's *auth-id* and plain text password encoded according to the
@@ -527,17 +530,19 @@ retrieving a *registration assertion* for the device from the configured
 
 **Examples**
 
-Publish some JSON data for device `4712`:
+Publish some JSON data on behalf of device `4712`:
 
 ~~~sh
-curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'content-type: application/json' --data-binary '{"temp": 5}' http://127.0.0.1:8080/event/DEFAULT_TENANT/4712
+curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'content-type: application/json' --data-binary '{"temp": 5}' http://127.0.0.1:8080/event//4712
 
 HTTP/1.1 202 Accepted
 content-length: 0
 ~~~
 
-**NB** The example above assumes that a gateway device has been registered with `hashed-password` credentials with
+{{% notice info %}}
+The example above assumes that a gateway device has been registered with `hashed-password` credentials with
 *auth-id* `gw` and password `gw-secret` which is authorized to publish data *on behalf of* device `4712`.
+{{% /notice %}}
 
 ## Command & Control
 
@@ -711,7 +716,8 @@ content-length: 0
 ### Sending a Response to a Command (authenticated Gateway)
 
 * URI: `/command/res/${tenantId}/${deviceId}/${commandRequestId}` or
-  `/command/res/${tenantId}/${deviceId}/${commandRequestId}?hono-cmd-status=${status}`
+  `/command/res/${tenantId}/${deviceId}/${commandRequestId}?hono-cmd-status=${status}` or
+  `/command/res//${deviceId}/${commandRequestId}` or `/command/res//${deviceId}/${commandRequestId}?hono-cmd-status=${status}`
 * Method: `PUT`
 * Request Headers:
   * (optional) *authorization*: The gateway's *auth-id* and plain text password encoded according to the
@@ -758,17 +764,19 @@ by means of retrieving a *registration assertion* for the device from the config
 
 **Examples**
 
-Send a response to a previously received command with the command-request-id `req-id-uuid` for device `4712`:
+Send a response to a previously received command with the command-request-id `req-id-uuid` on behalf of device `4712`:
 
 ~~~sh
-curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'content-type: application/json' --data-binary '{"brightness-changed": true}' http://127.0.0.1:8080/command/res/DEFAULT_TENANT/4712/req-id-uuid?hono-cmd-status=200
+curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'content-type: application/json' --data-binary '{"brightness-changed": true}' http://127.0.0.1:8080/command/res//4712/req-id-uuid?hono-cmd-status=200
 
 HTTP/1.1 202 Accepted
 content-length: 0
 ~~~
 
-**NB** The example above assumes that a gateway device has been registered with `hashed-password` credentials with
+{{% notice info %}}
+The example above assumes that a gateway device has been registered with `hashed-password` credentials with
 *auth-id* `gw` and password `gw-secret` which is authorized to publish data *on behalf of* device `4712`.
+{{% /notice %}}
 
 ## Downstream Meta Data
 

--- a/site/documentation/content/user-guide/http-adapter.md
+++ b/site/documentation/content/user-guide/http-adapter.md
@@ -366,8 +366,10 @@ The example above assumes that a gateway device has been registered with `hashed
     [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the
     device to present a client certificate as part of the TLS handshake during connection establishment.
   * (required) *content-type*: The type of payload contained in the request body.
-  * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
-  * (optional) *hono-ttl*: The *time-to-live* in number of seconds for event messages.  
+  * (optional) *hono-ttd*: The number of seconds the device will wait for the response. Alternatively, this may be
+    specified using a URI query parameter of the same name.
+  * (optional) *hono-ttl*: The message's *time-to-live* in number of seconds. Alternatively, this may be
+    specified using a URI query parameter of the same name.
 * Request Body:
   * (required) Arbitrary payload encoded according to the given content type.
 * Response Headers:
@@ -422,8 +424,10 @@ content-length: 0
 * Method: `PUT`
 * Request Headers:
   * (required) *content-type*: The type of payload contained in the request body.
-  * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
-  * (optional) *hono-ttl*: The *time-to-live* in number of seconds for event messages.
+  * (optional) *hono-ttd*: The number of seconds the device will wait for the response. Alternatively, this may be
+    specified using a URI query parameter of the same name.
+  * (optional) *hono-ttl*: The message's *time-to-live* in number of seconds. Alternatively, this may be
+    specified using a URI query parameter of the same name.
 * Request Body:
   * (required) Arbitrary payload encoded according to the given content type.
 * Response Headers:
@@ -479,8 +483,10 @@ content-length: 0
     [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the
     gateway to present a client certificate as part of the TLS handshake during connection establishment.
   * (required) *content-type*: The type of payload contained in the request body.
-  * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
-  * (optional) *hono-ttl*: The *time-to-live* in number of seconds for event messages.
+  * (optional) *hono-ttd*: The number of seconds the device will wait for the response. Alternatively, this may be
+    specified using a URI query parameter of the same name.
+  * (optional) *hono-ttl*: The message's *time-to-live* in number of seconds. Alternatively, this may be
+    specified using a URI query parameter of the same name.
 * Request Body:
   * (required) Arbitrary payload encoded according to the given content type.
 * Response Headers:

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -6,6 +6,13 @@ description = "Information about changes in recent Hono releases. Includes new f
 
 ## 2.0.0 (not yet released)
 
+### New features
+
+* The HTTP protocol adapter now allows authenticated gateway devices to omit the tenant ID from the URI of requests
+  used to upload telemetry, event or command response messages.
+* The AMQP protocol adapter now allows authenticated gateway devices to omit the tenant ID from the address of
+  messages used to upload telemetry or event messages.
+
 ### Fixes & Enhancements
 
 * The Quarkus variant of the MongoDB based device registry failed to start up if the *hono.mongodb.dbName* property

--- a/tests/src/test/resources/http/application.yml
+++ b/tests/src/test/resources/http/application.yml
@@ -74,6 +74,7 @@ hono:
   kafka:
     commonClientConfig:
       bootstrap.servers: ${hono.kafka.bootstrap.servers}
+      max.block.ms: 1000
 
 quarkus:
   application:


### PR DESCRIPTION
This is the first step for #3199

The HTTP protocol adapter has been changed to allow authenticated
gateway devices to omit the tenant ID from the URI of requests
used to upload telemetry or event messages.
