### PR TITLE
Add default error handler for HTTP requests with status 404

### DIFF
--- a/adapters/http-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -298,6 +298,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
             }
             ctx.next();
         });
+        HttpUtils.addDefault404ErrorHandler(router);
         return router;
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
@@ -207,6 +207,7 @@ public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends
             ctx.next();
         });
         addAuthHandler(router);
+        HttpUtils.addDefault404ErrorHandler(router);
         return router;
     }
 


### PR DESCRIPTION
Relates to #3298:
This makes sure that HTTP requests with status 404 are marked with an error tracing tag.