### PR TITLE
[#3259] Use AsyncHandlingAutoCommitKafkaConsumer in adapters

### DIFF
--- a/adapters/amqp-vertx-quarkus/src/test/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx-quarkus/src/test/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapterTest.java
@@ -480,7 +480,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
         // WHEN an unauthenticated device opens a receiver link with a valid source address
         final ProtonConnection deviceConnection = mock(ProtonConnection.class);
         when(deviceConnection.attachments()).thenReturn(mock(Record.class));
-        when(commandConsumerFactory.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), VertxMockSupport.anyHandler(), any(), any()))
+        when(commandConsumerFactory.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(), any(), any()))
             .thenReturn(Future.succeededFuture(mock(CommandConsumer.class)));
         final String sourceAddress = String.format("%s/%s/%s", getCommandEndpoint(), TEST_TENANT_ID, TEST_DEVICE);
         final ProtonSender sender = getSender(sourceAddress);
@@ -551,7 +551,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
         // and a device that wants to receive commands
         final CommandConsumer commandConsumer = mock(CommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());
-        when(commandConsumerFactory.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), VertxMockSupport.anyHandler(), any(), any()))
+        when(commandConsumerFactory.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(), any(), any()))
             .thenReturn(Future.succeededFuture(commandConsumer));
         final String sourceAddress = String.format("%s", getCommandEndpoint());
         final ProtonSender sender = getSender(sourceAddress);
@@ -643,7 +643,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
         // that wants to receive commands
         final CommandConsumer commandConsumer = mock(CommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());
-        when(commandConsumerFactory.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), VertxMockSupport.anyHandler(), any(), any()))
+        when(commandConsumerFactory.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(), any(), any()))
             .thenReturn(Future.succeededFuture(commandConsumer));
         final String sourceAddress = getCommandEndpoint();
         final ProtonSender sender = getSender(sourceAddress);
@@ -693,7 +693,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
         // that wants to receive commands
         final CommandConsumer commandConsumer = mock(CommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED)));
-        when(commandConsumerFactory.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), VertxMockSupport.anyHandler(), any(), any()))
+        when(commandConsumerFactory.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(), any(), any()))
                 .thenReturn(Future.succeededFuture(commandConsumer));
         final String sourceAddress = getCommandEndpoint();
         final ProtonSender sender = getSender(sourceAddress);
@@ -1437,7 +1437,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
         // that wants to receive commands
         final CommandConsumer commandConsumer = mock(CommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED)));
-        when(commandConsumerFactory.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), VertxMockSupport.anyHandler(), any(), any()))
+        when(commandConsumerFactory.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(), any(), any()))
                 .thenReturn(Future.succeededFuture(commandConsumer));
         final String sourceAddress = getCommandEndpoint();
         final ProtonSender sender = getSender(sourceAddress);

--- a/adapters/coap-vertx-quarkus/src/test/java/org/eclipse/hono/adapter/coap/CoapProtocolAdapterMockSupport.java
+++ b/adapters/coap-vertx-quarkus/src/test/java/org/eclipse/hono/adapter/coap/CoapProtocolAdapterMockSupport.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -30,7 +30,6 @@ import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.hono.adapter.test.ProtocolAdapterMockSupport;
 import org.eclipse.hono.client.command.CommandConsumer;
 import org.eclipse.hono.test.TracingMockSupport;
-import org.eclipse.hono.test.VertxMockSupport;
 import org.junit.jupiter.api.BeforeEach;
 
 import io.opentracing.Span;
@@ -69,9 +68,9 @@ abstract class CoapProtocolAdapterMockSupport<T extends CoapProtocolAdapter, P e
 
         commandConsumer = mock(CommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());
-        when(commandConsumerFactory.createCommandConsumer(anyString(), anyString(), VertxMockSupport.anyHandler(), any(), any()))
+        when(commandConsumerFactory.createCommandConsumer(anyString(), anyString(), any(), any(), any()))
             .thenReturn(Future.succeededFuture(commandConsumer));
-        when(commandConsumerFactory.createCommandConsumer(anyString(), anyString(), anyString(), VertxMockSupport.anyHandler(), any(), any()))
+        when(commandConsumerFactory.createCommandConsumer(anyString(), anyString(), anyString(), any(), any(), any()))
             .thenReturn(Future.succeededFuture(commandConsumer));
 
         properties = newDefaultConfigurationProperties();

--- a/adapters/coap-vertx-quarkus/src/test/java/org/eclipse/hono/adapter/coap/TelemetryResourceTest.java
+++ b/adapters/coap-vertx-quarkus/src/test/java/org/eclipse/hono/adapter/coap/TelemetryResourceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -29,6 +29,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.CoAP.Type;
@@ -44,7 +45,6 @@ import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.service.metric.MetricsTags.Direction;
 import org.eclipse.hono.service.metric.MetricsTags.ProcessingOutcome;
 import org.eclipse.hono.service.metric.MetricsTags.TtdStatus;
-import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessagingType;
@@ -59,7 +59,6 @@ import org.mockito.ArgumentCaptor;
 import io.micrometer.core.instrument.Timer.Sample;
 import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.junit5.Timeout;
@@ -437,10 +436,10 @@ public class TelemetryResourceTest extends ResourceTestBase {
         }
 
         when(commandContext.get(anyString())).thenReturn(commandTimer);
-        when(commandConsumerFactory.createCommandConsumer(eq(tenantId), eq(deviceId), VertxMockSupport.anyHandler(), any(), any()))
+        when(commandConsumerFactory.createCommandConsumer(eq(tenantId), eq(deviceId), any(), any(), any()))
             .thenAnswer(invocation -> {
-                final Handler<CommandContext> consumer = invocation.getArgument(2);
-                consumer.handle(commandContext);
+                final Function<CommandContext, Future<Void>> consumer = invocation.getArgument(2);
+                consumer.apply(commandContext);
                 return Future.succeededFuture(commandConsumer);
             });
 
@@ -521,10 +520,10 @@ public class TelemetryResourceTest extends ResourceTestBase {
 
         // and a commandConsumerFactory that upon creating a consumer will invoke it with a command
         final CommandContext commandContext = givenAOneWayCommandContext("tenant", "device", "doThis", null, null);
-        when(commandConsumerFactory.createCommandConsumer(eq("tenant"), eq("device"), VertxMockSupport.anyHandler(), any(), any()))
+        when(commandConsumerFactory.createCommandConsumer(eq("tenant"), eq("device"), any(), any(), any()))
             .thenAnswer(invocation -> {
-                final Handler<CommandContext> consumer = invocation.getArgument(2);
-                consumer.handle(commandContext);
+                final Function<CommandContext, Future<Void>> consumer = invocation.getArgument(2);
+                consumer.apply(commandContext);
                 return Future.succeededFuture(commandConsumer);
             });
 

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -119,7 +119,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
 
         commandConsumer = mock(CommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());
-        when(commandConsumerFactory.createCommandConsumer(anyString(), anyString(), VertxMockSupport.anyHandler(), any(), any()))
+        when(commandConsumerFactory.createCommandConsumer(anyString(), anyString(), any(), any(), any()))
             .thenReturn(Future.succeededFuture(commandConsumer));
 
         resourceLimitChecks = mock(ResourceLimitChecks.class);
@@ -239,7 +239,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
         // THEN the device gets a 403
         assertContextFailedWithClientError(ctx, HttpURLConnection.HTTP_FORBIDDEN);
         // and no Command consumer has been created for the device
-        verify(commandConsumerFactory, never()).createCommandConsumer(anyString(), anyString(), VertxMockSupport.anyHandler(), any(), any());
+        verify(commandConsumerFactory, never()).createCommandConsumer(anyString(), anyString(), any(), any(), any());
         // and the message has not been forwarded downstream
         assertNoTelemetryMessageHasBeenSentDownstream();
         // and has not been reported as processed
@@ -290,7 +290,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
         // and the message has not been forwarded downstream
         assertNoTelemetryMessageHasBeenSentDownstream();
         // and no Command consumer has been created for the device
-        verify(commandConsumerFactory, never()).createCommandConsumer(anyString(), anyString(), VertxMockSupport.anyHandler(), any(), any());
+        verify(commandConsumerFactory, never()).createCommandConsumer(anyString(), anyString(), any(), any(), any());
         // and has not been reported as processed
         verify(metrics, never())
             .reportTelemetry(
@@ -683,7 +683,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
         });
         // and the creation of the command consumer completes at a later point
         final Promise<CommandConsumer> commandConsumerPromise = Promise.promise();
-        when(commandConsumerFactory.createCommandConsumer(anyString(), anyString(), VertxMockSupport.anyHandler(), any(), any()))
+        when(commandConsumerFactory.createCommandConsumer(anyString(), anyString(), any(), any(), any()))
                 .thenReturn(commandConsumerPromise.future());
 
         adapter.doUploadMessage(ctx, "tenant", "device");

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import java.net.HttpURLConnection;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import org.eclipse.hono.adapter.auth.device.DeviceCredentialsAuthProvider;
 import org.eclipse.hono.adapter.auth.device.UsernamePasswordCredentials;
@@ -146,7 +147,7 @@ public class VertxBasedHttpProtocolAdapterTest extends ProtocolAdapterTestSuppor
 
         final CommandConsumer commandConsumer = mock(CommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());
-        when(commandConsumerFactory.createCommandConsumer(anyString(), anyString(), VertxMockSupport.anyHandler(), any(), any())).
+        when(commandConsumerFactory.createCommandConsumer(anyString(), anyString(), any(), any(), any())).
                 thenReturn(Future.succeededFuture(commandConsumer));
 
         doAnswer(invocation -> {
@@ -507,10 +508,10 @@ public class VertxBasedHttpProtocolAdapterTest extends ProtocolAdapterTestSuppor
                 "DEFAULT_TENANT", "device_1", "doThis", "reply-to-id", null, null, MessagingType.amqp);
         final CommandConsumer commandConsumer = mock(CommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());
-        when(commandConsumerFactory.createCommandConsumer(eq("DEFAULT_TENANT"), eq("device_1"), VertxMockSupport.anyHandler(), any(), any()))
+        when(commandConsumerFactory.createCommandConsumer(eq("DEFAULT_TENANT"), eq("device_1"), any(), any(), any()))
                 .thenAnswer(invocation -> {
-                    final Handler<CommandContext> consumer = invocation.getArgument(2);
-                    consumer.handle(commandContext);
+                    final Function<CommandContext, Future<Void>> consumer = invocation.getArgument(2);
+                    consumer.apply(commandContext);
                     return Future.succeededFuture(commandConsumer);
                 });
 
@@ -535,7 +536,7 @@ public class VertxBasedHttpProtocolAdapterTest extends ProtocolAdapterTestSuppor
                 .sendJsonObject(new JsonObject(), ctx.succeeding(r -> {
                     ctx.verify(() -> {
                         verify(commandConsumerFactory).createCommandConsumer(eq("DEFAULT_TENANT"), eq("device_1"),
-                                VertxMockSupport.anyHandler(), any(), any());
+                                any(), any(), any());
                         // and the command consumer has been closed again
                         verify(commandConsumer).close(any());
                         verify(commandContext).accept();

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -902,7 +902,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
         // WHEN a device subscribes to commands
         final CommandConsumer commandConsumer = mock(CommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());
-        when(commandConsumerFactory.createCommandConsumer(eq("tenant"), eq("deviceId"), VertxMockSupport.anyHandler(), any(), any()))
+        when(commandConsumerFactory.createCommandConsumer(eq("tenant"), eq("deviceId"), any(), any(), any()))
                         .thenReturn(Future.succeededFuture(commandConsumer));
         final List<MqttTopicSubscription> subscriptions = Collections.singletonList(
                 newMockTopicSubscription(getCommandSubscriptionTopic("tenant", "deviceId"), qos));
@@ -915,7 +915,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
         mqttDeviceEndpoint.onSubscribe(msg);
 
         // THEN the adapter creates a command consumer that is checked periodically
-        verify(commandConsumerFactory).createCommandConsumer(eq("tenant"), eq("deviceId"), VertxMockSupport.anyHandler(), any(), any());
+        verify(commandConsumerFactory).createCommandConsumer(eq("tenant"), eq("deviceId"), any(), any(), any());
         // and the adapter registers a hook on the connection to the device
         final ArgumentCaptor<Handler<Void>> closeHookCaptor = VertxMockSupport.argumentCaptorHandler();
         verify(endpoint).closeHandler(closeHookCaptor.capture());
@@ -1049,7 +1049,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
         // WHEN a device subscribes to commands
         final CommandConsumer commandConsumer = mock(CommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED)));
-        when(commandConsumerFactory.createCommandConsumer(eq("tenant"), eq("deviceId"), VertxMockSupport.anyHandler(), any(), any()))
+        when(commandConsumerFactory.createCommandConsumer(eq("tenant"), eq("deviceId"), any(), any(), any()))
                 .thenReturn(Future.succeededFuture(commandConsumer));
         final List<MqttTopicSubscription> subscriptions = Collections.singletonList(
                 newMockTopicSubscription(getCommandSubscriptionTopic("tenant", "deviceId"), MqttQoS.AT_MOST_ONCE));
@@ -1062,7 +1062,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
         mqttDeviceEndpoint.onSubscribe(msg);
 
         // THEN the adapter creates a command consumer that is checked periodically
-        verify(commandConsumerFactory).createCommandConsumer(eq("tenant"), eq("deviceId"), VertxMockSupport.anyHandler(), any(), any());
+        verify(commandConsumerFactory).createCommandConsumer(eq("tenant"), eq("deviceId"), any(), any(), any());
         // and the adapter registers a hook on the connection to the device
         final ArgumentCaptor<Handler<Void>> closeHookCaptor = VertxMockSupport.argumentCaptorHandler();
         verify(endpoint).closeHandler(closeHookCaptor.capture());
@@ -1098,7 +1098,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
         // and for subscribing to commands
         final CommandConsumer commandConsumer = mock(CommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());
-        when(commandConsumerFactory.createCommandConsumer(eq("tenant-1"), eq("device-A"), VertxMockSupport.anyHandler(), any(), any()))
+        when(commandConsumerFactory.createCommandConsumer(eq("tenant-1"), eq("device-A"), any(), any(), any()))
                         .thenReturn(Future.succeededFuture(commandConsumer));
         subscriptions.add(
                 newMockTopicSubscription(getCommandSubscriptionTopic("tenant-1", "device-A"), MqttQoS.AT_MOST_ONCE));

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandConsumerFactory.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandConsumerFactory.java
@@ -14,12 +14,12 @@
 package org.eclipse.hono.client.command;
 
 import java.time.Duration;
+import java.util.function.Function;
 
 import org.eclipse.hono.util.Lifecycle;
 
 import io.opentracing.SpanContext;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 
 /**
  * A factory for creating consumers for commands targeted at devices.
@@ -41,6 +41,7 @@ public interface CommandConsumerFactory extends Lifecycle {
      * @param commandHandler The handler to invoke with every command received. The handler must invoke one of the
      *                       terminal methods of the passed in {@link CommandContext} in order to settle the command
      *                       message transfer and finish the trace span associated with the {@link CommandContext}.
+     *                       The future returned by the handler indicates the outcome of handling the command.
      * @param lifespan The time period in which the command consumer shall be active. Using a negative duration or
      *                 {@code null} here is interpreted as an unlimited life span. The guaranteed granularity
      *                 taken into account here is seconds.
@@ -59,7 +60,7 @@ public interface CommandConsumerFactory extends Lifecycle {
     Future<CommandConsumer> createCommandConsumer(
             String tenantId,
             String deviceId,
-            Handler<CommandContext> commandHandler,
+            Function<CommandContext, Future<Void>> commandHandler,
             Duration lifespan,
             SpanContext context);
 
@@ -79,6 +80,7 @@ public interface CommandConsumerFactory extends Lifecycle {
      * @param commandHandler The handler to invoke with every command received. The handler must invoke one of the
      *                       terminal methods of the passed in {@link CommandContext} in order to settle the command
      *                       message transfer and finish the trace span associated with the {@link CommandContext}.
+     *                       The future returned by the handler indicates the outcome of handling the command.
      * @param lifespan The time period in which the command consumer shall be active. Using a negative duration or
      *                 {@code null} here is interpreted as an unlimited life span. The guaranteed granularity
      *                 taken into account here is seconds.
@@ -98,7 +100,7 @@ public interface CommandConsumerFactory extends Lifecycle {
             String tenantId,
             String deviceId,
             String gatewayId,
-            Handler<CommandContext> commandHandler,
+            Function<CommandContext, Future<Void>> commandHandler,
             Duration lifespan,
             SpanContext context);
 }

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandHandlers.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandHandlers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,12 +17,13 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.vertx.core.Context;
-import io.vertx.core.Handler;
+import io.vertx.core.Future;
 
 /**
  * A container for command handlers associated with devices.
@@ -46,12 +47,13 @@ public class CommandHandlers {
      * @param commandHandler The command handler. The handler must invoke one of the terminal methods of the passed
      *                       in {@link CommandContext} in order to settle the command message transfer and finish
      *                       the trace span associated with the {@link CommandContext}.
+     *                       The future returned by the handler indicates the outcome of handling the command.
      * @param context The vert.x context to run the handler on or {@code null} to invoke the handler directly.
      * @return The replaced handler entry or {@code null} if there was none.
      * @throws NullPointerException If any of tenantId, deviceId or commandHandler is {@code null}.
      */
     public CommandHandlerWrapper putCommandHandler(final String tenantId, final String deviceId,
-            final String gatewayId, final Handler<CommandContext> commandHandler, final Context context) {
+            final String gatewayId, final Function<CommandContext, Future<Void>> commandHandler, final Context context) {
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(commandHandler);

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandRouterCommandConsumerFactory.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandRouterCommandConsumerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.eclipse.hono.client.ClientErrorException;
@@ -36,7 +37,6 @@ import org.slf4j.LoggerFactory;
 import io.opentracing.SpanContext;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
 
@@ -163,7 +163,7 @@ public class CommandRouterCommandConsumerFactory implements CommandConsumerFacto
     public final Future<CommandConsumer> createCommandConsumer(
             final String tenantId,
             final String deviceId,
-            final Handler<CommandContext> commandHandler,
+            final Function<CommandContext, Future<Void>> commandHandler,
             final Duration lifespan,
             final SpanContext context) {
 
@@ -179,7 +179,7 @@ public class CommandRouterCommandConsumerFactory implements CommandConsumerFacto
             final String tenantId,
             final String deviceId,
             final String gatewayId,
-            final Handler<CommandContext> commandHandler,
+            final Function<CommandContext, Future<Void>> commandHandler,
             final Duration lifespan,
             final SpanContext context) {
 
@@ -195,7 +195,7 @@ public class CommandRouterCommandConsumerFactory implements CommandConsumerFacto
             final String tenantId,
             final String deviceId,
             final String gatewayId,
-            final Handler<CommandContext> commandHandler,
+            final Function<CommandContext, Future<Void>> commandHandler,
             final Duration lifespan,
             final SpanContext context) {
         // lifespan greater than what can be expressed in nanoseconds (i.e. 292 years) is considered unlimited, preventing ArithmeticExceptions down the road

--- a/clients/command/src/test/java/org/eclipse/hono/client/command/CommandRouterCommandConsumerFactoryTest.java
+++ b/clients/command/src/test/java/org/eclipse/hono/client/command/CommandRouterCommandConsumerFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -43,7 +43,7 @@ import io.vertx.core.Future;
  * Tests verifying behavior of {@link CommandRouterCommandConsumerFactory}.
  *
  */
-class CommandRouterCommandConsumerFactoryTest {
+public class CommandRouterCommandConsumerFactoryTest {
 
     private CommandRouterClient commandRouterClient;
     private CommandRouterCommandConsumerFactory factory;
@@ -69,9 +69,9 @@ class CommandRouterCommandConsumerFactoryTest {
         verify(conLifecycle).addReconnectListener(reconnectListener.capture());
         factory.setMaxTenantIdsPerRequest(2);
 
-        factory.createCommandConsumer("tenant1", "device1", "adapter", ctx -> {}, Duration.ofMinutes(10), null);
-        factory.createCommandConsumer("tenant2", "device2", "adapter", ctx -> {}, Duration.ofMinutes(10), null);
-        factory.createCommandConsumer("tenant3", "device3", "adapter", ctx -> {}, Duration.ofMinutes(10), null);
+        factory.createCommandConsumer("tenant1", "device1", "adapter", ctx -> Future.succeededFuture(), Duration.ofMinutes(10), null);
+        factory.createCommandConsumer("tenant2", "device2", "adapter", ctx -> Future.succeededFuture(), Duration.ofMinutes(10), null);
+        factory.createCommandConsumer("tenant3", "device3", "adapter", ctx -> Future.succeededFuture(), Duration.ofMinutes(10), null);
 
         // WHEN connection is lost and re-established
         final List<String> enabledTenants = new ArrayList<>();


### PR DESCRIPTION
This is for #3259:
The `AsyncHandlingAutoCommitKafkaConsumer` will now be used for receiving command messages in protocol adapters. This means that a rate limiting will be applied to limit the number of concurrently handled command messages, preventing adapters to reach load levels that could lead to timeouts.