### PR TITLE
[#3263]Remove the BodyHandler in createRouter.

### DIFF
--- a/adapters/http-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -261,8 +261,6 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
      * instrumentation,</li>
      * <li>a handler to add a Micrometer {@code Timer.Sample} to the routing context,</li>
      * <li>a handler to log when the connection is closed prematurely,</li>
-     * <li>a handler limiting the body size of requests to the maximum payload size set in the <em>config</em>
-     * properties.</li>
      * </ol>
      *
      * @return The newly created router (never {@code null}).
@@ -296,12 +294,6 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
             }
             ctx.next();
         });
-
-        // 4. BodyHandler with request size limit
-        log.info("limiting size of inbound request body to {} bytes", getConfig().getMaxPayloadSize());
-        final BodyHandler bodyHandler = BodyHandler.create(DEFAULT_UPLOADS_DIRECTORY)
-                .setBodyLimit(getConfig().getMaxPayloadSize());
-        matchAllRoute.handler(bodyHandler);
         return router;
     }
 
@@ -1264,5 +1256,17 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
         } else {
             return MetricsTags.QoS.AT_LEAST_ONCE;
         }
+    }
+
+    /**
+     * Gets body handler and sets the maximum body size.
+     * <p>This method sets body limit size from the configuration.
+     *
+     * @return The body handler.
+     */
+    protected BodyHandler getBodyHandler() {
+        final BodyHandler bodyHandler = BodyHandler.create(DEFAULT_UPLOADS_DIRECTORY);
+        bodyHandler.setBodyLimit(getConfig().getMaxPayloadSize());
+        return bodyHandler;
     }
 }

--- a/adapters/http-base/src/main/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-base/src/main/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapter.java
@@ -158,7 +158,9 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
                     .setName("/telemetry (CORS)");
 
             // require auth for POSTing telemetry
-            router.post(ROUTE_TELEMETRY_ENDPOINT).handler(authHandler);
+            router.post(ROUTE_TELEMETRY_ENDPOINT)
+                    .handler(authHandler)
+                    .handler(getBodyHandler());
 
             // route for posting telemetry data using tenant and device ID determined as part of
             // device authentication
@@ -174,6 +176,7 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
 
         // route for uploading telemetry data
         router.putWithRegex("\\/telemetry\\/.+")
+                .handler(getBodyHandler())
                 .handler(this::handlePutTelemetry)
                 .setName(telemetryPutPathWithParams);
     }
@@ -207,7 +210,9 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
                     .setName("/event (CORS)");
 
             // require auth for POSTing events
-            router.post(ROUTE_EVENT_ENDPOINT).handler(authHandler);
+            router.post(ROUTE_EVENT_ENDPOINT)
+                    .handler(authHandler)
+                    .handler(getBodyHandler());
 
             // route for posting events using tenant and device ID determined as part of
             // device authentication
@@ -223,6 +228,7 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
 
         // route for sending event messages
         router.putWithRegex("\\/event\\/.+")
+                .handler(getBodyHandler())
                 .handler(this::handlePutTelemetry)
                 .setName(eventPutPathWithParams);
     }
@@ -252,6 +258,7 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
             // require auth for POSTing command response messages
             router.post(commandResponseMatchAllPath)
                     .handler(authHandler)
+                    .handler(getBodyHandler())
                     .setName(commandResponsePostPathWithParam);
 
             // route for POSTing command response messages using tenant and device ID determined as part of
@@ -270,10 +277,10 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
 
         // route for uploading command response message
         router.put(commandResponseMatchAllPath)
+                .handler(getBodyHandler())
                 .handler(this::handlePutCommandResponse)
                 .setName(commandResponsePutPathWithParams);
     }
-
 
     private static String getTenantParam(final RoutingContext ctx) {
         return ctx.request().getParam(PARAM_TENANT);

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/LoraProtocolAdapter.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/LoraProtocolAdapter.java
@@ -200,6 +200,7 @@ public final class LoraProtocolAdapter extends AbstractVertxBasedHttpProtocolAda
 
                 router.route(provider.acceptedHttpMethod(), pathPrefix)
                         .consumes(provider.acceptedContentType())
+                        .handler(getBodyHandler())
                         .handler(ctx -> this.handleProviderRoute(HttpContext.from(ctx), provider));
 
                 router.route(provider.acceptedHttpMethod(), pathPrefix).handler(ctx -> {

--- a/adapters/sigfox/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
+++ b/adapters/sigfox/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
@@ -120,11 +120,13 @@ public final class SigfoxProtocolAdapter
         router.route("/data/telemetry/:" + SIGFOX_PARAM_TENANT)
                 .method(HttpMethod.GET)
                 .handler(dataCorsHandler())
+                .handler(getBodyHandler())
                 .handler(ctx -> dataHandler(HttpContext.from(ctx), this::uploadTelemetryMessage));
 
         router.route("/data/event/:" + SIGFOX_PARAM_TENANT)
                 .method(HttpMethod.GET)
                 .handler(dataCorsHandler())
+                .handler(getBodyHandler())
                 .handler(ctx -> dataHandler(HttpContext.from(ctx), this::uploadEventMessage));
 
         router.errorHandler(500, t -> LOG.warn("Unhandled exception", t.failure()));

--- a/service-base/src/main/java/org/eclipse/hono/service/http/AbstractHttpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/AbstractHttpEndpoint.java
@@ -49,6 +49,11 @@ public abstract class AbstractHttpEndpoint<T extends ServiceConfigProperties> ex
         implements HttpEndpoint {
 
     /**
+     * Default file uploads directory used by Vert.x Web.
+     */
+    protected static final String DEFAULT_UPLOADS_DIRECTORY = "/tmp";
+
+    /**
      * The key that is used to put a valid JSON payload to the RoutingContext.
      */
     protected static final String KEY_REQUEST_BODY = "KEY_REQUEST_BODY";

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
@@ -34,7 +34,6 @@ import io.vertx.ext.healthchecks.HealthCheckHandler;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.AuthenticationHandler;
-import io.vertx.ext.web.handler.BodyHandler;
 
 /**
  * A base class for implementing services using HTTP.
@@ -42,11 +41,6 @@ import io.vertx.ext.web.handler.BodyHandler;
  * @param <T> The type of configuration properties used by this service.
  */
 public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends AbstractServiceBase<T> {
-
-    /**
-     * Default file uploads directory used by Vert.x Web.
-     */
-    protected static final String DEFAULT_UPLOADS_DIRECTORY = "/tmp";
 
     private final Map<String, HttpEndpoint> endpoints = new HashMap<>();
 
@@ -180,8 +174,6 @@ public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends
      * <li>a default failure handler,</li>
      * <li>a handler to keep track of the tracing span created for the request by means of the Vert.x/Quarkus
      * instrumentation,</li>
-     * <li>a handler limiting the body size of requests to the maximum payload size set in the <em>config</em>
-     * properties.</li>
      * <li>the authentication handler, set via {@link #setAuthHandler(AuthenticationHandler)}.</li>
      * </ul>
      *
@@ -200,13 +192,9 @@ public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends
         // route name will be used as HTTP request tracing span name,
         // ensuring a fixed name is set in case no other route matches (otherwise the span name would unsuitably be set to the request path)
         matchAllRoute.setName("/* (default route)");
-        // 1. handler to keep track of the tracing span created by the Vert.x/Quarkus instrumentation (set as active span there)
+        // handler to keep track of the tracing span created by the Vert.x/Quarkus instrumentation (set as active span there)
         matchAllRoute.handler(HttpServerSpanHelper.getRouteHandlerForAdoptingActiveSpan(tracer, getCustomTags()));
-        // 2. BodyHandler with request size limit
-        log.info("limiting size of inbound request body to {} bytes", getConfig().getMaxPayloadSize());
-        matchAllRoute.handler(BodyHandler.create().setUploadsDirectory(DEFAULT_UPLOADS_DIRECTORY)
-                .setBodyLimit(getConfig().getMaxPayloadSize()));
-        // 3. AuthHandler
+         // AuthHandler
         addAuthHandler(router);
         return router;
     }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/DelegatingCredentialsManagementHttpEndpoint.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/DelegatingCredentialsManagementHttpEndpoint.java
@@ -54,7 +54,6 @@ import io.vertx.ext.web.handler.BodyHandler;
  */
 public class DelegatingCredentialsManagementHttpEndpoint<S extends CredentialsManagementService> extends AbstractDelegatingRegistryHttpEndpoint<S, ServiceConfigProperties> {
 
-
     private static final String SPAN_NAME_GET_CREDENTIALS = "get Credentials from management API";
     private static final String SPAN_NAME_UPDATE_CREDENTIALS = "update Credentials from management API";
 
@@ -88,7 +87,7 @@ public class DelegatingCredentialsManagementHttpEndpoint<S extends CredentialsMa
         // Add CORS handler
         router.route(pathWithTenantAndDeviceId).handler(createCorsHandler(config.getCorsAllowedOrigin(), Set.of(HttpMethod.GET, HttpMethod.PUT)));
 
-        final BodyHandler bodyHandler = BodyHandler.create();
+        final BodyHandler bodyHandler = BodyHandler.create(DEFAULT_UPLOADS_DIRECTORY);
         bodyHandler.setBodyLimit(config.getMaxPayloadSize());
 
         // get all credentials for a given device

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DelegatingDeviceManagementHttpEndpoint.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DelegatingDeviceManagementHttpEndpoint.java
@@ -98,7 +98,7 @@ public class DelegatingDeviceManagementHttpEndpoint<S extends DeviceManagementSe
         router.route(pathWithTenant).handler(createCorsHandler(config.getCorsAllowedOrigin(), Set.of(HttpMethod.POST)));
         router.route(pathWithTenantAndDeviceId).handler(createDefaultCorsHandler(config.getCorsAllowedOrigin()));
 
-        final BodyHandler bodyHandler = BodyHandler.create();
+        final BodyHandler bodyHandler = BodyHandler.create(DEFAULT_UPLOADS_DIRECTORY);
         bodyHandler.setBodyLimit(config.getMaxPayloadSize());
 
         // CREATE device with auto-generated deviceID

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/tenant/DelegatingTenantManagementHttpEndpoint.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/tenant/DelegatingTenantManagementHttpEndpoint.java
@@ -52,7 +52,6 @@ import io.vertx.ext.web.handler.BodyHandler;
  * @param <S> The type of service this endpoint delegates to.
  */
 public class DelegatingTenantManagementHttpEndpoint<S extends TenantManagementService> extends AbstractDelegatingRegistryHttpEndpoint<S, ServiceConfigProperties> {
-
     static final int DEFAULT_PAGE_OFFSET = 0;
     static final int DEFAULT_PAGE_SIZE = 30;
     static final int MAX_PAGE_SIZE = 200;
@@ -95,7 +94,7 @@ public class DelegatingTenantManagementHttpEndpoint<S extends TenantManagementSe
         router.route(path).handler(createCorsHandler(config.getCorsAllowedOrigin(), Set.of(HttpMethod.POST)));
         router.route(pathWithTenant).handler(createDefaultCorsHandler(config.getCorsAllowedOrigin()));
 
-        final BodyHandler bodyHandler = BodyHandler.create();
+        final BodyHandler bodyHandler = BodyHandler.create(DEFAULT_UPLOADS_DIRECTORY);
         bodyHandler.setBodyLimit(config.getMaxPayloadSize());
 
         // ADD tenant with auto-generated ID


### PR DESCRIPTION
    [#3263] Remove the BodyHandler.
    
    Remove the BodyHandler in createRouter because it is already added.
    Add a default uploads directory when creating a bodyhandler.
    Fix javadoc(createRouter).
    
    Signed-off-by: Ivanova Suzana <Suzana.Ivanova@bosch.io>
