### PR TITLE
[#3266] Fix HTTP request span names

### DIFF
--- a/adapters/http-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -256,11 +256,11 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
      * This method creates a router instance along with a route matching all request. That route is initialized with the
      * following handlers and failure handlers:
      * <ol>
+     * <li>a default failure handler,</li>
      * <li>a handler to keep track of the tracing span created for the request by means of the Vert.x/Quarkus
      * instrumentation,</li>
      * <li>a handler to add a Micrometer {@code Timer.Sample} to the routing context,</li>
      * <li>a handler to log when the connection is closed prematurely,</li>
-     * <li>a default failure handler,</li>
      * <li>a handler limiting the body size of requests to the maximum payload size set in the <em>config</em>
      * properties.</li>
      * </ol>
@@ -269,9 +269,17 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
      */
     protected Router createRouter() {
 
+        // route (failure) handlers are added in a specific order here!
         final Router router = Router.router(vertx);
+        final Route matchAllFailuresRoute = router.route();
+        // failure handler is added on a separate route for which no name is set, otherwise all tracing spans
+        // of failed HTTP requests would get that route name as span name
+        matchAllFailuresRoute.failureHandler(new DefaultFailureHandler());
+
         final Route matchAllRoute = router.route();
-        // the handlers and failure handlers are added here in a specific order!
+        // route name will be used as HTTP request tracing span name,
+        // ensuring a fixed name is set in case no other route matches (otherwise the span name would unsuitably be set to the request path)
+        matchAllRoute.setName("/* (default route)");
         // 1. handler to keep track of the tracing span created by the Vert.x/Quarkus instrumentation (set as active span there)
         matchAllRoute.handler(HttpServerSpanHelper.getRouteHandlerForAdoptingActiveSpan(tracer, getCustomTags()));
 
@@ -289,10 +297,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
             ctx.next();
         });
 
-        // 4. default handler for failed routes
-        matchAllRoute.failureHandler(new DefaultFailureHandler());
-
-        // 5. BodyHandler with request size limit
+        // 4. BodyHandler with request size limit
         log.info("limiting size of inbound request body to {} bytes", getConfig().getMaxPayloadSize());
         final BodyHandler bodyHandler = BodyHandler.create(DEFAULT_UPLOADS_DIRECTORY)
                 .setBodyLimit(getConfig().getMaxPayloadSize());


### PR DESCRIPTION
This fixes #3266.
HTTP requests for which no specific route matches shall get a fixed tracing span name, not one corresponding to the request path.