### PR TITLE
Fix deserialization of CommandEndpoint class in native image

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/CommandEndpoint.java
+++ b/core/src/main/java/org/eclipse/hono/util/CommandEndpoint.java
@@ -22,13 +22,19 @@ import java.util.Objects;
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * Encapsulates the command endpoint information for a device as defined by the
  * <a href="https://www.eclipse.org/hono/docs/api/device-registration/">Device Registration API</a>.
  */
-public class CommandEndpoint {
+@RegisterForReflection
+@JsonInclude(value = Include.NON_NULL)
+public final class CommandEndpoint {
     private String uri;
     private Map<String, String> headers = new HashMap<>();
     private Map<String, Object> payloadProperties = new HashMap<>();
@@ -64,6 +70,7 @@ public class CommandEndpoint {
      * @return An unmodifiable view on the headers.
      */
     @JsonProperty(value = RegistrationConstants.FIELD_COMMAND_ENDPOINT_HEADERS)
+    @JsonInclude(value = Include.NON_EMPTY)
     public Map<String, String> getHeaders() {
         return Collections.unmodifiableMap(headers);
     }
@@ -86,6 +93,7 @@ public class CommandEndpoint {
      * @return An unmodifiable view on the payload properties.
      */
     @JsonProperty(value = RegistrationConstants.FIELD_COMMAND_ENDPOINT_PAYLOAD_PROPERTIES)
+    @JsonInclude(value = Include.NON_EMPTY)
     public Map<String, Object> getPayloadProperties() {
         return Collections.unmodifiableMap(payloadProperties);
     }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/Device.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/Device.java
@@ -383,4 +383,25 @@ public class Device {
     public final Set<String> getAuthorities() {
         return Collections.unmodifiableSet(authorities);
     }
+
+    /**
+     * Gets the definition of the endpoint that commands for this device should be sent to.
+     *
+     * @return The endpoint definition or {@code null} if not set.
+     */
+    public final CommandEndpoint getCommandEndpoint() {
+        return commandEndpoint;
+    }
+
+    /**
+     * Sets the definition of the endpoint that commands for this device should be sent to.
+     *
+     * @param endpoint The endpoint definition.
+     * @return A reference to this for fluent use.
+     * @throws NullPointerException if endpoint is {@code null}.
+     */
+    public final Device setCommandEndpoint(final CommandEndpoint endpoint) {
+        this.commandEndpoint = Objects.requireNonNull(endpoint);
+        return this;
+    }
 }

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -46,6 +46,8 @@ description = "Information about changes in recent Hono releases. Includes new f
 * The mechanism to delete obsolete `hono.command_internal.*` Kafka topics could have deleted still used topics in
   case the Kubernetes API server gave information about the running containers with a delay of several seconds. This has
   been fixed.
+* The native executable based images of protocol adapters failed to deserialize a registration assertion if it included command
+  endpoint information that had been configured for the device. This has been fixed.
 
 ### API Changes
 


### PR DESCRIPTION
The native executable based images of protocol adapters failed to
deserialize a registration assertion if it included command endpoint
information that had been configured for the device.

The CommandEndpoint class has been amended with the
@RegisterForReflection annotation and the registry ITs have been
extended to also verify the transfer of command endpoint info in the
registration assertion.

Fixes #3287
