### PR TITLE
[#3199] Allow gateways to omit tenant ID with MQTT adapter

### DIFF
--- a/site/documentation/content/user-guide/mqtt-adapter.md
+++ b/site/documentation/content/user-guide/mqtt-adapter.md
@@ -177,7 +177,7 @@ mosquitto_pub -t telemetry/DEFAULT_TENANT/4711 -m '{"temp": 5}'
 
 ## Publish Telemetry Data (authenticated Gateway)
 
-* Topic: `telemetry/${tenant-id}/${device-id}` or `t/${tenant-id}/${device-id}`
+* Topic: `telemetry/${tenant-id}/${device-id}` or `t/${tenant-id}/${device-id}` or `telemetry//${device-id}` or `t//${device-id}`
 * Authentication: required
 * Payload:
   * (required) Arbitrary payload
@@ -285,7 +285,7 @@ mosquitto_pub -t event/DEFAULT_TENANT/4711/?hono-ttl=15 -q 1 -m '{"alarm": 1}'
 
 ## Publish an Event (authenticated Gateway)
 
-* Topic: `event/${tenant-id}/${device-id}` or `e/${tenant-id}/${device-id}`
+* Topic: `event/${tenant-id}/${device-id}` or `e/${tenant-id}/${device-id}` or `event//${device-id}` or `e//${device-id}`
 * Authentication: required
 * Payload:
   * (required) Arbitrary payload

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -14,6 +14,8 @@ description = "Information about changes in recent Hono releases. Includes new f
   used to upload telemetry, event or command response messages.
 * The AMQP protocol adapter now allows authenticated gateway devices to omit the tenant ID from the address of
   messages used to upload telemetry or event messages.
+* The MQTT protocol adapter now allows authenticated gateway devices to omit the tenant ID from the topic of
+  messages used to upload telemetry or event messages.
 
 ### Fixes & Enhancements
 

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
@@ -62,8 +62,16 @@ public class EventMqttIT extends MqttPublishTestBase {
             final String deviceId,
             final Buffer payload,
             final boolean useShortTopicName,
+            final boolean includeTenantIdInTopic,
             final Map<String, String> topicPropertyBag) {
-        return send(tenantId, deviceId, payload, useShortTopicName, topicPropertyBag, this::handlePublishAttempt);
+        return send(
+                tenantId,
+                deviceId,
+                payload,
+                useShortTopicName,
+                includeTenantIdInTopic,
+                topicPropertyBag,
+                this::handlePublishAttempt);
     }
 
     private Future<Integer> send(
@@ -71,13 +79,14 @@ public class EventMqttIT extends MqttPublishTestBase {
             final String deviceId,
             final Buffer payload,
             final boolean useShortTopicName,
+            final boolean includeTenantIdInTopic,
             final Map<String, String> topicPropertyBag,
             final BiConsumer<AsyncResult<Integer>, Promise<Integer>> sendAttemptHandler) {
 
         final String topic = String.format(
                 TOPIC_TEMPLATE,
                 useShortTopicName ? EventConstants.EVENT_ENDPOINT_SHORT : EventConstants.EVENT_ENDPOINT,
-                tenantId,
+                includeTenantIdInTopic ? tenantId : "",
                 deviceId);
         final Promise<Integer> result = Promise.promise();
         mqttClient.publish(
@@ -132,7 +141,7 @@ public class EventMqttIT extends MqttPublishTestBase {
         // WHEN a device that belongs to the tenant publishes an event
         final AtomicInteger receivedMessageCount = new AtomicInteger(0);
         connectToAdapter(IntegrationTestSupport.getUsername(deviceId, tenantId), "secret")
-        .compose(connAck -> send(tenantId, deviceId, Buffer.buffer("hello"), false, null, (sendAttempt, result) -> {
+        .compose(connAck -> send(tenantId, deviceId, Buffer.buffer("hello"), false, true, null, (sendAttempt, result) -> {
             if (sendAttempt.succeeded()) {
                 LOGGER.info("successfully sent event [tenant-id: {}, device-id: {}]", tenantId, deviceId);
                 result.complete();
@@ -190,7 +199,7 @@ public class EventMqttIT extends MqttPublishTestBase {
         }
 
         // WHEN a device that belongs to the tenant publishes an event
-        send(tenantId, deviceId, Buffer.buffer(messagePayload), false, null, (sendAttempt, result) -> {
+        send(tenantId, deviceId, Buffer.buffer(messagePayload), false, true, null, (sendAttempt, result) -> {
             if (sendAttempt.succeeded()) {
                 LOGGER.debug("successfully sent event [tenant-id: {}, device-id: {}]", tenantId, deviceId);
                 // THEN create a consumer once the event message has been successfully sent

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS0IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS0IT.java
@@ -57,12 +57,13 @@ public class TelemetryMqttQoS0IT extends MqttPublishTestBase {
             final String deviceId,
             final Buffer payload,
             final boolean useShortTopicName,
+            final boolean includeTenantIdInTopic,
             final Map<String, String> topicPropertyBag) {
 
         final String topic = String.format(
                 TOPIC_TEMPLATE,
                 useShortTopicName ? TelemetryConstants.TELEMETRY_ENDPOINT_SHORT : TelemetryConstants.TELEMETRY_ENDPOINT,
-                tenantId,
+                includeTenantIdInTopic ? tenantId : "",
                 deviceId);
         final Promise<Integer> result = Promise.promise();
         // throttle sending to allow adapter to be replenished with credits from consumer

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS1IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS1IT.java
@@ -69,9 +69,17 @@ public class TelemetryMqttQoS1IT extends MqttPublishTestBase {
             final String deviceId,
             final Buffer payload,
             final boolean useShortTopicName,
+            final boolean includeTenantIdInTopic,
             final Map<String, String> topicPropertyBag) {
 
-        return send(tenantId, deviceId, payload, useShortTopicName, topicPropertyBag, DEFAULT_PUBLISH_COMPLETION_TIMEOUT);
+        return send(
+                tenantId,
+                deviceId,
+                payload,
+                useShortTopicName,
+                includeTenantIdInTopic,
+                topicPropertyBag,
+                DEFAULT_PUBLISH_COMPLETION_TIMEOUT);
     }
 
     private Future<Integer> send(
@@ -79,13 +87,14 @@ public class TelemetryMqttQoS1IT extends MqttPublishTestBase {
             final String deviceId,
             final Buffer payload,
             final boolean useShortTopicName,
+            final boolean includeTenantIdInTopic,
             final Map<String, String> topicPropertyBag,
             final long publishCompletionTimeout) {
 
         final String topic = String.format(
                 TOPIC_TEMPLATE,
                 useShortTopicName ? TelemetryConstants.TELEMETRY_ENDPOINT_SHORT : TelemetryConstants.TELEMETRY_ENDPOINT,
-                tenantId,
+                includeTenantIdInTopic ? tenantId : "",
                 deviceId);
         final Promise<Integer> result = Promise.promise();
         mqttClient.publish(
@@ -140,7 +149,7 @@ public class TelemetryMqttQoS1IT extends MqttPublishTestBase {
                 ctx,
                 tenantId,
                 connectToAdapter(IntegrationTestSupport.getUsername(deviceId, tenantId), password),
-                (payload) -> send(tenantId, deviceId, payload, true, null, publishCompletionTimeout)
+                (payload) -> send(tenantId, deviceId, payload, true, true, null, publishCompletionTimeout)
                         .map(String::valueOf),
                 (messageHandler) -> Future.succeededFuture(), // no consumer created here (future succeeded with null value)
                 (msg) -> {


### PR DESCRIPTION
The last step of #3199

The MQTT protocol adapter has been changed to allow authenticated
gateway devices to omit the tenant ID from the topic of messages
used to upload telemetry or event messages.
