### PR TITLE
[#3219] Re-enable parallel execution of unit tests

### DIFF
--- a/adapter-base/pom.xml
+++ b/adapter-base/pom.xml
@@ -145,17 +145,6 @@
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <properties>
-            <configurationParameters>
-              junit.jupiter.execution.parallel.enabled = false
-            </configurationParameters>
-          </properties>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/adapters/amqp-vertx-quarkus/pom.xml
+++ b/adapters/amqp-vertx-quarkus/pom.xml
@@ -62,19 +62,6 @@
         </plugin>
       </plugins>
     </pluginManagement>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <properties>
-            <configurationParameters>
-              junit.jupiter.execution.parallel.enabled = false
-            </configurationParameters>
-          </properties>
-        </configuration>
-      </plugin>
-    </plugins>
   </build>
 
   <profiles>

--- a/adapters/coap-vertx-quarkus/pom.xml
+++ b/adapters/coap-vertx-quarkus/pom.xml
@@ -69,19 +69,6 @@
       </plugins>
     </pluginManagement>
 
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <properties>
-            <configurationParameters>
-              junit.jupiter.execution.parallel.enabled = false
-            </configurationParameters>
-          </properties>
-        </configuration>
-      </plugin>
-    </plugins>
   </build>
 
   <profiles>

--- a/adapters/http-vertx-base/pom.xml
+++ b/adapters/http-vertx-base/pom.xml
@@ -46,17 +46,6 @@
         <groupId>org.jboss.jandex</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <properties>
-            <configurationParameters>
-              junit.jupiter.execution.parallel.enabled = false
-            </configurationParameters>
-          </properties>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 

--- a/adapters/lora-vertx-quarkus/pom.xml
+++ b/adapters/lora-vertx-quarkus/pom.xml
@@ -83,19 +83,6 @@
         </plugin>
       </plugins>
     </pluginManagement>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <properties>
-            <configurationParameters>
-              junit.jupiter.execution.parallel.enabled = false
-            </configurationParameters>
-          </properties>
-        </configuration>
-      </plugin>
-    </plugins>
   </build>
 
   <profiles>

--- a/adapters/mqtt-vertx-base/pom.xml
+++ b/adapters/mqtt-vertx-base/pom.xml
@@ -47,17 +47,6 @@
         <groupId>org.jboss.jandex</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <properties>
-            <configurationParameters>
-              junit.jupiter.execution.parallel.enabled = false
-            </configurationParameters>
-          </properties>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -206,17 +206,6 @@
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <properties>
-            <configurationParameters>
-              junit.jupiter.execution.parallel.enabled = false
-            </configurationParameters>
-          </properties>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 

--- a/services/auth-base/pom.xml
+++ b/services/auth-base/pom.xml
@@ -83,17 +83,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <properties>
-            <configurationParameters>
-              junit.jupiter.execution.parallel.enabled = false
-            </configurationParameters>
-          </properties>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.jboss.jandex</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
       </plugin>

--- a/services/command-router-quarkus/pom.xml
+++ b/services/command-router-quarkus/pom.xml
@@ -105,19 +105,6 @@
         </plugin>
       </plugins>
     </pluginManagement>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <properties>
-            <configurationParameters>
-              junit.jupiter.execution.parallel.enabled = false
-            </configurationParameters>
-          </properties>
-        </configuration>
-      </plugin>
-    </plugins>
 
   </build>
 

--- a/services/device-registry-base/pom.xml
+++ b/services/device-registry-base/pom.xml
@@ -110,17 +110,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <properties>
-            <configurationParameters>
-              junit.jupiter.execution.parallel.enabled = false
-            </configurationParameters>
-          </properties>
-        </configuration>
-      </plugin>
       <!--
         Copy legal documents from "target/classes" folder to "target/test-classes" folder
         so that we make sure to include legal docs in test jar.
@@ -177,7 +166,7 @@
         </executions>
         <configuration>
           <excludes>
-            <exclude>logback-test.xml</exclude>
+            <exclude>application.yml</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/services/device-registry-jdbc-quarkus/pom.xml
+++ b/services/device-registry-jdbc-quarkus/pom.xml
@@ -136,11 +136,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <properties>
-            <configurationParameters>
-              junit.jupiter.execution.parallel.enabled = false
-            </configurationParameters>
-          </properties>
           <systemPropertyVariables>
             <org.eclipse.hono.service.base.jdbc.store.skipDumpingStatementConfiguration>true</org.eclipse.hono.service.base.jdbc.store.skipDumpingStatementConfiguration>
           </systemPropertyVariables>

--- a/services/device-registry-mongodb-quarkus/pom.xml
+++ b/services/device-registry-mongodb-quarkus/pom.xml
@@ -139,11 +139,6 @@
           <systemProperties>
             <mongoDbImageName>${mongodb-image.name}</mongoDbImageName>
           </systemProperties>
-          <properties>
-            <configurationParameters>
-              junit.jupiter.execution.parallel.enabled = false
-            </configurationParameters>
-          </properties>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
A follow up of #3219 

With Quarkus 2.8, a race condition during initialization of logging when
running unit tests has been fixed.
