### PR TITLE
Use SubstrateVM specific min RAM requirement

### DIFF
--- a/adapters/coap/src/main/java/org/eclipse/hono/adapter/coap/impl/ConfigBasedCoapEndpointFactory.java
+++ b/adapters/coap/src/main/java/org/eclipse/hono/adapter/coap/impl/ConfigBasedCoapEndpointFactory.java
@@ -68,9 +68,14 @@ public class ConfigBasedCoapEndpointFactory implements CoapEndpointFactory {
     }
 
     /**
-     * The minimum amount of memory that the adapter requires to run.
+     * The minimum amount of memory (bytes) that the adapter requires to run on a standard Java VM.
      */
-    private static final int MINIMAL_MEMORY = 100_000_000; // 100MB: minimal memory necessary for startup
+    private static final int MINIMAL_MEMORY_JVM = 100_000_000; // 100MB: minimal memory necessary for startup
+    /**
+     * The minimum amount of memory (bytes) that the adapter requires to run on a Substrate VM (i.e. when running
+     * as a native executable).
+     */
+    private static final int MINIMAL_MEMORY_SUBSTRATE = 35_000_000;
     /**
      * The amount of memory required for each connection.
      */
@@ -170,7 +175,7 @@ public class ConfigBasedCoapEndpointFactory implements CoapEndpointFactory {
         final int maxConnections = config.getMaxConnections();
         if (maxConnections == 0) {
             final MemoryBasedConnectionLimitStrategy limits = MemoryBasedConnectionLimitStrategy.forParams(
-                    MINIMAL_MEMORY,
+                    config.isSubstrateVm() ? MINIMAL_MEMORY_SUBSTRATE : MINIMAL_MEMORY_JVM,
                     MEMORY_PER_CONNECTION,
                     config.getGcHeapPercentage());
             configuration.set(CoapConfig.MAX_ACTIVE_PEERS, limits.getRecommendedLimit());


### PR DESCRIPTION
The CoAP adapter has been adapted to consider the reduced minimum RAM
requirement for starting on a Substrate VM when determining the maximum
number of connections supported by the adapter.

Fixes #3303
