### PR TITLE
Update bouncycastle; make the dependency more explicit

### DIFF
--- a/adapter-base/pom.xml
+++ b/adapter-base/pom.xml
@@ -125,6 +125,11 @@
       <artifactId>truth</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,6 +30,7 @@
   <properties>
     <artemis.image.name>quay.io/enmasse/artemis-base:2.13.0</artemis.image.name>
     <assertj.version>3.22.0</assertj.version>
+    <bouncycastle.version>1.71</bouncycastle.version>
     <caffeine.version>2.9.3</caffeine.version>
     <californium.version>3.4.0</californium.version>
     <cryptvault.version>1.0.2</cryptvault.version>
@@ -605,6 +606,12 @@ quarkus.vertx.resolver.cache-max-time-to-live=0
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
         <version>${qpid-jms.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk18on</artifactId>
+        <version>${bouncycastle.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -173,6 +173,11 @@
       <artifactId>opentelemetry-sdk</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -541,14 +541,14 @@
             </configuration>
           </execution>
           <execution>
-            <id>enforce-java-11</id>
+            <id>enforce-java-17</id>
             <goals>
               <goal>enforce</goal>
             </goals>
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>11</version>
+                  <version>17</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -573,24 +573,6 @@
   </build>
 
   <profiles>
-    <profile>
-      <id>java_15_and_later</id>
-      <activation>
-        <jdk>[15,)</jdk>
-      </activation>
-      <dependencies>
-        <!--
-          use BC for creating self-signed certs instead of sun.security.x509
-          which has been removed in OpenJDK 15
-        -->
-        <dependency>
-          <groupId>org.bouncycastle</groupId>
-          <artifactId>bcpkix-jdk15on</artifactId>
-          <version>1.69</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
     <profile>
       <id>no_docker</id>
       <activation>

--- a/services/device-registry-base/pom.xml
+++ b/services/device-registry-base/pom.xml
@@ -106,6 +106,11 @@
       <artifactId>jcl-over-slf4j</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/services/device-registry-jdbc/pom.xml
+++ b/services/device-registry-jdbc/pom.xml
@@ -99,6 +99,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/services/device-registry-mongodb/pom.xml
+++ b/services/device-registry-mongodb/pom.xml
@@ -97,7 +97,11 @@
       <artifactId>core-test-utils</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -338,6 +338,11 @@
       <artifactId>opentelemetry-sdk</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Use `bcpkix-jdk18on` instead of `bcpkix-jdk15on` now (see https://www.bouncycastle.org/latest_releases.html).