### PR TITLE
[#3218] Adapt API naming to better reflect messaging infrastructure

### DIFF
--- a/site/documentation/content/api/command-and-control-kafka/index.md
+++ b/site/documentation/content/api/command-and-control-kafka/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Command & Control API for Kafka Specification"
-linkTitle: "Command & Control API for Kafka"
-weight: 419
+title: "Command & Control API Specification for Kafka"
+linkTitle: "Command & Control API (Kafka)"
+weight: 415
 ---
 
-The *Command & Control* API of Eclipse Hono&trade; is used by *Business Applications* to send commands to connected devices.
+The *Command & Control* API of Eclipse Hono&trade; is used by *Business Applications* to send commands to connected
+devices.
 
 Commands can be used to trigger actions on devices. Examples include updating a configuration property, installing a
 software component or switching the state of an actuator.
@@ -19,10 +20,6 @@ The second type of commands expects a *response* to be sent back from the device
 In this case the response contains a *status* code which indicates whether the command could be processed successfully.
 If so, the response may also include data representing the result of processing the command. This type of command is
 plainly referred to as a *command* because it represents the default case.
-
-The Command & Control API for Kafka is an alternative to the
-[Command & Control API for AMQP]({{< relref "/api/command-and-control" >}}). With this API, clients send command
-messages to an Apache Kafka&reg; cluster instead of an AMQP Messaging Network.
 
 See [Kafka-based APIs]({{< relref "/api/kafka-api" >}}) for fundamental information about Hono's Kafka-based APIs.
 The statements there apply to this specification.

--- a/site/documentation/content/api/command-and-control/index.md
+++ b/site/documentation/content/api/command-and-control/index.md
@@ -1,7 +1,7 @@
 ---
-title: "Command & Control API Specification"
-linkTitle: "Command & Control API"
-weight: 415
+title: "Command & Control API Specification for AMQP 1.0"
+linkTitle: "Command & Control API (AMQP 1.0)"
+weight: 419
 resources:
   - src: device_not_connected.svg
   - src: malformed_message.svg
@@ -12,25 +12,43 @@ resources:
   - src: control_success.svg
 ---
 
-The *Command & Control* API of Eclipse Hono&trade; is used by *Business Applications* to send commands to connected devices.
+The *Command & Control* API of Eclipse Hono&trade; is used by *Business Applications* to send commands to connected
+devices.
 
-Commands can be used to trigger actions on devices. Examples include updating a configuration property, installing a software component or switching the state of an actuator.
+Commands can be used to trigger actions on devices. Examples include updating a configuration property, installing a
+software component or switching the state of an actuator.
 <!--more-->
 
-Hono distinguishes two types of commands. The first type is *one-way* only. In this case the sender of the command does not expect the device to send back a message in response to the command. This type of command is referred to as a *one-way command* in the remainder of this page. One-way commands may be used to e.g. *notify* a device about a change of state.
+Hono distinguishes two types of commands. The first type is *one-way* only. In this case the sender of the command
+does not expect the device to send back a message in response to the command. This type of command is referred to as
+a *one-way command* in the remainder of this page. One-way commands may be used to e.g. *notify* a device about a
+change of state.
 
-The second type of commands expects a *response* to be sent back from the device as a result of processing the command. In this case the response contains a *status* code which indicates whether the command could be processed successfully. If so, the response may also include data representing the result of processing the command. This type of command is plainly referred to as a *command* because it represents the default case.
+The second type of commands expects a *response* to be sent back from the device as a result of processing the command.
+In this case the response contains a *status* code which indicates whether the command could be processed successfully.
+If so, the response may also include data representing the result of processing the command. This type of command is
+plainly referred to as a *command* because it represents the default case.
 
-The Command & Control API is defined by means of AMQP 1.0 message exchanges, i.e. a client needs to connect to Hono using AMQP 1.0 in order to invoke operations of the API as described in the following sections. Throughout the remainder of this page we will simply use AMQP when referring to AMQP 1.0.
+The Command & Control API is defined by means of AMQP 1.0 message exchanges, i.e. a client needs to connect to Hono
+using AMQP 1.0 in order to invoke operations of the API as described in the following sections. Throughout the
+remainder of this page we will simply use AMQP when referring to AMQP 1.0.
+
+The Command & Control API for AMQP 1.0 is an alternative to the
+[Command & Control API for Kafka]({{< relref "/api/command-and-control-kafka" >}}) for applications that want to
+use an AMQP 1.0 Messaging Network instead of an Apache Kafka&trade; broker to send command messages to devices.
+
 
 ## Send a One-Way Command
 
-Business Applications use this operation to send a command to a device for which they do not expect to receive a response from the device.
+Business Applications use this operation to send a command to a device for which they do not expect to receive a
+response from the device.
 
 **Preconditions**
 
 1. The *Business Application* has established an AMQP connection with the AMQP 1.0 Network.
-2. The *Business Application* has established an AMQP link in role *sender* with the target address `command/${tenant_id}`, where `${tenant_id}` is the ID of the tenant that the device belongs to. This link is used by the *Business Application* to send command messages.
+2. The *Business Application* has established an AMQP link in role *sender* with the target address `command/${tenant_id}`,
+   where `${tenant_id}` is the ID of the tenant that the device belongs to. This link is used by the *Business
+   Application* to send command messages.
 
 The following sequence diagram illustrates the establishment of the required link:
 
@@ -38,7 +56,8 @@ The following sequence diagram illustrates the establishment of the required lin
 
 **Message Format**
 
-The following table provides an overview of the properties the *Business Application* needs to set on a one-way command message.
+The following table provides an overview of the properties the *Business Application* needs to set on a one-way command
+message.
 
 | Name             | Mandatory | Location                 | Type         | Description |
 | :--------------- | :-------: | :----------------------- | :----------- | :---------- |
@@ -57,19 +76,25 @@ Hono indicates the outcome of the operation by means of the following AMQP deliv
 | `released`    | The command has not been delivered to the device or can not be processed by the device due to reasons that are not the responsibility of the sender of the command. Possible reasons are:<ul><li>The device is (currently) not connected.</li><li>In case the transport protocol supports acknowledgements: The device hasn't sent an acknowledgement in time or has indicated that the message cannot be processed.</li><li>There was an error forwarding the command to the device.</li></ul> |
 | `rejected`    | The command has not been delivered to or processed by the device because the command message does not contain all required information. Another reason may be that a message limit has been exceeded. |
 
-**Note** that Hono relies on the particular protocol adapter to deliver commands to devices. Depending on the used transport protocol and the adapter's implementation, the `accepted` outcome may thus indicate any of the following:
+{{% notice info %}}
+Hono relies on the particular protocol adapter to deliver commands to devices. Depending on the used transport
+protocol and the adapter's implementation, the `accepted` outcome may thus indicate any of the following:
 
-- An *attempt* has been made to deliver the command to the device. However, it is unclear if the device has received (or processed) the command.
-- The device has acknowledged the reception of the command but has not processed the command yet.
-- The device has received and processed the command.
+* An *attempt* has been made to deliver the command to the device. However, it is unclear if the device has received
+  (or processed) the command.
+* The device has acknowledged the reception of the command but has not processed the command yet.
+* The device has received and processed the command.
+{{% /notice %}}
 
 **Examples**
 
-The following sequence diagram shows the successful delivery of a one-way command called `switchOn` to device `4711` of the `DEFAULT_TENANT`:
+The following sequence diagram shows the successful delivery of a one-way command called `switchOn` to device `4711` of
+the `DEFAULT_TENANT`:
 
 {{< figure src="one_way_success.svg" title="Successfully send a One-Way Command" >}}
 
-The following sequence diagram shows how the delivery of the same one-way command fails because the device is not connected:
+The following sequence diagram shows how the delivery of the same one-way command fails because the device is not
+connected:
 
 {{< figure src="device_not_connected.svg" title="Device not connected" >}}
 
@@ -81,16 +106,21 @@ The following sequence diagram illustrates how a malformed command sent by a *Bu
 
 ## Send a (Request/Response) Command
 
-*Business Applications* use this operation to send a command to a device for which they expect the device to send back a response.
+*Business Applications* use this operation to send a command to a device for which they expect the device to send
+back a response.
 
 <a name="receiver-link-precondition"></a>
 
 **Preconditions**
 
 1. The *Business Application* has established an AMQP connection with the AMQP 1.0 Network.
-2. The *Business Application* has established an AMQP link in role *sender* with the target address `command/${tenant_id}`, where `${tenant_id}` is the ID of the tenant that the device belongs to. This link is used by the *Business Application* to send command messages.
-3. The *Business Application* has established an AMQP link in role *receiver* with the source address `command_response/${tenant_id}/${reply_id}`.
-This link is used by the *Business Application* to receive the response to the command from the device. This link’s source address is also used as the `reply-to` address for the request messages. The `${reply_id}` may be any arbitrary string chosen by the application.
+1. The *Business Application* has established an AMQP link in role *sender* with the target address `command/${tenant_id}`,
+   where `${tenant_id}` is the ID of the tenant that the device belongs to. This link is used by the *Business
+   Application* to send command messages.
+1. The *Business Application* has established an AMQP link in role *receiver* with the source address
+   `command_response/${tenant_id}/${reply_id}`. This link is used by the *Business Application* to receive the response to
+   the command from the device. This link’s source address is also used as the `reply-to` address for the request
+   messages. The `${reply_id}` may be any arbitrary string chosen by the application.
 
 The following sequence diagram illustrates the establishment of the required links:
 
@@ -119,12 +149,18 @@ Hono uses following AMQP delivery states to indicate the outcome of sending the 
 | `released`    | The command has not been delivered to the device or can not be processed by the device due to reasons that are not the responsibility of the sender of the command. Possible reasons are:<ul><li>The device is (currently) not connected.</li><li>In case the transport protocol supports acknowledgements: The device hasn't sent an acknowledgement in time or has indicated that the message cannot be processed.</li><li>There was an error forwarding the command to the device.</li></ul> |
 | `rejected`    | The command has not been delivered to or processed by the device because the command message does not contain all required information. Another reason may be that a message limit has been exceeded. |
 
-**Note** that Hono relies on the particular protocol adapter to deliver commands to devices. Depending on the used transport protocol and the adapter's implementation, the `accepted` outcome may thus indicate any of the following:
+{{% notice info %}}
+Hono relies on the particular protocol adapter to deliver commands to devices. Depending on the used transport
+protocol and the adapter's implementation, the `accepted` outcome may thus indicate any of the following:
 
-- An *attempt* has been made to deliver the command to the device. However, it is unclear if the device has received (or processed) the command.
-- The device has acknowledged the reception of the command but has not processed the command yet.
+* An *attempt* has been made to deliver the command to the device. However, it is unclear if the device has received
+  (or processed) the command.
+* The device has acknowledged the reception of the command but has not processed the command yet.
 
-An application can determine the overall outcome of the operation by means of the response to the command that is sent back by the device. An application should consider execution of a command to have failed, if it does not receive a response within a reasonable amount of time.
+An application can determine the overall outcome of the operation by means of the response to the command that is
+sent back by the device. An application should consider execution of a command to have failed, if it does not receive
+a response within a reasonable amount of time.
+{{% /notice %}}
 
 **Response Message Format**
 
@@ -147,16 +183,21 @@ The *status* property must contain an [HTTP 1.1 response status code](https://to
 | *4xx* | The command could not be processed due to a client error, e.g. malformed message payload. |
 | *5xx* | The command could not be processed due to an internal problem at the device side. |
 
-The semantics of the individual codes are specific to the device and command. For status codes indicating an error (codes in the `400 - 599` range) the message body MAY contain a detailed description of the error that occurred.
+The semantics of the individual codes are specific to the device and command. For status codes indicating an error
+(codes in the `400 - 599` range) the message body MAY contain a detailed description of the error that occurred.
 
-If a command message response contains a payload, the body of the message MUST consist of a single AMQP *Data* section containing the response message data.
+If a command message response contains a payload, the body of the message MUST consist of a single AMQP *Data* section
+containing the response message data.
 
 **Examples**
 
-The following sequence diagram illustrates how a *Business Application* sends a command called `getReading` to device `4711` of the `DEFAULT_TENANT` and receives a response from the device:
+The following sequence diagram illustrates how a *Business Application* sends a command called `getReading` to device
+`4711` of the `DEFAULT_TENANT` and receives a response from the device:
 
 {{< figure src="request_response_success.svg" title="Successfully send a Command" >}}
 
-The sending of a command may fail for the same reasons as those illustrated for sending a one-way command. Additionally, the sending of a command may be considered unsuccessful by an application if it does not receive the response from the device in a reasonable amount of time:
+The sending of a command may fail for the same reasons as those illustrated for sending a one-way command. Additionally,
+the sending of a command may be considered unsuccessful by an application if it does not receive the response from the
+device in a reasonable amount of time:
 
 {{< figure src="response_time_out.svg" title="Command times out" >}}

--- a/site/documentation/content/api/event-kafka/index.md
+++ b/site/documentation/content/api/event-kafka/index.md
@@ -1,7 +1,7 @@
 ---
-title: "Event API for Kafka Specification"
-linkTitle: "Event API for Kafka"
-weight: 418
+title: "Event API Specification for Kafka"
+linkTitle: "Event API (Kafka)"
+weight: 410
 resources:
   - src: produce_kafka.svg
   - src: consume_kafka.svg
@@ -10,9 +10,6 @@ resources:
 The *Event* API is used by *Protocol Adapters* to send event messages downstream.
 *Business Applications* and other consumers use the API to receive messages published by devices belonging to a
 particular tenant.
-
-The Event API for Kafka is an alternative to the [Event API for AMQP]({{< relref "/api/event" >}}).
-With this API, clients publish event messages to an Apache Kafka&reg; cluster instead of an AMQP Messaging Network. 
 
 See [Kafka-based APIs]({{< relref "/api/kafka-api" >}}) for fundamental information about Hono's Kafka-based APIs.
 The statements there apply to this specification.

--- a/site/documentation/content/api/event/index.md
+++ b/site/documentation/content/api/event/index.md
@@ -1,38 +1,53 @@
 ---
-title: "Event API Specification"
-linkTitle: "Event API"
-weight: 410
+title: "Event API Specification for AMQP 1.0"
+linkTitle: "Event API (AMQP 1.0)"
+weight: 418
 resources:
   - src: forward.svg
   - src: consume.svg
 ---
 
 The *Event* API is used by *Protocol Adapters* to send event messages downstream.
-*Business Applications* and other consumers use the API to receive messages published by devices belonging to a particular tenant.
+*Business Applications* and other consumers use the API to receive messages published by devices belonging to a
+particular tenant.
 <!--more-->
 
-The Event API is defined by means of AMQP 1.0 message exchanges, i.e. a client needs to connect to Hono using AMQP 1.0 in order to invoke operations of the API as described in the following sections. Throughout the remainder of this page we will simply use *AMQP* when referring to AMQP 1.0.
+The Event API is defined by means of AMQP 1.0 message exchanges, i.e. a client needs to connect to Hono using AMQP 1.0
+in order to invoke operations of the API as described in the following sections. Throughout the remainder of this page
+we will simply use *AMQP* when referring to AMQP 1.0.
+
+The Event API for AMQP 1.0 is an alternative to the [Event API for Kafka]({{< relref "/api/event" >}}) for
+applications that want to consume events from an AMQP Messaging Network instead of an Apache Kafka&trade; broker.
 
 
 ## Southbound Operations
 
-The following operations can be used by *Protocol Adapters* to forward event messages received from devices to downstream consumers like *Business Applications*.
+The following operations can be used by *Protocol Adapters* to forward event messages received from devices to
+downstream consumers like *Business Applications*.
 
 ### Forward Event
 
 **Preconditions**
 
 1. Adapter has established an AMQP connection with the AMQP Messaging Network.
-1. Adapter has established an AMQP link in role *sender* with the AMQP Messaging Network using target address `event/${tenant_id}` where `${tenant_id}` is the ID of the tenant that the client wants to upload event messages for. 
-1. The device for which the adapter wants to send an event has been registered (see [Device Registration API]({{< relref "/api/device-registration" >}})).
+1. Adapter has established an AMQP link in role *sender* with the AMQP Messaging Network using target address
+   `event/${tenant_id}` where `${tenant_id}` is the ID of the tenant that the client wants to upload event messages for. 
+1. The device for which the adapter wants to send an event has been registered (see
+   [Device Registration API]({{< relref "/api/device-registration" >}})).
 
-Hono supports *AT LEAST ONCE* delivery of *Event* messages only. A client therefore MUST use `unsettled` for the *snd-settle-mode* and `first` for the *rcv-settle-mode* fields of its *attach* frame during link establishment. All other combinations are not supported by Hono and may result in the termination of the link or connection (depending on the configuration of the AMQP Messaging Network).
+Hono supports *AT LEAST ONCE* delivery of *Event* messages only. A client therefore MUST use `unsettled` for the
+*snd-settle-mode* and `first` for the *rcv-settle-mode* fields of its *attach* frame during link establishment. All
+other combinations are not supported by Hono and may result in the termination of the link or connection (depending
+on the configuration of the AMQP Messaging Network).
 
-The AMQP messages used to forward events to the AMQP Messaging Network MUST have their <em>durable</em> property set to `true`. The AMQP Messaging Network is expected to write such messages to a persistent store before settling the transfer with the `accepted` outcome.
+The AMQP messages used to forward events to the AMQP Messaging Network MUST have their <em>durable</em> property set
+to `true`. The AMQP Messaging Network is expected to write such messages to a persistent store before settling the
+transfer with the `accepted` outcome.
 
 **Message Flow**
 
-The following sequence diagram illustrates the flow of messages involved in the *MQTT Adapter* forwarding an event to the downstream AMQP Messaging Network.
+The following sequence diagram illustrates the flow of messages involved in the *MQTT Adapter* forwarding an event
+to the downstream AMQP Messaging Network.
 
 {{< figure src="forward.svg" title="Forward event flow" >}}
 
@@ -41,7 +56,9 @@ The following sequence diagram illustrates the flow of messages involved in the 
    1. *AMQP 1.0 Messaging Network* acknowledges reception of the message.
    1. *MQTT Adapter* acknowledges the reception of the message to the *Device*.
 
-When the AMQP Messaging Network fails to settle the transfer of an event message or settles the transfer with any other outcome than `accepted`, the protocol adapter MUST NOT try to re-send such rejected messages but MUST indicate the failed transfer to the device if the transport protocol provides means to do so.
+When the AMQP Messaging Network fails to settle the transfer of an event message or settles the transfer with any
+other outcome than `accepted`, the protocol adapter MUST NOT try to re-send such rejected messages but MUST indicate
+the failed transfer to the device if the transport protocol provides means to do so.
 
 **Message Format**
 
@@ -51,20 +68,27 @@ See [Telemetry API]({{< relref "/api/telemetry#forward-telemetry-data" >}}) for 
 
 ### Receive Events
 
-Hono delivers messages containing events reported by a particular device in the same order that they have been received in (using the [Forward Event]({{< relref "#forward-event" >}}) operation).
+Hono delivers messages containing events reported by a particular device in the same order that they have been
+received in (using the [Forward Event]({{< relref "#forward-event" >}}) operation).
 
-Hono supports multiple non-competing *Business Application* consumers of event messages for a given tenant. Hono allows each *Business Application* to have multiple competing consumers for event messages for a given tenant to share the load of processing the messages.
+Hono supports multiple non-competing *Business Application* consumers of event messages for a given tenant. Hono
+allows each *Business Application* to have multiple competing consumers for event messages for a given tenant to share
+the load of processing the messages.
 
 **Preconditions**
 
 1. Client has established an AMQP connection with Hono.
-2. Client has established an AMQP link in role *receiver* with Hono using source address `event/${tenant_id}` where `${tenant_id}` represents the ID of the tenant the client wants to retrieve event messages for.
+1. Client has established an AMQP link in role *receiver* with Hono using source address `event/${tenant_id}` where
+   `${tenant_id}` represents the ID of the tenant the client wants to retrieve event messages for.
 
-Hono supports *AT LEAST ONCE* delivery of *Event* messages only. A client therefore MUST use `unsettled` for the *snd-settle-mode* and `first` for the *rcv-settle-mode* fields of its *attach* frame during link establishment. All other combinations are not supported by Hono and result in the termination of the link.
+Hono supports *AT LEAST ONCE* delivery of *Event* messages only. A client therefore MUST use `unsettled` for the
+*snd-settle-mode* and `first` for the *rcv-settle-mode* fields of its *attach* frame during link establishment.
+All other combinations are not supported by Hono and result in the termination of the link.
 
 **Message Flow**
 
-The following sequence diagram illustrates the flow of messages involved in a *Business Application* receiving an event message from Hono. 
+The following sequence diagram illustrates the flow of messages involved in a *Business Application* receiving an
+event message from Hono. 
 
 {{< figure src="consume.svg" title="Receive event data flow (success)" >}}
 
@@ -78,13 +102,15 @@ See [Telemetry API]({{< relref "/api/telemetry#forward-telemetry-data" >}}) for 
 
 ## Well-known Event Message Types
 
-Hono defines several *well-known* event types which have specific semantics. Events of these types are identified by means of the AMQP message's *content-type*.
+Hono defines several *well-known* event types which have specific semantics. Events of these types are identified
+by means of the AMQP message's *content-type*.
 
 ### Empty Notification
 
 An AMQP message containing this type of event does not have any payload, so the body of the message MUST be empty.
 
-The AMQP 1.0 properties an event sender needs to set for an *empty notification* event are defined in the [*Telemetry API*]({{< relref "/api/telemetry" >}}). 
+The AMQP 1.0 properties an event sender needs to set for an *empty notification* event are defined in the
+[Telemetry API]({{< relref "/api/telemetry" >}}). 
 
 The relevant properties are listed again in the following table:
 
@@ -93,7 +119,11 @@ The relevant properties are listed again in the following table:
 | *content-type* | yes              | *properties*             | *symbol*  | MUST be set to *application/vnd.eclipse-hono-empty-notification* |
 | *ttd*          | no               | *application-properties* | *int*     | The *time 'til disconnect* as described in the [*Telemetry API*]({{< relref "/api/telemetry" >}}). |
 
-**NB** An empty notification can be used to indicate to a *Business Application* that a device is currently ready to receive an upstream message by setting the *ttd* property. *Backend Applications* may use this information to determine the time window during which the device will be able to receive a command.
+{{% notice tip %}}
+An empty notification can be used to indicate to a *Business Application* that a device is currently ready to
+receive an upstream message by setting the *ttd* property. *Backend Applications* may use this information to determine
+the time window during which the device will be able to receive a command.
+{{% /notice %}}
 
 ### Connection Event
 
@@ -102,14 +132,16 @@ been established or has ended. Note that such events can only be sent for authen
 though, because an event is always scoped to a tenant and the tenant of a device is
 established as part of the authentication process.
 
-The AMQP message for a connection event MUST contain the following properties in addition to the standard event properties:
+The AMQP message for a connection event MUST contain the following properties in addition to the standard event
+properties:
 
 | Name           | Mandatory | Location                 | Type      | Description |
 | :------------- | :-------: | :----------------------- | :-------- | :---------- |
 | *content-type* | yes       | *properties*             | *symbol*  | Must be set to  *application/vnd.eclipse-hono-dc-notification+json* |
 | *device_id*    | yes       | *application-properties* | *string*  | The ID of the authenticated device |
 
-Each connection event's payload MUST contain a UTF-8 encoded string representation of a single JSON object with the following fields:
+Each connection event's payload MUST contain a UTF-8 encoded string representation of a single JSON object with the
+following fields:
 
 | Name        | Mandatory | Type      | Description |
 | :---------- | :-------: | :-------- | :---------- |
@@ -118,7 +150,8 @@ Each connection event's payload MUST contain a UTF-8 encoded string representati
 | *source*    | yes       | *string*  | The type name of the protocol adapter reporting the event, e.g. `hono-mqtt`. |
 | *data*      | no        | *object*  | An arbitrary JSON object which may contain additional information about the occurrence of the event. |
 
-The example below might be used by the MQTT adapter to indicate that a connection with a device using client identifier `mqtt-client-id-1` has been established:
+The example below might be used by the MQTT adapter to indicate that a connection with a device using client
+identifier `mqtt-client-id-1` has been established:
 
 ~~~json
 {
@@ -133,8 +166,9 @@ The example below might be used by the MQTT adapter to indicate that a connectio
 
 ### Device Provisioning Notification
 
-Device registries may send this event to convey provisioning related changes regarding a device. This may be used as a hook for 
-northbound applications if further application specific logic should be implemented upon provisioning changes.
+Device registries may send this event to convey provisioning related changes regarding a device. This may be used as
+a hook for north bound applications if further application specific logic should be implemented upon provisioning
+changes.
 
 An AMQP message containing this type of event does not have any payload, so the body of the message MUST be empty.
 

--- a/site/documentation/content/api/telemetry-kafka/index.md
+++ b/site/documentation/content/api/telemetry-kafka/index.md
@@ -1,7 +1,7 @@
 ---
-title: "Telemetry API for Kafka Specification"
-linkTitle: "Telemetry API for Kafka"
-weight: 417
+title: "Telemetry API Specification for Kafka"
+linkTitle: "Telemetry API (Kafka)"
+weight: 405
 resources:
   - src: produce_kafka_qos0.svg
   - src: produce_kafka_qos1.svg
@@ -11,9 +11,6 @@ resources:
 The *Telemetry* API is used by *Protocol Adapters* to send telemetry data downstream.
 *Business Applications* and other consumers use the API to receive data published by devices belonging to a particular
 tenant.
-
-The Telemetry API for Kafka is an alternative to the [Telemetry API for AMQP]({{< relref "/api/telemetry" >}}).
-With this API, clients publish telemetry data to an Apache Kafka&reg; cluster instead of an AMQP Messaging Network. 
 
 See [Kafka-based APIs]({{< relref "/api/kafka-api" >}}) for fundamental information about Hono's Kafka-based APIs.
 The statements there apply to this specification.

--- a/site/documentation/content/api/telemetry/index.md
+++ b/site/documentation/content/api/telemetry/index.md
@@ -1,7 +1,7 @@
 ---
-title: "Telemetry API Specification"
-linkTitle: "Telemetry API"
-weight: 405
+title: "Telemetry API Specification for AMQP 1.0"
+linkTitle: "Telemetry API (AMQP 1.0)"
+weight: 417
 resources:
   - src: forward_qos0.svg
   - src: forward_qos1.svg
@@ -15,6 +15,11 @@ consumers use the API to receive data published by devices belonging to a partic
 The Telemetry API is defined by means of AMQP 1.0 message exchanges, i.e. a client needs to connect to Hono using
 AMQP 1.0 in order to invoke operations of the API as described in the following sections. Throughout the remainder of
 this page we will simply use *AMQP* when referring to AMQP 1.0.
+
+The Telemetry API for AMQP 1.0 is an alternative to the [Telemetry API for Kafka]({{< relref "/api/telemetry-kafka" >}})
+for applications that want to consume telemetry data from an AMQP Messaging Network instead of an Apache Kafka&trade;
+broker.
+
 
 ## Southbound Operations
 


### PR DESCRIPTION
This is for #3218

The API names have been adapted in the documentation to always reflect
the underlying messaging infrastructure being used.

The Kafka based APIs have been moved up in the documentation to reflect
the fact that Kafka based messaging is the default with Hono 2.0.0.
