### PR TITLE
[#3092] Rename adapter K8s service references

### DIFF
--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaAdminClientConfigPropertiesTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaAdminClientConfigPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -88,7 +88,7 @@ public class KafkaAdminClientConfigPropertiesTest {
      */
     @Test
     public void testThatCreatedClientIdConformsToExpectedFormat() {
-        final String componentUid = "hono-adapter-amqp-vertx-7548cc6c66-4qhqh_ed7c6ab9cc27";
+        final String componentUid = "hono-adapter-amqp-7548cc6c66-4qhqh_ed7c6ab9cc27";
 
         final KafkaAdminClientConfigProperties config = new KafkaAdminClientConfigProperties();
         config.setAdminClientConfig(Map.of("client.id", "configuredId"));

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/KafkaConsumerConfigPropertiesTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/KafkaConsumerConfigPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -105,7 +105,7 @@ public class KafkaConsumerConfigPropertiesTest {
      */
     @Test
     public void testThatCreatedClientIdConformsToExpectedFormat() {
-        final String componentUid = "hono-adapter-amqp-vertx-7548cc6c66-4qhqh_ed7c6ab9cc27";
+        final String componentUid = "hono-adapter-amqp-7548cc6c66-4qhqh_ed7c6ab9cc27";
 
         config.setConsumerConfig(Map.of("client.id", "configuredId"));
         config.overrideComponentUidUsedForClientId(componentUid);

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/producer/KafkaProducerConfigPropertiesTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/producer/KafkaProducerConfigPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -95,7 +95,7 @@ public class KafkaProducerConfigPropertiesTest {
      */
     @Test
     public void testThatCreatedClientIdConformsToExpectedFormat() {
-        final String componentUid = "hono-adapter-amqp-vertx-7548cc6c66-4qhqh_ed7c6ab9cc27";
+        final String componentUid = "hono-adapter-amqp-7548cc6c66-4qhqh_ed7c6ab9cc27";
 
         config.setProducerConfig(Map.of("client.id", "configuredId"));
         config.overrideComponentUidUsedForClientId(componentUid);

--- a/clients/notification-kafka/src/test/java/org/eclipse/hono/client/notification/kafka/NotificationKafkaConsumerConfigPropertiesTest.java
+++ b/clients/notification-kafka/src/test/java/org/eclipse/hono/client/notification/kafka/NotificationKafkaConsumerConfigPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -123,7 +123,7 @@ public class NotificationKafkaConsumerConfigPropertiesTest {
      */
     @Test
     public void testThatCreatedClientIdConformsToExpectedFormat() {
-        final String componentUid = "hono-adapter-amqp-vertx-7548cc6c66-4qhqh_ed7c6ab9cc27";
+        final String componentUid = "hono-adapter-amqp-7548cc6c66-4qhqh_ed7c6ab9cc27";
 
         final NotificationKafkaConsumerConfigProperties config = new NotificationKafkaConsumerConfigProperties();
         config.setConsumerConfig(Map.of("client.id", "configuredId"));

--- a/clients/notification-kafka/src/test/java/org/eclipse/hono/client/notification/kafka/NotificationKafkaProducerConfigPropertiesTest.java
+++ b/clients/notification-kafka/src/test/java/org/eclipse/hono/client/notification/kafka/NotificationKafkaProducerConfigPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -117,7 +117,7 @@ public class NotificationKafkaProducerConfigPropertiesTest {
      */
     @Test
     public void testThatCreatedClientIdConformsToExpectedFormat() {
-        final String componentUid = "hono-adapter-amqp-vertx-7548cc6c66-4qhqh_ed7c6ab9cc27";
+        final String componentUid = "hono-adapter-amqp-7548cc6c66-4qhqh_ed7c6ab9cc27";
 
         final NotificationKafkaProducerConfigProperties config = new NotificationKafkaProducerConfigProperties();
         config.setProducerConfig(Map.of("client.id", "configuredId"));

--- a/demo-certs/ca_opts
+++ b/demo-certs/ca_opts
@@ -89,28 +89,28 @@ subjectAltName       = DNS.1:hono-service-command-router,DNS.2:hono-service-comm
 subjectKeyIdentifier = hash
 keyUsage             = keyAgreement,keyEncipherment,digitalSignature
 extendedKeyUsage     = serverAuth, clientAuth
-subjectAltName       = DNS.1:hono-adapter-http-vertx,DNS.2:hono-adapter-http-vertx.hono,DNS.3:localhost
+subjectAltName       = DNS.1:hono-adapter-http,DNS.2:hono-adapter-http.hono,DNS.3:localhost
 
 [ req_ext_lora-adapter ]
 
 subjectKeyIdentifier = hash
 keyUsage             = keyAgreement,keyEncipherment,digitalSignature
 extendedKeyUsage     = serverAuth, clientAuth
-subjectAltName       = DNS.1:hono-adapter-lora-vertx,DNS.2:hono-adapter-lora-vertx.hono,DNS.3:localhost
+subjectAltName       = DNS.1:hono-adapter-lora,DNS.2:hono-adapter-lora.hono,DNS.3:localhost
 
 [ req_ext_mqtt-adapter ]
 
 subjectKeyIdentifier = hash
 keyUsage             = keyAgreement,keyEncipherment,digitalSignature
 extendedKeyUsage     = serverAuth, clientAuth
-subjectAltName       = DNS.1:hono-adapter-mqtt-vertx,DNS.2:hono-adapter-mqtt-vertx.hono,DNS.3:localhost
+subjectAltName       = DNS.1:hono-adapter-mqtt,DNS.2:hono-adapter-mqtt.hono,DNS.3:localhost
 
 [ req_ext_amqp-adapter ]
 
 subjectKeyIdentifier = hash
 keyUsage             = keyAgreement,keyEncipherment,digitalSignature
 extendedKeyUsage     = serverAuth, clientAuth
-subjectAltName       = DNS.1:hono-adapter-amqp-vertx,DNS.2:hono-adapter-amqp-vertx.hono,DNS.3:localhost
+subjectAltName       = DNS.1:hono-adapter-amqp,DNS.2:hono-adapter-amqp.hono,DNS.3:localhost
 
 [ req_ext_artemis ]
 
@@ -124,7 +124,7 @@ subjectAltName       = DNS.1:hono-artemis,DNS.2:hono-artemis.hono,DNS.3:localhos
 subjectKeyIdentifier = hash
 keyUsage             = keyAgreement,keyEncipherment,digitalSignature
 extendedKeyUsage     = serverAuth, clientAuth
-subjectAltName       = DNS.1:hono-adapter-coap-vertx,DNS.2:hono-adapter-coap-vertx.hono,DNS.3:localhost
+subjectAltName       = DNS.1:hono-adapter-coap,DNS.2:hono-adapter-coap.hono,DNS.3:localhost
 
 [ req_ext_example-gateway ]
 

--- a/deploy/src/main/deploy/services.sh
+++ b/deploy/src/main/deploy/services.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #*******************************************************************************
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -29,11 +29,11 @@ function get_service_ip {
 
 get_service_ip hono-dispatch-router-ext AMQP_NETWORK_IP
 get_service_ip hono-service-device-registry-ext REGISTRY_IP
-get_service_ip hono-adapter-amqp-vertx AMQP_ADAPTER_IP
-get_service_ip hono-adapter-coap-vertx COAP_ADAPTER_IP
-get_service_ip hono-adapter-http-vertx HTTP_ADAPTER_IP
-get_service_ip hono-adapter-kura KURA_ADAPTER_IP
-get_service_ip hono-adapter-mqtt-vertx MQTT_ADAPTER_IP
+get_service_ip hono-adapter-amqp AMQP_ADAPTER_IP
+get_service_ip hono-adapter-coap COAP_ADAPTER_IP
+get_service_ip hono-adapter-http HTTP_ADAPTER_IP
+get_service_ip hono-adapter-lora LORA_ADAPTER_IP
+get_service_ip hono-adapter-mqtt MQTT_ADAPTER_IP
 echo "# Run this command to populate environment variables"
 echo "# with the IP addresses of Hono's API endpoints:"
 echo "# eval \"\$(./services.sh namespace)\""

--- a/examples/protocol-gateway-example/scripts/create_hono_device.sh
+++ b/examples/protocol-gateway-example/scripts/create_hono_device.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #*******************************************************************************
-# Copyright (c) 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -12,14 +12,14 @@
 # SPDX-License-Identifier: EPL-2.0
 #*******************************************************************************
 
-# A simple shell script to get IP addresses for hono-service-device-registry-ext, hono-dispatch-router-ext and hono-adapter-amqp-vertx and creates a device id and password
+# A simple shell script to get IP addresses for hono-service-device-registry-ext, hono-dispatch-router-ext and hono-adapter-amqp and creates a device id and password
 
 # prior: setup hono in kubernetes namespace "hono"
 export REGISTRY_IP=$(kubectl -n hono get service hono-service-device-registry-ext --output='jsonpath={.status.loadBalancer.ingress[0].ip}')
 echo "REGISTRY_IP=${REGISTRY_IP}"
 export AMQP_NETWORK_IP=$(kubectl -n hono get service hono-dispatch-router-ext --output='jsonpath={.status.loadBalancer.ingress[0].ip}')
 echo "AMQP_NETWORK_IP=${AMQP_NETWORK_IP}"
-export AMQP_ADAPTER_PORT=$(kubectl -n hono get service hono-adapter-amqp-vertx --output='jsonpath={.status.loadBalancer.ingress[0].port}')
+export AMQP_ADAPTER_PORT=$(kubectl -n hono get service hono-adapter-amqp --output='jsonpath={.status.loadBalancer.ingress[0].port}')
 echo "AMQP_ADAPTER_IP=${AMQP_ADAPTER_IP}"
 
 # Get example tenant or

--- a/site/documentation/content/deployment/resource-limitation.md
+++ b/site/documentation/content/deployment/resource-limitation.md
@@ -55,18 +55,18 @@ resource descriptor illustrates the mechanism:
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: hono-adapter-http-vertx
+  name: hono-adapter-http
 spec:
   template:
     metadata:
       labels:
-        app: hono-adapter-http-vertx
+        app: hono-adapter-http
         version: "${project.version}"
         group: ${project.groupId}
     spec:
       containers:
       - image: eclipse/hono-adapter-http:${project.version}
-        name: eclipse-hono-adapter-http-vertx
+        name: eclipse-hono-adapter-http
         resources:
           limits:
             memory: "300Mi"
@@ -83,7 +83,7 @@ spec:
       volumes:
       - name: conf
         secret:
-          secretName: hono-adapter-http-vertx-conf
+          secretName: hono-adapter-http-conf
 ~~~
 
 The `resources` property defines the overall limit of 256 MB of memory that the pod may use. The `JDK_JAVA_OPTIONS`

--- a/site/documentation/content/getting-started/_index.md
+++ b/site/documentation/content/getting-started/_index.md
@@ -170,8 +170,8 @@ be used during the remainder of this guide to set and refresh some environment v
 
 ~~~sh
 echo "export REGISTRY_IP=$(kubectl get service eclipse-hono-service-device-registry-ext --output="jsonpath={.status.loadBalancer.ingress[0]['hostname','ip']}" -n hono)" > hono.env
-echo "export HTTP_ADAPTER_IP=$(kubectl get service eclipse-hono-adapter-http-vertx --output="jsonpath={.status.loadBalancer.ingress[0]['hostname','ip']}" -n hono)" >> hono.env
-echo "export MQTT_ADAPTER_IP=$(kubectl get service eclipse-hono-adapter-mqtt-vertx --output="jsonpath={.status.loadBalancer.ingress[0]['hostname','ip']}" -n hono)" >> hono.env
+echo "export HTTP_ADAPTER_IP=$(kubectl get service eclipse-hono-adapter-http --output="jsonpath={.status.loadBalancer.ingress[0]['hostname','ip']}" -n hono)" >> hono.env
+echo "export MQTT_ADAPTER_IP=$(kubectl get service eclipse-hono-adapter-mqtt --output="jsonpath={.status.loadBalancer.ingress[0]['hostname','ip']}" -n hono)" >> hono.env
 KAFKA_IP=$(kubectl get service eclipse-hono-kafka-0-external --output="jsonpath={.status.loadBalancer.ingress[0]['hostname','ip']}" -n hono)
 KAFKA_TRUSTSTORE_PATH=/tmp/truststore.pem
 kubectl get secrets eclipse-hono-kafka-certs --template="{{index .data \"ca.crt\" | base64decode}}" -n hono > ${KAFKA_TRUSTSTORE_PATH}
@@ -234,8 +234,8 @@ be used during the remainder of this guide to set and refresh some environment v
 
 ~~~sh
 echo "export REGISTRY_IP=$(kubectl get service eclipse-hono-service-device-registry-ext --output="jsonpath={.status.loadBalancer.ingress[0]['hostname','ip']}" -n hono)" > hono.env
-echo "export HTTP_ADAPTER_IP=$(kubectl get service eclipse-hono-adapter-http-vertx --output="jsonpath={.status.loadBalancer.ingress[0]['hostname','ip']}" -n hono)" >> hono.env
-echo "export MQTT_ADAPTER_IP=$(kubectl get service eclipse-hono-adapter-mqtt-vertx --output="jsonpath={.status.loadBalancer.ingress[0]['hostname','ip']}" -n hono)" >> hono.env
+echo "export HTTP_ADAPTER_IP=$(kubectl get service eclipse-hono-adapter-http --output="jsonpath={.status.loadBalancer.ingress[0]['hostname','ip']}" -n hono)" >> hono.env
+echo "export MQTT_ADAPTER_IP=$(kubectl get service eclipse-hono-adapter-mqtt --output="jsonpath={.status.loadBalancer.ingress[0]['hostname','ip']}" -n hono)" >> hono.env
 AMQP_NETWORK_IP=$(kubectl get service eclipse-hono-dispatch-router-ext --output="jsonpath={.status.loadBalancer.ingress[0]['hostname','ip']}" -n hono)
 echo "export APP_OPTIONS='--amqp -H ${AMQP_NETWORK_IP} -P 15672 -u consumer@HONO -p verysecret'" >> hono.env
 ~~~


### PR DESCRIPTION
This is for #3092.
Rename adapter K8s service references, dropping the "-vertx" suffix.