### PR TITLE
[#3275] Fix NPE on Command Router startup

### DIFF
--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/InternalKafkaTopicCleanupService.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/InternalKafkaTopicCleanupService.java
@@ -79,11 +79,13 @@ public class InternalKafkaTopicCleanupService extends AbstractVerticle {
         Objects.requireNonNull(adminClientConfigProperties);
 
         final var adminClientConfig = adminClientConfigProperties.getAdminClientConfig(CLIENT_NAME);
-        final var kafkaClientFactory = new KafkaClientFactory(vertx);
-        this.kafkaAdminClientCreator = () -> kafkaClientFactory.createKafkaAdminClientWithRetries(
-                adminClientConfig,
-                lifecycleStatus::isStarting,
-                KafkaClientFactory.UNLIMITED_RETRIES_DURATION);
+        this.kafkaAdminClientCreator = () -> {
+            final var kafkaClientFactory = new KafkaClientFactory(vertx);
+            return kafkaClientFactory.createKafkaAdminClientWithRetries(
+                    adminClientConfig,
+                    lifecycleStatus::isStarting,
+                    KafkaClientFactory.UNLIMITED_RETRIES_DURATION);
+        };
     }
 
     /**


### PR DESCRIPTION
This fixes #3275.

`vertx` is `null` in the `InternalKafkaTopicCleanupService` constructor.