### PR TITLE
[#3247] Support short endpoint names in CoAP adapter

### DIFF
--- a/adapters/coap-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/coap/CoapContext.java
+++ b/adapters/coap-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/coap/CoapContext.java
@@ -17,6 +17,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
@@ -25,9 +26,11 @@ import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.hono.adapter.MapBasedTelemetryExecutionContext;
 import org.eclipse.hono.auth.Device;
+import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.TelemetryConstants;
 import org.eclipse.hono.util.TenantObject;
 
 import io.micrometer.core.instrument.Timer.Sample;
@@ -50,6 +53,10 @@ public final class CoapContext extends MapBasedTelemetryExecutionContext {
      * (Legacy support for device with firmware versions not supporting  piggypacked response.)
      */
     static final String PARAM_PIGGYBACKED = "piggy";
+    private static final Set<String> SHORT_EP_NAMES = Set.of(
+                            TelemetryConstants.TELEMETRY_ENDPOINT_SHORT,
+                            EventConstants.EVENT_ENDPOINT_SHORT,
+                            CommandConstants.COMMAND_RESPONSE_ENDPOINT_SHORT);
 
     private final CoapExchange exchange;
     private final Device originDevice;
@@ -460,5 +467,15 @@ public final class CoapContext extends MapBasedTelemetryExecutionContext {
     @Override
     public String getOrigAddress() {
         return "/" + exchange.getRequestOptions().getUriPathString();
+    }
+
+    /**
+     * Checks if the request URI contains the short version of an API endpoint name.
+     *
+     * @return {@code true} if the URI contains a short version.
+     */
+    public boolean hasShortEndpointName() {
+        final String ep = exchange.getRequestOptions().getUriPath().get(0);
+        return SHORT_EP_NAMES.contains(ep);
     }
 }

--- a/adapters/coap-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/coap/app/Application.java
+++ b/adapters/coap-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/coap/app/Application.java
@@ -27,6 +27,9 @@ import org.eclipse.hono.adapter.coap.EventResource;
 import org.eclipse.hono.adapter.coap.TelemetryResource;
 import org.eclipse.hono.adapter.coap.impl.ConfigBasedCoapEndpointFactory;
 import org.eclipse.hono.adapter.coap.impl.VertxBasedCoapAdapter;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.EventConstants;
+import org.eclipse.hono.util.TelemetryConstants;
 
 /**
  * The Hono CoAP adapter main application class.
@@ -58,9 +61,12 @@ public class Application extends AbstractProtocolAdapterApplication<CoapAdapterP
         adapter.setMetrics(metrics);
         setCollaborators(adapter);
         adapter.addResources(Set.of(
-                new TelemetryResource(adapter, tracer, vertx),
-                new EventResource(adapter, tracer, vertx),
-                new CommandResponseResource(adapter, tracer, vertx)));
+                new TelemetryResource(TelemetryConstants.TELEMETRY_ENDPOINT, adapter, tracer, vertx),
+                new TelemetryResource(TelemetryConstants.TELEMETRY_ENDPOINT_SHORT, adapter, tracer, vertx),
+                new EventResource(EventConstants.EVENT_ENDPOINT, adapter, tracer, vertx),
+                new EventResource(EventConstants.EVENT_ENDPOINT_SHORT, adapter, tracer, vertx),
+                new CommandResponseResource(CommandConstants.COMMAND_RESPONSE_ENDPOINT, adapter, tracer, vertx),
+                new CommandResponseResource(CommandConstants.COMMAND_RESPONSE_ENDPOINT_SHORT, adapter, tracer, vertx)));
 
         final var endpointFactory = new ConfigBasedCoapEndpointFactory(vertx, protocolAdapterProperties);
         endpointFactory.setPskStore(new DeviceRegistryBasedPskStore(adapter, tracer));

--- a/core/src/main/java/org/eclipse/hono/util/CommandConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/CommandConstants.java
@@ -39,6 +39,12 @@ public class CommandConstants {
     public static final String COMMAND_RESPONSE_ENDPOINT = "command_response";
 
     /**
+     * The short name of the Command and Control API endpoint provided by protocol adapters that use a separate
+     * endpoint for command responses.
+     */
+    public static final String COMMAND_RESPONSE_ENDPOINT_SHORT = "cr";
+
+    /**
      * The name of the internal Command and Control API endpoint provided by protocol adapters for delegating
      * commands from one adapter to another.
      */

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -16,6 +16,8 @@ description = "Information about changes in recent Hono releases. Includes new f
   messages used to upload telemetry or event messages.
 * The MQTT protocol adapter now allows authenticated gateway devices to omit the tenant ID from the topic of
   messages used to upload telemetry or event messages.
+* The CoAP adapter now exposes its resources using short endpoint name alternatives to the existing resources.
+  Using the short endpoint names, devices can save a few bytes per request.
 
 ### Fixes & Enhancements
 

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/CoapCommandEndpointConfiguration.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/CoapCommandEndpointConfiguration.java
@@ -34,10 +34,24 @@ public final class CoapCommandEndpointConfiguration extends CommandEndpointConfi
         super(subscriberRole);
     }
 
-    String getCommandResponseUri(final String tenantId, final String deviceId, final String reqId) {
+    String getCommandResponseUri(
+            final int msgNo,
+            final String tenantId,
+            final String deviceId,
+            final String reqId) {
+
+        final boolean isEven = msgNo % 2 == 0;
+        final String endpointName = isEven ?
+                CommandConstants.COMMAND_RESPONSE_ENDPOINT : CommandConstants.COMMAND_RESPONSE_ENDPOINT_SHORT;
         if (isSubscribeAsGateway() || isSubscribeAsUnauthenticatedDevice()) {
-            return String.format("/%s/%s/%s/%s", CommandConstants.COMMAND_RESPONSE_ENDPOINT, tenantId, deviceId, reqId);
+            String tenantToUse = tenantId;
+            if (isSubscribeAsGateway() && isEven) {
+                tenantToUse = "";
+            }
+            return String.format("/%s/%s/%s/%s", endpointName, tenantToUse, deviceId, reqId);
         }
-        return String.format("/%s/%s", CommandConstants.COMMAND_RESPONSE_ENDPOINT, reqId);
+        return String.format("/%s/%s", endpointName, reqId);
     }
+
+
 }

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/EventCoapIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/EventCoapIT.java
@@ -48,7 +48,8 @@ import io.vertx.junit5.VertxTestContext;
 public class EventCoapIT extends CoapTestBase {
 
     private static final String POST_URI = "/" + EventConstants.EVENT_ENDPOINT;
-    private static final String PUT_URI_TEMPLATE = POST_URI + "/%s/%s";
+    private static final String POST_URI_SHORT = "/" + EventConstants.EVENT_ENDPOINT_SHORT;
+    private static final String PUT_URI_TEMPLATE = "%s/%s/%s";
 
     @Override
     protected Future<MessageConsumer> createConsumer(
@@ -64,13 +65,13 @@ public class EventCoapIT extends CoapTestBase {
     }
 
     @Override
-    protected String getPutResource(final String tenant, final String deviceId) {
-        return String.format(PUT_URI_TEMPLATE, tenant, deviceId);
+    protected String getPutResource(final int msgNo, final String tenant, final String deviceId) {
+        return String.format(PUT_URI_TEMPLATE, getPostResource(msgNo), tenant, deviceId);
     }
 
     @Override
-    protected String getPostResource() {
-        return POST_URI;
+    protected String getPostResource(final int msgNo) {
+        return msgNo % 2 == 0 ? POST_URI : POST_URI_SHORT;
     }
 
     @Override

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
@@ -57,7 +57,8 @@ import io.vertx.junit5.VertxTestContext;
 public class TelemetryCoapIT extends CoapTestBase {
 
     private static final String POST_URI = "/" + TelemetryConstants.TELEMETRY_ENDPOINT;
-    private static final String PUT_URI_TEMPLATE = POST_URI + "/%s/%s";
+    private static final String POST_URI_SHORT = "/" + TelemetryConstants.TELEMETRY_ENDPOINT_SHORT;
+    private static final String PUT_URI_TEMPLATE = "%s/%s/%s";
 
     @Override
     protected Future<MessageConsumer> createConsumer(
@@ -69,13 +70,13 @@ public class TelemetryCoapIT extends CoapTestBase {
     }
 
     @Override
-    protected String getPutResource(final String tenant, final String deviceId) {
-        return String.format(PUT_URI_TEMPLATE, tenant, deviceId);
+    protected String getPutResource(final int msgNo, final String tenant, final String deviceId) {
+        return String.format(PUT_URI_TEMPLATE, getPostResource(msgNo), tenant, deviceId);
     }
 
     @Override
-    protected String getPostResource() {
-        return POST_URI;
+    protected String getPostResource(final int msgNo) {
+        return msgNo % 2 == 0 ? POST_URI : POST_URI_SHORT;
     }
 
     @Override


### PR DESCRIPTION
The CoAP adapter now exposes its resources using short endpoint name
alternatives to the existing resources.

Fixes #3247
