### PR TITLE
Remove wording regarding custom properties in telemetry messages

### DIFF
--- a/site/documentation/content/api/telemetry-kafka/index.md
+++ b/site/documentation/content/api/telemetry-kafka/index.md
@@ -90,7 +90,8 @@ The following table provides an overview of the headers a client needs to set on
 | *ttd*           | no              | *int*       | The *time 'til disconnect* indicates the number of seconds that the device will remain connected to the protocol adapter. The value of this header must be interpreted relative to the message's *creation-time*. A value of `-1` is used to indicate that the device will remain connected until further notice, i.e. until another message indicates a *ttd* value of `0`. In absence of this property, the connection status of the device is to be considered indeterminate. *Backend Applications* might use this information to determine a time window during which the device will be able to receive a command. |
 | *ttl*           | no              | *long*      | The *time-to-live* in milliseconds. A consumer of the message SHOULD discard the message if the sum of *creation-time* and *ttl* is greater than the current time (milliseconds since the Unix epoch). |
 
-Protocol adapters MAY add additional headers to the Kafka record. 
+Protocol adapters MAY set additional headers on the Kafka record.  Any such headers will be defined in the adapter's
+corresponding user guide.
 
 The value of the message MUST consist of a byte array containing the telemetry data. The format and encoding of the
 data MUST be indicated by the *content-type* and (optional) *content-encoding* headers of the message.

--- a/site/documentation/content/api/telemetry/index.md
+++ b/site/documentation/content/api/telemetry/index.md
@@ -8,25 +8,31 @@ resources:
   - src: consume.svg
 ---
 
-The *Telemetry* API is used by *Protocol Adapters* to send telemetry data downstream.
-*Business Applications* and other consumers use the API to receive data published by devices belonging to a particular tenant.
+The *Telemetry* API is used by *Protocol Adapters* to send telemetry data downstream. *Business Applications* and other
+consumers use the API to receive data published by devices belonging to a particular tenant.
 <!--more-->
 
-The Telemetry API is defined by means of AMQP 1.0 message exchanges, i.e. a client needs to connect to Hono using AMQP 1.0 in order to invoke operations of the API as described in the following sections. Throughout the remainder of this page we will simply use *AMQP* when referring to AMQP 1.0.
+The Telemetry API is defined by means of AMQP 1.0 message exchanges, i.e. a client needs to connect to Hono using
+AMQP 1.0 in order to invoke operations of the API as described in the following sections. Throughout the remainder of
+this page we will simply use *AMQP* when referring to AMQP 1.0.
 
 ## Southbound Operations
 
-The following operations can be used by *Protocol Adapters* to forward telemetry data received from devices to downstream consumers like *Business Applications*.
+The following operations can be used by *Protocol Adapters* to forward telemetry data received from devices to
+downstream consumers like *Business Applications*.
 
 ### Forward Telemetry Data
 
 **Preconditions**
 
 1. Adapter has established an AMQP connection with the AMQP Messaging Network.
-1. Adapter has established an AMQP link in role *sender* with the AMQP Messaging Network using target address `telemetry/${tenant_id}` where `${tenant_id}` is the ID of the tenant that the client wants to upload telemetry data for. 
-1. The device for which the adapter wants to send telemetry data has been registered (see [Device Registration API]({{< relref "/api/device-registration" >}})).
+1. Adapter has established an AMQP link in role *sender* with the AMQP Messaging Network using target address
+   `telemetry/${tenant_id}` where `${tenant_id}` is the ID of the tenant that the client wants to upload telemetry data for. 
+1. The device for which the adapter wants to send telemetry data has been registered (see
+   [Device Registration API]({{< relref "/api/device-registration" >}})).
 
-The adapter indicates its preferred message delivery mode by means of the *snd-settle-mode* and *rcv-settle-mode* fields of its *attach* frame during link establishment.
+The adapter indicates its preferred message delivery mode by means of the *snd-settle-mode* and *rcv-settle-mode*
+fields of its *attach* frame during link establishment.
 
 | snd-settle-mode        | rcv-settle-mode        | Delivery semantics |
 | :--------------------- | :--------------------- | :----------------- |
@@ -37,12 +43,17 @@ All other combinations are not supported by Hono and may result in the terminati
 
 **Message Flow**
 
-As indicated above, it is up to the discretion of the protocol adapter whether it wants to use *AT LEAST ONCE* or *AT MOST ONCE* delivery semantics.
+As indicated above, it is up to the discretion of the protocol adapter whether it wants to use *AT LEAST ONCE* or
+*AT MOST ONCE* delivery semantics.
 
 Hono's HTTP adapter allows devices to indicate, which delivery semantics they want to use when uploading telemetry data.
-The HTTP adapter always forwards messages unsettled and either ignores the outcome of the message transfer (*AT MOST ONCE*) or waits for the downstream peer to accept the message (*AT LEAST ONCE*) before acknowledging the reception of the message to the device.
+The HTTP adapter always forwards messages unsettled and either ignores the outcome of the message transfer
+(*AT MOST ONCE*) or waits for the downstream peer to accept the message (*AT LEAST ONCE*) before acknowledging the
+reception of the message to the device.
 
-The following sequence diagram illustrates the flow of messages involved in the *HTTP Adapter* forwarding an *unsettled* telemetry data message to the downstream AMQP Messaging Network implementing *AT MOST ONCE* delivery semantics.
+The following sequence diagram illustrates the flow of messages involved in the *HTTP Adapter* forwarding an
+*unsettled* telemetry data message to the downstream AMQP Messaging Network implementing *AT MOST ONCE* delivery
+semantics.
 
 {{< figure src="forward_qos0.svg" title="Forward telemetry data flow (AT MOST ONCE)" >}}
 
@@ -52,11 +63,16 @@ The following sequence diagram illustrates the flow of messages involved in the 
 1. *AMQP 1.0 Messaging Network* acknowledges reception of the message which is ignored by the *HTTP Adapter*.
 
 {{% notice info %}}
-In the example above the HTTP adapter does not wait for the outcome of the transfer of the message to the AMQP Messaging Network before sending back the HTTP response to the device.
-If the messaging network had sent a disposition frame with the *rejected* instead of the *accepted* outcome, the HTTP adapter would still have signaled a 202 status code back to the device. In this case the data would have been lost without the device noticing.
+In the example above the HTTP adapter does not wait for the outcome of the transfer of the message to the AMQP
+Messaging Network before sending back the HTTP response to the device.
+If the messaging network had sent a disposition frame with the *rejected* instead of the *accepted* outcome, the HTTP
+adapter would still have signaled a 202 status code back to the device. In this case the data would have been lost
+without the device noticing.
 {{% /notice %}}
 
-The following sequence diagram illustrates the flow of messages involved in the *HTTP Adapter* forwarding an *unsettled* telemetry data message to the downstream AMQP Messaging Network implementing *AT LEAST ONCE* delivery semantics.
+The following sequence diagram illustrates the flow of messages involved in the *HTTP Adapter* forwarding an
+*unsettled* telemetry data message to the downstream AMQP Messaging Network implementing *AT LEAST ONCE* delivery
+semantics.
 
 {{< figure src="forward_qos1.svg" title="Forward telemetry data flow (AT LEAST ONCE)" >}}
 
@@ -65,7 +81,9 @@ The following sequence diagram illustrates the flow of messages involved in the 
    1. *AMQP 1.0 Messaging Network* acknowledges reception of the message.
    1. *HTTP Adapter* acknowledges the reception of the data to the *Device*.
 
-When the AMQP Messaging Network fails to settle the transfer of a telemetry message or settles the transfer with any other outcome than `accepted`, the protocol adapter MUST NOT try to re-send such rejected messages but SHOULD indicate the failed transfer to the device if the transport protocol provides means to do so.
+When the AMQP Messaging Network fails to settle the transfer of a telemetry message or settles the transfer with any
+other outcome than `accepted`, the protocol adapter MUST NOT try to re-send such rejected messages but SHOULD indicate
+the failed transfer to the device if the transport protocol provides means to do so.
 
 **Message Format**
 
@@ -78,33 +96,49 @@ The following table provides an overview of the properties a client needs to set
 | *device_id*     | yes             | *application-properties* | *string*    | The identifier of the device that the data in the payload is originating from. |
 | *ttd*           | no              | *application-properties* | *int*       | The *time 'til disconnect* indicates the number of seconds that the device will remain connected to the protocol adapter. The value of this property must be interpreted relative to the message's *creation-time*. A value of `-1` is used to indicate that the device will remain connected until further notice, i.e. until another message indicates a *ttd* value of `0`. In absence of this property, the connection status of the device is to be considered indeterminate. *Backend Applications* might use this information to determine a time window during which the device will be able to receive a command. |
 
+Protocol adapters MAY set additional *properties* or *application-properties* on a downstream message. Any such
+properties will be defined in the adapter's corresponding user guide.
 
-The body of the message MUST consist of a single AMQP *Data* section containing the telemetry data. The format and encoding of the data MUST be indicated by the *content-type* and (optional) *content-encoding* properties of the message.
-
-Any additional properties set by the client in either the *properties* or *application-properties* sections are preserved by Hono, i.e. these properties will also be contained in the message delivered to consumers.
+The body of the message MUST consist of a single AMQP *Data* section containing the telemetry data. The format and
+encoding of the data MUST be indicated by the *content-type* and (optional) *content-encoding* properties of the message.
 
 ## Northbound Operations
 
 ### Receive Telemetry Data
 
-Hono delivers messages containing telemetry data reported by a particular device in the same order that they have been received in (using the [Forward Telemetry Data]({{< relref "#forward-telemetry-data" >}}) operation). Hono MAY drop telemetry messages that it cannot deliver to any consumers. Reasons for this include that there are no consumers connected to Hono or the existing consumers are not able to process the messages from Hono fast enough.
+Hono delivers messages containing telemetry data reported by a particular device in the same order that they have been
+received in (using the [Forward Telemetry Data]({{< relref "#forward-telemetry-data" >}}) operation). Hono MAY drop
+telemetry messages that it cannot deliver to any consumers. Reasons for this include that there are no consumers
+connected to Hono or the existing consumers are not able to process the messages from Hono fast enough.
 
-Hono supports multiple non-competing *Business Application* consumers of telemetry data for a given tenant. Hono allows each *Business Application* to have multiple competing consumers for telemetry data for a given tenant to share the load of processing the messages.
+Hono supports multiple non-competing *Business Application* consumers of telemetry data for a given tenant. Hono
+allows each *Business Application* to have multiple competing consumers for telemetry data for a given tenant to
+share the load of processing the messages.
 
 **Preconditions**
 
 1. Client has established an AMQP connection with Hono.
-2. Client has established an AMQP link in role *receiver* with Hono using source address `telemetry/${tenant_id}` where `${tenant_id}` represents the ID of the tenant the client wants to retrieve telemetry data for.
+2. Client has established an AMQP link in role *receiver* with Hono using source address `telemetry/${tenant_id}` where
+   `${tenant_id}` represents the ID of the tenant the client wants to retrieve telemetry data for.
 
-Hono supports both *AT MOST ONCE* as well as *AT LEAST ONCE* delivery of telemetry messages. However, clients SHOULD use *AT LEAST ONCE* delivery in order to support end-to-end flow control and therefore SHOULD set the *snd-settle-mode* field to `unsettled` and the *rcv-settle-mode* field to `first` in their *attach* frame during link establishment.
+Hono supports both *AT MOST ONCE* as well as *AT LEAST ONCE* delivery of telemetry messages. However, clients SHOULD
+use *AT LEAST ONCE* delivery in order to support end-to-end flow control and therefore SHOULD set the *snd-settle-mode*
+field to `unsettled` and the *rcv-settle-mode* field to `first` in their *attach* frame during link establishment.
 
-A client MAY indicate to Hono during link establishment that it wants to distribute the telemetry messages received for a given tenant among multiple consumers by including a link property `subscription-name` whose value is shared by all other consumers of the tenant. Hono ensures that messages from a given device are delivered to the same consumer. Note that this also means that telemetry messages MAY not be evenly distributed among consumers, e.g. when only a single device sends data. **NB** This feature is not supported yet.
+A client MAY indicate to Hono during link establishment that it wants to distribute the telemetry messages received
+for a given tenant among multiple consumers by including a link property `subscription-name` whose value is shared by all
+other consumers of the tenant. Hono ensures that messages from a given device are delivered to the same consumer.
+Note that this also means that telemetry messages MAY not be evenly distributed among consumers, e.g. when only a
+single device sends data. **NB** This feature is not supported yet.
 
-In addition a client MAY include a boolean link property `ordering-required` with value `false` during link establishment in order to indicate to Hono that it does not require messages being delivered strictly in order per device but instead allows for messages being distributed evenly among the consumers. **NB** This feature is not supported yet.
+In addition a client MAY include a boolean link property `ordering-required` with value `false` during link establishment
+in order to indicate to Hono that it does not require messages being delivered strictly in order per device but instead
+allows for messages being distributed evenly among the consumers. **NB** This feature is not supported yet.
 
 **Message Flow**
 
-The following sequence diagram illustrates the flow of messages involved in a *Business Application* receiving a telemetry data message from Hono. The delivery mode used is *AT LEAST ONCE*.
+The following sequence diagram illustrates the flow of messages involved in a *Business Application* receiving a
+telemetry data message from Hono. The delivery mode used is *AT LEAST ONCE*.
 
 {{< figure src="consume.svg" title="Receive Telemetry Data" >}}
 
@@ -112,9 +146,12 @@ The following sequence diagram illustrates the flow of messages involved in a *B
    1. *Business Application* acknowledges reception of message.
 
 {{% notice info %}}
-The *Business Application* can only consume telemetry messages that have been uploaded to Hono *after* the *Business Application* has established the link with the *AMQP 1.0 Messaging Network*. This is because telemetry messages are not *durable*, i.e. they are not persisted in Hono in order to be forwarded at a later time.
+The *Business Application* can only consume telemetry messages that have been uploaded to Hono *after* the *Business
+Application* has established the link with the *AMQP 1.0 Messaging Network*. This is because telemetry messages are
+not *durable*, i.e. they are not persisted in Hono in order to be forwarded at a later time.
 {{% /notice %}}
 
 **Message Format**
 
-The format of the messages containing the telemetry data is the same as for the [Forward Telemetry Data operation]({{< relref "#forward-telemetry-data" >}}).
+The format of the messages containing the telemetry data is the same as for the
+[Forward Telemetry Data operation]({{< relref "#forward-telemetry-data" >}}).

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpUploadTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpUploadTestBase.java
@@ -447,7 +447,8 @@ public abstract class AmqpUploadTestBase extends AmqpAdapterTestBase {
                             msg.getContentType(), msg.getPayload().toString());
                 }
                 messageSending.verify(() -> {
-                    DownstreamMessageAssertions.assertTelemetryMessageProperties(msg, tenantId);
+                    DownstreamMessageAssertions.assertTelemetryApiProperties(msg);
+                    DownstreamMessageAssertions.assertMessageContainsAdapterAndAddress(msg);
                     assertThat(msg.getQos()).isEqualTo(AmqpUploadTestBase.getQoS(senderQoS));
                     assertAdditionalMessageProperties(msg);
                     callback.handle(null);

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
@@ -433,9 +433,8 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
                             helper.getSendCommandTimeout(counter.get() == 1))
                         .map(response -> {
                             ctx.verify(() -> {
-                                assertThat(response.getDeviceId()).isEqualTo(commandTargetDeviceId);
-                                assertThat(response.getTenantId()).isEqualTo(tenantId);
-                                DownstreamMessageAssertions.assertMessageContainsCreationTime(response);
+                                DownstreamMessageAssertions.assertCommandAndControlApiProperties(
+                                        response, tenantId, commandTargetDeviceId);
                                 DownstreamMessageAssertions.assertMessageContainsTimeToLive(response, TTL_COMMAND_RESPONSE);
                             });
                             return (Void) null;

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/EventAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/EventAmqpIT.java
@@ -78,7 +78,6 @@ public class EventAmqpIT extends AmqpUploadTestBase {
     @Override
     protected void assertAdditionalMessageProperties(final DownstreamMessage<? extends MessageContext> msg) {
         DownstreamMessageAssertions.assertMessageIsDurable(msg);
-        DownstreamMessageAssertions.assertMessageContainsCreationTime(msg);
         DownstreamMessageAssertions.assertMessageContainsTimeToLive(msg, TTL);
     }
 

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/TelemetryAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/TelemetryAmqpIT.java
@@ -64,7 +64,6 @@ public class TelemetryAmqpIT extends AmqpUploadTestBase {
 
     @Override
     protected void assertAdditionalMessageProperties(final DownstreamMessage<? extends MessageContext> msg) {
-        DownstreamMessageAssertions.assertMessageContainsCreationTime(msg);
         final Duration expectedTtl = msg.getQos() == QoS.AT_MOST_ONCE ? TTL_QOS0 : TTL_QOS1;
         DownstreamMessageAssertions.assertMessageContainsTimeToLive(msg, expectedTtl);
     }

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
@@ -652,7 +652,8 @@ public abstract class CoapTestBase {
         createConsumer(tenantId, msg -> {
             ctx.verify(() -> {
                 logger.trace("received {}", msg);
-                DownstreamMessageAssertions.assertTelemetryMessageProperties(msg, tenantId);
+                DownstreamMessageAssertions.assertTelemetryApiProperties(msg);
+                DownstreamMessageAssertions.assertMessageContainsAdapterAndAddress(msg);
                 assertThat(msg.getQos()).isEqualTo(getExpectedQoS(expectedQos));
                 assertAdditionalMessageProperties(msg);
                 if (messageConsumer != null) {
@@ -957,10 +958,9 @@ public abstract class CoapTestBase {
                                     notification.getMillisecondsUntilExpiry())
                                     .map(response -> {
                                         ctx.verify(() -> {
+                                            DownstreamMessageAssertions.assertCommandAndControlApiProperties(
+                                                    response, tenantId, commandTargetDeviceId);
                                             assertThat(response.getContentType()).isEqualTo("text/plain");
-                                            assertThat(response.getDeviceId()).isEqualTo(commandTargetDeviceId);
-                                            assertThat(response.getTenantId()).isEqualTo(tenantId);
-                                            assertThat(response.getCreationTime()).isNotNull();
                                         });
                                         return response;
                                     });

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/EventCoapIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/EventCoapIT.java
@@ -61,7 +61,6 @@ public class EventCoapIT extends CoapTestBase {
     @Override
     protected void assertAdditionalMessageProperties(final DownstreamMessage<? extends MessageContext> msg) {
         DownstreamMessageAssertions.assertMessageIsDurable(msg);
-        DownstreamMessageAssertions.assertMessageContainsCreationTime(msg);
     }
 
     @Override

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
@@ -32,7 +32,6 @@ import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.application.client.MessageContext;
 import org.eclipse.hono.config.KeyLoader;
 import org.eclipse.hono.service.management.tenant.Tenant;
-import org.eclipse.hono.tests.DownstreamMessageAssertions;
 import org.eclipse.hono.tests.EnabledIfDnsRebindingIsSupported;
 import org.eclipse.hono.tests.EnabledIfRegistrySupportsFeatures;
 import org.eclipse.hono.tests.IntegrationTestSupport;
@@ -67,11 +66,6 @@ public class TelemetryCoapIT extends CoapTestBase {
 
         return helper.applicationClient
                 .createTelemetryConsumer(tenantId, (Handler) messageConsumer, remoteClose -> {});
-    }
-
-    @Override
-    protected void assertAdditionalMessageProperties(final DownstreamMessage<? extends MessageContext> msg) {
-        DownstreamMessageAssertions.assertMessageContainsCreationTime(msg);
     }
 
     @Override

--- a/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
@@ -66,7 +66,6 @@ public class EventHttpIT extends HttpTestBase {
     @Override
     protected void assertAdditionalMessageProperties(final DownstreamMessage<? extends MessageContext> msg) {
         DownstreamMessageAssertions.assertMessageIsDurable(msg);
-        DownstreamMessageAssertions.assertMessageContainsCreationTime(msg);
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -569,7 +569,8 @@ import io.vertx.junit5.VertxTestContext;
         createConsumer(tenantId, msg -> {
             logger.trace("received {}", msg);
             ctx.verify(() -> {
-                DownstreamMessageAssertions.assertTelemetryMessageProperties(msg, tenantId);
+                DownstreamMessageAssertions.assertTelemetryApiProperties(msg);
+                DownstreamMessageAssertions.assertMessageContainsAdapterAndAddress(msg);
                 assertThat(msg.getQos()).isEqualTo(getExpectedQoS(expectedQos));
                 assertAdditionalMessageProperties(msg);
             });
@@ -1212,10 +1213,9 @@ import io.vertx.junit5.VertxTestContext;
                                         notification.getMillisecondsUntilExpiry())
                                         .map(response -> {
                                             ctx.verify(() -> {
+                                                DownstreamMessageAssertions.assertCommandAndControlApiProperties(
+                                                        response, tenantId, commandTargetDeviceId);
                                                 assertThat(response.getContentType()).isEqualTo("text/plain");
-                                                assertThat(response.getDeviceId()).isEqualTo(commandTargetDeviceId);
-                                                assertThat(response.getTenantId()).isEqualTo(tenantId);
-                                                assertThat(response.getCreationTime()).isNotNull();
                                             });
                                             return (Void) null;
                                         });

--- a/tests/src/test/java/org/eclipse/hono/tests/http/TelemetryHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/TelemetryHttpIT.java
@@ -29,7 +29,6 @@ import org.eclipse.hono.client.SendMessageTimeoutException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.AssumeMessagingSystem;
-import org.eclipse.hono.tests.DownstreamMessageAssertions;
 import org.eclipse.hono.tests.EnabledIfDnsRebindingIsSupported;
 import org.eclipse.hono.tests.EnabledIfRegistrySupportsFeatures;
 import org.eclipse.hono.tests.IntegrationTestSupport;
@@ -78,11 +77,6 @@ public class TelemetryHttpIT extends HttpTestBase {
             final Handler<DownstreamMessage<? extends MessageContext>> messageConsumer) {
         return helper.applicationClient
                 .createTelemetryConsumer(tenantId, (Handler) messageConsumer, remoteClose -> {});
-    }
-
-    @Override
-    protected void assertAdditionalMessageProperties(final DownstreamMessage<? extends MessageContext> msg) {
-        DownstreamMessageAssertions.assertMessageContainsCreationTime(msg);
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
@@ -43,6 +43,7 @@ import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaRecordHelper;
 import org.eclipse.hono.tests.AssumeMessagingSystem;
 import org.eclipse.hono.tests.CommandEndpointConfiguration.SubscriberRole;
+import org.eclipse.hono.tests.DownstreamMessageAssertions;
 import org.eclipse.hono.tests.GenericKafkaSender;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.EventConstants;
@@ -254,9 +255,8 @@ public class CommandAndControlMqttIT extends MqttTestBase {
                     helper.getSendCommandTimeout(counter.get() == 1))
                     .map(response -> {
                         ctx.verify(() -> {
-                            assertThat(response.getDeviceId()).isEqualTo(commandTargetDeviceId);
-                            assertThat(response.getTenantId()).isEqualTo(tenantId);
-                            assertThat(response.getCreationTime()).isNotNull();
+                            DownstreamMessageAssertions.assertCommandAndControlApiProperties(
+                                    response, tenantId, commandTargetDeviceId);
                         });
                         return (Void) null;
                     });

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
@@ -110,7 +110,6 @@ public class EventMqttIT extends MqttPublishTestBase {
     @Override
     protected void assertAdditionalMessageProperties(final DownstreamMessage<? extends MessageContext> msg) {
         DownstreamMessageAssertions.assertMessageIsDurable(msg);
-        DownstreamMessageAssertions.assertMessageContainsCreationTime(msg);
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
@@ -673,7 +673,8 @@ public abstract class MqttPublishTestBase extends MqttTestBase {
             }
             LOGGER.trace("received {}", msg);
             ctx.verify(() -> {
-                DownstreamMessageAssertions.assertTelemetryMessageProperties(msg, tenantId);
+                DownstreamMessageAssertions.assertTelemetryApiProperties(msg);
+                DownstreamMessageAssertions.assertMessageContainsAdapterAndAddress(msg);
                 assertThat(msg.getQos().ordinal()).isEqualTo(getQos().ordinal());
                 assertAdditionalMessageProperties(msg);
             });

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS0IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS0IT.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.application.client.MessageContext;
-import org.eclipse.hono.tests.DownstreamMessageAssertions;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.TelemetryConstants;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,11 +39,6 @@ import io.vertx.junit5.VertxTestContext;
 public class TelemetryMqttQoS0IT extends MqttPublishTestBase {
 
     private static final String TOPIC_TEMPLATE = "%s/%s/%s";
-
-    @Override
-    protected void assertAdditionalMessageProperties(final DownstreamMessage<? extends MessageContext> msg) {
-        DownstreamMessageAssertions.assertMessageContainsCreationTime(msg);
-    }
 
     @Override
     protected MqttQoS getQos() {

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS1IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS1IT.java
@@ -26,7 +26,6 @@ import org.eclipse.hono.client.NoConsumerException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.AssumeMessagingSystem;
-import org.eclipse.hono.tests.DownstreamMessageAssertions;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.MessagingType;
@@ -52,11 +51,6 @@ import io.vertx.junit5.VertxTestContext;
 public class TelemetryMqttQoS1IT extends MqttPublishTestBase {
 
     private static final String TOPIC_TEMPLATE = "%s/%s/%s";
-
-    @Override
-    protected void assertAdditionalMessageProperties(final DownstreamMessage<? extends MessageContext> msg) {
-        DownstreamMessageAssertions.assertMessageContainsCreationTime(msg);
-    }
 
     @Override
     protected MqttQoS getQos() {


### PR DESCRIPTION
The Telemetry API might have been read to expect that custom properties
that an AMQP based device includes in a message that it uploads to the
AMQP adapter are being forwarded in the downstream Telemetry messages.

The wording has been adapted to clarify that this only applies to
properties added by protocol adapters. Thus it depends on the protocol
adapter implementation if and how properties provided by devices are
being included.
