### PR TITLE
[#3199] Allow gateways to omit tenant ID with CoAP adapter

### DIFF
--- a/adapters/coap-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/coap/RequestDeviceAndAuth.java
+++ b/adapters/coap-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/coap/RequestDeviceAndAuth.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,7 +19,7 @@ import org.eclipse.hono.auth.Device;
 /**
  * Contains device and authentication related information pertaining to a CoAP request message.
  */
-public class RequestDeviceAndAuth {
+public final class RequestDeviceAndAuth {
 
     /**
      * Request message's origin device.
@@ -55,7 +55,7 @@ public class RequestDeviceAndAuth {
      *
      * @return The device.
      */
-    public final Device getOriginDevice() {
+    public Device getOriginDevice() {
         return originDevice;
     }
 
@@ -66,7 +66,7 @@ public class RequestDeviceAndAuth {
      *
      * @return The authentication identifier or {@code null}.
      */
-    public final String getAuthId() {
+    public String getAuthId() {
         return authId;
     }
 
@@ -80,7 +80,7 @@ public class RequestDeviceAndAuth {
      *
      * @return The authenticated device or {@code null}.
      */
-    public final Device getAuthenticatedDevice() {
+    public Device getAuthenticatedDevice() {
         return authenticatedDevice;
     }
 

--- a/adapters/coap-vertx-quarkus/src/test/java/org/eclipse/hono/adapter/coap/AbstractHonoResourceTest.java
+++ b/adapters/coap-vertx-quarkus/src/test/java/org/eclipse/hono/adapter/coap/AbstractHonoResourceTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.coap;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.security.Principal;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.coap.OptionSet;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.elements.EndpointContext;
+import org.eclipse.californium.elements.auth.AdditionalInfo;
+import org.eclipse.californium.elements.auth.ExtensiblePrincipal;
+import org.eclipse.hono.auth.Device;
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import io.opentracing.noop.NoopTracerFactory;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+
+/**
+ * A AbstractHonoResourceTest.
+ *
+ */
+@ExtendWith(VertxExtension.class)
+class AbstractHonoResourceTest extends ResourceTestBase {
+
+    private AbstractHonoResource givenAResource(final CoapProtocolAdapter adapter) {
+
+        return new AbstractHonoResource("test", adapter, NoopTracerFactory.create(), vertx) {
+        };
+    }
+
+    private Request newRequest(final String uri, final Device authenticatedDevice) {
+
+        final var sourceContext = mock(EndpointContext.class);
+        Optional.ofNullable(authenticatedDevice).ifPresent(device -> {
+            final var info = AdditionalInfo.from(Map.of(DeviceInfoSupplier.EXT_INFO_KEY_HONO_DEVICE, device));
+            @SuppressWarnings("unchecked")
+            final ExtensiblePrincipal<Principal> peerIdentity = mock(ExtensiblePrincipal.class);
+            when(peerIdentity.getExtendedInfo()).thenReturn(info);
+            when(sourceContext.getPeerIdentity()).thenReturn(peerIdentity);
+        });
+        final var options = new OptionSet();
+        options.setUriPath(uri);
+        final Request request = mock(Request.class);
+        when(request.getType()).thenReturn(Type.CON);
+        when(request.isConfirmable()).thenReturn(true);
+        when(request.getOptions()).thenReturn(options);
+        when(request.getSourceContext()).thenReturn(sourceContext);
+        return request;
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "true,/telemetry/DEFAULT_TENANT/device_1",
+            "false,/telemetry/DEFAULT_TENANT/device_1",
+            "true,/telemetry//device_1",
+            "true,/event/DEFAULT_TENANT/device_1",
+            "false,/event/DEFAULT_TENANT/device_1",
+            "true,/event//device_1",
+            "true,/command_response/DEFAULT_TENANT/device_1/request_id",
+            "false,/command_response/DEFAULT_TENANT/device_1/request_id",
+            "true,/command_response//device_1/request_id"
+            })
+    void getPutRequestDeviceAndAuthSucceeds(
+            final boolean isDeviceAuthenticated,
+            final String uri,
+            final VertxTestContext ctx) {
+
+        // GIVEN an adapter
+        givenAnAdapter(properties);
+        final var resource = givenAResource(adapter);
+        final var request = newRequest(uri, isDeviceAuthenticated ? new Device("DEFAULT_TENANT", "device_1") : null);
+        final var exchange = newCoapExchange(Buffer.buffer(), request);
+        resource.getPutRequestDeviceAndAuth(exchange)
+            .onComplete(ctx.succeeding(r -> {
+                ctx.verify(() -> {
+                    assertThat(r.getOriginDevice().getTenantId().equals("DEFAULT_TENANT"));
+                    assertThat(r.getOriginDevice().getDeviceId().equals("device_1"));
+                });
+                ctx.completeNow();
+            }));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "true,/telemetry/OTHER_TENANT/device_1,403",
+            "false,/telemetry//device_1,404",
+            "true,/event/OTHER_TENANT/device_1,403",
+            "false,/event//device_1,404",
+            "true,/command_response/OTHER_TENANT/device_1/request_id,403",
+            "false,/event//device_1/request_id,404"
+            })
+    void getPutRequestDeviceAndAuthFailsForInvalidUri(
+            final boolean isDeviceAuthenticated,
+            final String uri,
+            final int expectedErrorCode,
+            final VertxTestContext ctx) {
+
+        // GIVEN an adapter
+        givenAnAdapter(properties);
+        final var resource = givenAResource(adapter);
+        final var request = newRequest(uri, isDeviceAuthenticated ? new Device("DEFAULT_TENANT", "device_1") : null);
+        final var exchange = newCoapExchange(Buffer.buffer(), request);
+        resource.getPutRequestDeviceAndAuth(exchange)
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> {
+                    assertThat(t).isInstanceOf(ClientErrorException.class);
+                    assertThat(ServiceInvocationException.extractStatusCode(t)).isEqualTo(expectedErrorCode);
+                });
+                ctx.completeNow();
+            }));
+    }
+}

--- a/adapters/coap-vertx-quarkus/src/test/java/org/eclipse/hono/adapter/coap/ResourceTestBase.java
+++ b/adapters/coap-vertx-quarkus/src/test/java/org/eclipse/hono/adapter/coap/ResourceTestBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -59,11 +59,16 @@ abstract class ResourceTestBase extends CoapProtocolAdapterMockSupport<CoapProto
     }
 
     static CoapExchange newCoapExchange(final Buffer payload, final Type requestType, final OptionSet options) {
-
         final Request request = mock(Request.class);
         when(request.getType()).thenReturn(requestType);
         when(request.isConfirmable()).thenReturn(requestType == Type.CON);
         when(request.getOptions()).thenReturn(options);
+        return newCoapExchange(payload, request);
+    }
+
+    static CoapExchange newCoapExchange(final Buffer payload, final Request request) {
+
+        final OptionSet options = request.getOptions();
         final Object identity = "dummy";
         final Exchange exchange = new Exchange(request, identity, Origin.REMOTE, mock(Executor.class));
         final CoapExchange coapExchange = mock(CoapExchange.class);

--- a/site/documentation/content/user-guide/coap-adapter.md
+++ b/site/documentation/content/user-guide/coap-adapter.md
@@ -232,7 +232,7 @@ coap-client -m PUT coap://hono.eclipseprojects.io/telemetry/DEFAULT_TENANT/4711?
 
 ## Publish Telemetry Data (authenticated Gateway)
 
-* URI: `/telemetry/${tenantId}/${deviceId}`
+* URI: `/telemetry/${tenantId}/${deviceId}` or `/telemetry//${deviceId}`
 * Method: `PUT`
 * Type:
   * `CON`: *at least once* delivery semantics
@@ -298,30 +298,32 @@ retrieving a *registration assertion* for the device from the configured
 
 **Examples**
 
-Publish some JSON data for device `4712` using default message type `CON` (*at least once*):
+Publish some JSON data on behalf of device `4712` using default message type `CON` (*at least once*):
 
 ~~~sh
-coap-client -u gw@DEFAULT_TENANT -k gw-secret -m PUT coaps://hono.eclipseprojects.io/telemetry/DEFAULT_TENANT/4712 -t application/json -e '{"temp": 5}'
+coap-client -u gw@DEFAULT_TENANT -k gw-secret -m PUT coaps://hono.eclipseprojects.io/telemetry//4712 -t application/json -e '{"temp": 5}'
 ~~~
 
-Publish some JSON data for device `4712` using message type `NON` (*at most once*):
+Publish some JSON data on behalf of device `4712` using message type `NON` (*at most once*):
 
 ~~~sh
-coap-client -u gw@DEFAULT_TENANT -k gw-secret -N -m PUT coaps://hono.eclipseprojects.io/telemetry/DEFAULT_TENANT/4712 -t application/json -e '{"temp": 5}'
+coap-client -u gw@DEFAULT_TENANT -k gw-secret -N -m PUT coaps://hono.eclipseprojects.io/telemetry//4712 -t application/json -e '{"temp": 5}'
 ~~~
 
-Publish some JSON data for device `4712`, indicating that the gateway will wait for 10 seconds to receive the response:
+Publish some JSON data on behalf of device `4712`, indicating that the gateway will wait for 10 seconds to receive the response:
 
 ~~~sh
-coap-client -u gw@DEFAULT_TENANT -k gw-secret -m PUT coaps://hono.eclipseprojects.io/telemetry/DEFAULT_TENANT/4712?hono-ttd=10 -t application/json -e '{"temp": 5}'
+coap-client -u gw@DEFAULT_TENANT -k gw-secret -m PUT coaps://hono.eclipseprojects.io/telemetry//4712?hono-ttd=10 -t application/json -e '{"temp": 5}'
 
 {
   "brightness": 87
 }
 ~~~
 
-**NB** The examples above assume that a gateway device has been registered with `psk` credentials with *auth-id* `gw` and
-secret `gw-secret` which is authorized to publish data *on behalf of* device `4712`.
+{{% notice info %}}
+The example above assumes that a gateway device has been registered with `psk` credentials with
+*auth-id* `gw` and secret `gw-secret` which is authorized to publish data *on behalf of* device `4712`.
+{{% /notice %}}
 
 ## Publish an Event (authenticated Device)
 
@@ -473,7 +475,7 @@ coap-client -m PUT coap://hono.eclipseprojects.io/event/DEFAULT_TENANT/4711?hono
 
 ## Publish an Event (authenticated Gateway)
 
-* URI: `/event/${tenantId}/${deviceId}`
+* URI: `/event/${tenantId}/${deviceId}` or `/event//${deviceId}`
 * Method: `PUT`
 * Type:`CON`
 * Request Options:
@@ -533,24 +535,26 @@ retrieving a *registration assertion* for the device from the configured
 
 **Examples**
 
-Publish some JSON data for device `4712` using default message type `CON` (*at least once*):
+Publish some JSON data on behalf of device `4712` using default message type `CON` (*at least once*):
 
 ~~~sh
-coap-client -u gw@DEFAULT_TENANT -k gw-secret -m PUT coaps://hono.eclipseprojects.io/event/DEFAULT_TENANT/4712 -t application/json -e '{"temp": 5}'
+coap-client -u gw@DEFAULT_TENANT -k gw-secret -m PUT coaps://hono.eclipseprojects.io/event//4712 -t application/json -e '{"temp": 5}'
 ~~~
 
-Publish some JSON data for device `4712`, indicating that the gateway will wait for 10 seconds to receive the response:
+Publish some JSON data on behalf of device `4712`, indicating that the gateway will wait for 10 seconds to receive the response:
 
 ~~~sh
-coap-client -u gw@DEFAULT_TENANT -k gw-secret -m PUT coaps://hono.eclipseprojects.io/event/DEFAULT_TENANT/4712?hono-ttd=10 -t application/json -e '{"temp": 5}'
+coap-client -u gw@DEFAULT_TENANT -k gw-secret -m PUT coaps://hono.eclipseprojects.io/event//4712?hono-ttd=10 -t application/json -e '{"temp": 5}'
 
 {
   "brightness": 87
 }
 ~~~
 
-**NB** The examples above assume that a gateway device has been registered with `psk` credentials with *auth-id* `gw` and
-secret `gw-secret` which is authorized to publish data *on behalf of* device `4712`.
+{{% notice info %}}
+The example above assumes that a gateway device has been registered with `psk` credentials with
+*auth-id* `gw` and secret `gw-secret` which is authorized to publish data *on behalf of* device `4712`.
+{{% /notice %}}
 
 ## Command & Control
 
@@ -675,7 +679,7 @@ coap-client -u sensor1@DEFAULT_TENANT -k hono-secret coaps://hono.eclipseproject
 
 ### Sending a Response to a Command (authenticated Gateway)
 
-* URI: `/command_response/${tenantId}/${deviceId}/${commandRequestId}`
+* URI: `/command_response/${tenantId}/${deviceId}/${commandRequestId}` or `/command_response//${deviceId}/${commandRequestId}`
 * Method: `PUT`
 * Type: `CON`
 * Request Options:
@@ -717,15 +721,16 @@ by means of retrieving a *registration assertion* for the device from the config
 
 **Examples**
 
-Send a response to a previously received command with the command-request-id `req-id-uuid` for device `4712`:
+Send a response to a previously received command with the command-request-id `req-id-uuid` on behalf of device `4712`:
 
 ~~~sh
-coap-client -u gw@DEFAULT_TENANT -k gw-secret coaps://hono.eclipseprojects.io/command_response/DEFAULT_TENANT/4712/req-id-uuid?hono-cmd-status=200 -e '{"brightness-changed": true}'
+coap-client -u gw@DEFAULT_TENANT -k gw-secret coaps://hono.eclipseprojects.io/command_response//4712/req-id-uuid?hono-cmd-status=200 -e '{"brightness-changed": true}'
 ~~~
 
-**NB** The example above assumes that a gateway device has been registered with `psk` credentials with *auth-id* `gw` and
-secret `gw-secret` which is authorized to publish data *on behalf of* device `4712`.
-
+{{% notice info %}}
+The example above assumes that a gateway device has been registered with `psk` credentials with
+*auth-id* `gw` and secret `gw-secret` which is authorized to publish data *on behalf of* device `4712`.
+{{% /notice %}}
 
 ## Downstream Meta Data
 

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -10,6 +10,8 @@ description = "Information about changes in recent Hono releases. Includes new f
 
 * The HTTP protocol adapter now allows authenticated gateway devices to omit the tenant ID from the URI of requests
   used to upload telemetry, event or command response messages.
+* The CoAP protocol adapter now allows authenticated gateway devices to omit the tenant ID from the URI of requests
+  used to upload telemetry, event or command response messages.
 * The AMQP protocol adapter now allows authenticated gateway devices to omit the tenant ID from the address of
   messages used to upload telemetry or event messages.
 

--- a/tests/src/test/resources/coap/application.yml
+++ b/tests/src/test/resources/coap/application.yml
@@ -80,6 +80,7 @@ hono:
   kafka:
     commonClientConfig:
       bootstrap.servers: "${hono.kafka.bootstrap.servers}"
+      max.block.ms: 1000
 
 quarkus:
   application:


### PR DESCRIPTION
This is for #3199

The CoAP protocol adapter has been changed to allow authenticated
gateway devices to omit the tenant ID from the URI of requests
used to upload telemetry or event messages.
