### PR TITLE
Drop event bus message spans

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/quarkus/DropBySpanNamePrefixSampler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/quarkus/DropBySpanNamePrefixSampler.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.service.quarkus;
+
+import java.util.List;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+
+/**
+ * Sampler that drops spans based on a given list of span name prefixes.
+ */
+public class DropBySpanNamePrefixSampler implements Sampler {
+
+    private final Sampler sampler;
+    private final List<String> spanNamePrefixList;
+
+    /**
+     * Creates a new DropBySpanNamePrefixSampler.
+     *
+     * @param sampler Sampler to use if the span name didn't match the given prefixes.
+     * @param spanNamePrefixList The list of prefixes to match the span name against for the decision whether to drop
+     *            the span.
+     */
+    public DropBySpanNamePrefixSampler(final Sampler sampler, final List<String> spanNamePrefixList) {
+        this.sampler = sampler;
+        this.spanNamePrefixList = spanNamePrefixList;
+    }
+
+    @Override
+    public SamplingResult shouldSample(final Context parentContext, final String traceId, final String spanName, final SpanKind spanKind,
+            final Attributes attributes, final List<LinkData> parentLinks) {
+
+        for (final String spanNamePrefix : spanNamePrefixList) {
+            if (spanName.startsWith(spanNamePrefix)) {
+                return SamplingResult.drop();
+            }
+        }
+        return sampler.shouldSample(parentContext, traceId, spanName, spanKind, attributes, parentLinks);
+    }
+
+    @Override
+    public String getDescription() {
+        return sampler.getDescription();
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/quarkus/DropHttpRequestSpansSampler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/quarkus/DropHttpRequestSpansSampler.java
@@ -12,7 +12,6 @@
  */
 package org.eclipse.hono.service.quarkus;
 
-import java.net.URI;
 import java.util.List;
 
 import io.opentelemetry.api.common.Attributes;
@@ -43,23 +42,12 @@ public class DropHttpRequestSpansSampler implements Sampler {
     public SamplingResult shouldSample(final Context parentContext, final String traceId, final String spanName, final SpanKind spanKind,
             final Attributes attributes, final List<LinkData> parentLinks) {
         if (spanKind.equals(SpanKind.SERVER)) {
-            final String httpTargetPath = getHttpTargetPath(attributes.get(SemanticAttributes.HTTP_TARGET));
-            if (httpTargetPath != null && !httpTargetPath.isBlank() && httpTargetPath.equals(spanName)) {
+            final String httpTarget = attributes.get(SemanticAttributes.HTTP_TARGET);
+            if (httpTarget != null && httpTarget.equals(spanName)) {
                 return SamplingResult.drop();
             }
         }
         return sampler.shouldSample(parentContext, traceId, spanName, spanKind, attributes, parentLinks);
-    }
-
-    private String getHttpTargetPath(final String httpTarget) {
-        if (httpTarget != null) {
-            try {
-                return URI.create(httpTarget).getPath();
-            } catch (final IllegalArgumentException e) {
-                // ignore
-            }
-        }
-        return null;
     }
 
     @Override

--- a/service-base/src/main/java/org/eclipse/hono/service/quarkus/SamplerProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/quarkus/SamplerProducer.java
@@ -12,12 +12,15 @@
  */
 package org.eclipse.hono.service.quarkus;
 
+import java.util.List;
 import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
+import org.eclipse.hono.util.AuthenticationConstants;
+import org.eclipse.hono.util.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +55,12 @@ public class SamplerProducer {
         // Dropping all requests spans also makes sure there are no liveness/readiness request spans created.
         // Suppression of these spans via "quarkus.opentelemetry.tracer.suppress-non-application-uris" doesn't work
         // if the non-application-root-path is the same as the overall root path.
-        return new DropHttpRequestSpansSampler(sampler);
+        sampler = new DropHttpRequestSpansSampler(sampler);
+        // drop spans for the given event bus message prefixes
+        return new DropBySpanNamePrefixSampler(
+                sampler,
+                List.of(Constants.EVENT_BUS_ADDRESS_NOTIFICATION_PREFIX, Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
+                        AuthenticationConstants.EVENT_BUS_ADDRESS_AUTHENTICATION_IN));
     }
 
     private static Sampler getBaseSampler(final String samplerName, final Optional<Double> ratio) {


### PR DESCRIPTION
Follow up of #3219:
With the new Quarkus version, traces for Vert.x event bus messages now get created (by means of [EventBusInstrumenterVertxTracer](https://github.com/quarkusio/quarkus/blob/2.8/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/vertx/EventBusInstrumenterVertxTracer.java)). This means the adapter traces will now include traces like
`notification.tenant-change-v1 send` with `notification.tenant-change-v1 receive` child spans (and corresponding traces for device and credentials changes). And the device registry/command router will contain `authentication.in send` traces (with `authentication.in receive` child span).

These traces just represent an implementation detail on how notification messages and the authentication processing are handled and don't offer real value. Therefore, this PR drops these traces.

Note that the usage of `TracingPolicy.IGNORE` to prevent creation of such traces (as described in the [Vert.x documentation](https://vertx.io/docs/vertx-opentelemetry/java/#_eventbus_tracing)) doesn't work with the current Quarkus version - see https://github.com/quarkusio/quarkus/issues/25417.