### PR TITLE
Remove support for Jaeger context propagation

### DIFF
--- a/adapters/base-quarkus/pom.xml
+++ b/adapters/base-quarkus/pom.xml
@@ -67,11 +67,6 @@
       <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>
     <dependency>
-      <!-- adding support for jaeger propagator -->
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-extension-trace-propagators</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -101,7 +101,6 @@ quarkus.micrometer.binder.kafka.enabled=false
 quarkus.micrometer.binder.system=true
 quarkus.micrometer.binder.vertx.enabled=true
 quarkus.micrometer.export.prometheus.path=/prometheus
-quarkus.opentelemetry.propagators=tracecontext,baggage,jaeger
 quarkus.smallrye-health.root-path=${health.check.root-path}
 quarkus.smallrye-health.liveness-path=${health.check.liveness-path}
 quarkus.smallrye-health.readiness-path=${health.check.readiness-path}

--- a/clients/amqp-connection/pom.xml
+++ b/clients/amqp-connection/pom.xml
@@ -65,11 +65,6 @@
       <artifactId>opentelemetry-sdk</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-extension-trace-propagators</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/clients/amqp-connection/src/test/java/org/eclipse/hono/client/amqp/tracing/MessageAnnotationsInjectExtractAdapterTest.java
+++ b/clients/amqp-connection/src/test/java/org/eclipse/hono/client/amqp/tracing/MessageAnnotationsInjectExtractAdapterTest.java
@@ -23,8 +23,8 @@ import org.apache.qpid.proton.message.Message;
 import org.junit.jupiter.api.Test;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
-import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
 import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentracing.Span;
@@ -79,7 +79,7 @@ public class MessageAnnotationsInjectExtractAdapterTest {
     @Test
     public void testTracerShimCanUseAdapter() {
         final OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
-                .setPropagators(ContextPropagators.create(JaegerPropagator.getInstance()))
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
                 .build();
         final Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
         final Span span = tracer.buildSpan("do").start();

--- a/clients/kafka-common/pom.xml
+++ b/clients/kafka-common/pom.xml
@@ -111,11 +111,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-extension-trace-propagators</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.hono</groupId>
       <artifactId>kafka-test-utils</artifactId>
       <scope>test</scope>

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/tracing/KafkaHeadersInjectExtractAdapterTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/tracing/KafkaHeadersInjectExtractAdapterTest.java
@@ -23,8 +23,8 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
-import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
 import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentracing.Span;
@@ -69,7 +69,7 @@ public class KafkaHeadersInjectExtractAdapterTest {
     @Test
     public void testTracerShimCanUseAdapter() {
         final OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
-                .setPropagators(ContextPropagators.create(JaegerPropagator.getInstance()))
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
                 .build();
         final Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
         final Span span = tracer.buildSpan("do").start();

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -174,11 +174,6 @@
       <artifactId>opentelemetry-sdk</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-extension-trace-propagators</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/test/java/org/eclipse/hono/tracing/JsonObjectInjectExtractAdapterTest.java
+++ b/core/src/test/java/org/eclipse/hono/tracing/JsonObjectInjectExtractAdapterTest.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
-import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
 import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentracing.Span;
@@ -74,7 +74,7 @@ public class JsonObjectInjectExtractAdapterTest {
     @Test
     public void testTracerShimCanUseAdapter() {
         final OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
-                .setPropagators(ContextPropagators.create(JaegerPropagator.getInstance()))
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
                 .build();
         final Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
         final Span span = tracer.buildSpan("do").start();

--- a/core/src/test/java/org/eclipse/hono/tracing/MultiMapInjectExtractAdapterTest.java
+++ b/core/src/test/java/org/eclipse/hono/tracing/MultiMapInjectExtractAdapterTest.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
-import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
 import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentracing.Span;
@@ -64,7 +64,7 @@ public class MultiMapInjectExtractAdapterTest {
     @Test
     public void testTracerShimCanUseAdapter() {
         final OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
-                .setPropagators(ContextPropagators.create(JaegerPropagator.getInstance()))
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
                 .build();
         final Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
         final Span span = tracer.buildSpan("do").start();

--- a/legal/src/main/resources/legal/DEPENDENCIES
+++ b/legal/src/main/resources/legal/DEPENDENCIES
@@ -89,7 +89,6 @@ maven/mavencentral/io.opentelemetry/opentelemetry-context/1.9.1, Apache-2.0, app
 maven/mavencentral/io.opentelemetry/opentelemetry-exporter-otlp-common/1.9.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.opentelemetry/opentelemetry-exporter-otlp-trace/1.9.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.opentelemetry/opentelemetry-extension-annotations/1.9.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.opentelemetry/opentelemetry-extension-trace-propagators/1.9.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.opentelemetry/opentelemetry-opentracing-shim/1.9.0-alpha, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.opentelemetry/opentelemetry-sdk/1.9.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.opentelemetry/opentelemetry-sdk-common/1.9.1, Apache-2.0, approved, clearlydefined

--- a/legal/src/main/resources/legal/hono-maven.deps
+++ b/legal/src/main/resources/legal/hono-maven.deps
@@ -89,7 +89,6 @@ io.opentelemetry:opentelemetry-context:jar:1.9.1
 io.opentelemetry:opentelemetry-exporter-otlp-common:jar:1.9.1
 io.opentelemetry:opentelemetry-exporter-otlp-trace:jar:1.9.1
 io.opentelemetry:opentelemetry-extension-annotations:jar:1.9.1
-io.opentelemetry:opentelemetry-extension-trace-propagators:jar:1.9.1
 io.opentelemetry:opentelemetry-opentracing-shim:jar:1.9.0-alpha
 io.opentelemetry:opentelemetry-sdk-common:jar:1.9.1
 io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:jar:1.9.1

--- a/services/base-quarkus/pom.xml
+++ b/services/base-quarkus/pom.xml
@@ -71,11 +71,6 @@
       <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>
     <dependency>
-      <!-- adding support for jaeger propagator -->
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-extension-trace-propagators</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>

--- a/site/documentation/content/admin-guide/monitoring-tracing-config.md
+++ b/site/documentation/content/admin-guide/monitoring-tracing-config.md
@@ -128,6 +128,11 @@ Please refer to the
 [Quarkus OpenTelemetry documentation](https://quarkus.io/guides/opentelemetry#quarkus-opentelemetry-exporter-otlp_configuration)
 for further configuration trace exporter options.
 
+In order to integrate traces from Hono with those from other applications, Hono supports reading and writing trace
+context information from and to messages exchanged with these applications. This is done according to the
+[W3C Trace Context](https://www.w3.org/TR/trace-context/) and the [W3C Baggage](https://www.w3.org/TR/baggage/)
+specifications.
+
 ## OpenTracing instrumentation
 
 [OpenTracing](https://opentracing.io/) is a predecessor to [OpenTelemetry](https://opentelemetry.io/). Hono components

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -93,6 +93,10 @@ description = "Information about changes in recent Hono releases. Includes new f
   configure the trace sampling and the OpenTelemetry Collector endpoint to send the traces to. The `jaeger` Maven build
   profile used for including the Jaeger client in the Hono images has been removed. In order to forward Hono traces to a
   Jaeger back-end, the OpenTelemetry Collector should be configured accordingly.
+* The Hono components now support reading and writing trace context information from and to messages exchanged with
+  other applications in the format defined by the [W3C Trace Context](https://www.w3.org/TR/trace-context/) and the
+  [W3C Baggage](https://www.w3.org/TR/baggage/) specifications. The Jaeger native propagation format used in earlier Hono
+  versions is not supported any more.
 
 ### Deprecations
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -340,11 +340,6 @@
       <artifactId>opentelemetry-sdk</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-extension-trace-propagators</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -87,8 +87,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
-import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
 import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentracing.Tracer;
@@ -486,7 +486,7 @@ public final class IntegrationTestSupport {
     public static final int KAFKA_TOPIC_CREATION_ADD_TO_TIMEOUT = 2; // seconds to add
 
     private static final OpenTelemetry OPENTELEMETRY = OpenTelemetrySdk.builder()
-            .setPropagators(ContextPropagators.create(JaegerPropagator.getInstance()))
+            .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
             .build();
     /**
      * An OpenTracing tracer that can be used by devices and downstream clients to inject


### PR DESCRIPTION
Supporting the W3C Trace Context and W3C Baggage specifications should be sufficient.
Relates to #3190.