### PR TITLE
[#3263] Remove the BodyHandler.

### DIFF
--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -281,8 +281,6 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
      * <li>a handler and failure handler that creates tracing data for all server requests,</li>
      * <li>a handler to log when the connection is closed prematurely,</li>
      * <li>a default failure handler,</li>
-     * <li>a handler limiting the body size of requests to the maximum payload size set in the <em>config</em>
-     * properties.</li>
      * </ol>
      *
      * @return The newly created router (never {@code null}).
@@ -311,12 +309,6 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
 
         // 4. default handler for failed routes
         matchAllRoute.failureHandler(new DefaultFailureHandler());
-
-        // 5. BodyHandler with request size limit
-        log.info("limiting size of inbound request body to {} bytes", getConfig().getMaxPayloadSize());
-        final BodyHandler bodyHandler = BodyHandler.create(DEFAULT_UPLOADS_DIRECTORY)
-                .setBodyLimit(getConfig().getMaxPayloadSize());
-        matchAllRoute.handler(bodyHandler);
         return router;
     }
 
@@ -1307,5 +1299,17 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
         } else {
             return MetricsTags.QoS.AT_LEAST_ONCE;
         }
+    }
+
+    /**
+     * Gets body handler and sets the maximum body size.
+     * <p>This method sets body limit size from the configuration.
+     *
+     * @return The body handler.
+     */
+    protected BodyHandler getBodyHandler() {
+        final BodyHandler bodyHandler = BodyHandler.create(DEFAULT_UPLOADS_DIRECTORY);
+        bodyHandler.setBodyLimit(getConfig().getMaxPayloadSize());
+        return bodyHandler;
     }
 }

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapter.java
@@ -151,7 +151,9 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
                     .exposedHeader(Constants.HEADER_COMMAND_REQUEST_ID));
 
             // require auth for POSTing telemetry
-            router.route(HttpMethod.POST, ROUTE_TELEMETRY_ENDPOINT).handler(authHandler);
+            router.route(HttpMethod.POST, ROUTE_TELEMETRY_ENDPOINT)
+                    .handler(authHandler)
+                    .handler(getBodyHandler());
 
             // route for posting telemetry data using tenant and device ID determined as part of
             // device authentication
@@ -166,6 +168,7 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
 
         // route for uploading telemetry data
         router.route(HttpMethod.PUT, String.format("/telemetry/:%s/:%s", PARAM_TENANT, PARAM_DEVICE_ID))
+                .handler(getBodyHandler())
                 .handler(ctx -> uploadTelemetryMessage(HttpContext.from(ctx), getTenantParam(ctx), getDeviceIdParam(ctx)));
     }
 
@@ -192,7 +195,9 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
                     .exposedHeader(Constants.HEADER_COMMAND_REQUEST_ID));
 
             // require auth for POSTing events
-            router.route(HttpMethod.POST, ROUTE_EVENT_ENDPOINT).handler(authHandler);
+            router.route(HttpMethod.POST, ROUTE_EVENT_ENDPOINT)
+                    .handler(authHandler)
+                    .handler(getBodyHandler());
 
             // route for posting events using tenant and device ID determined as part of
             // device authentication
@@ -207,6 +212,7 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
 
         // route for sending event messages
         router.route(HttpMethod.PUT, String.format("/event/:%s/:%s", PARAM_TENANT, PARAM_DEVICE_ID))
+                .handler(getBodyHandler())
                 .handler(ctx -> uploadEventMessage(HttpContext.from(ctx), getTenantParam(ctx), getDeviceIdParam(ctx)));
     }
 
@@ -232,7 +238,9 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
                     .allowedHeader(HttpHeaders.CONTENT_TYPE.toString()));
 
             // require auth for POSTing command response messages
-            router.route(HttpMethod.POST, commandResponseMatchAllPath).handler(authHandler);
+            router.route(HttpMethod.POST, commandResponseMatchAllPath)
+                    .handler(authHandler)
+                    .handler(getBodyHandler());
 
             // route for POSTing command response messages using tenant and device ID determined as part of
             // device authentication
@@ -252,7 +260,8 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
         router.route(
                 HttpMethod.PUT,
                 String.format("/%s/res/:%s/:%s/:%s", commandResponsePrefix, PARAM_TENANT, PARAM_DEVICE_ID, PARAM_COMMAND_REQUEST_ID))
-            .handler(ctx -> uploadCommandResponseMessage(HttpContext.from(ctx), getTenantParam(ctx), getDeviceIdParam(ctx),
+                .handler(getBodyHandler())
+                .handler(ctx -> uploadCommandResponseMessage(HttpContext.from(ctx), getTenantParam(ctx), getDeviceIdParam(ctx),
                     getCommandRequestIdParam(ctx), getCommandResponseStatusParam(ctx)));
     }
 

--- a/adapters/lora-vertx-base/src/main/java/org/eclipse/hono/adapter/lora/LoraProtocolAdapter.java
+++ b/adapters/lora-vertx-base/src/main/java/org/eclipse/hono/adapter/lora/LoraProtocolAdapter.java
@@ -200,6 +200,7 @@ public final class LoraProtocolAdapter extends AbstractVertxBasedHttpProtocolAda
 
                 router.route(provider.acceptedHttpMethod(), pathPrefix)
                         .consumes(provider.acceptedContentType())
+                        .handler(getBodyHandler())
                         .handler(ctx -> this.handleProviderRoute(HttpContext.from(ctx), provider));
 
                 router.route(provider.acceptedHttpMethod(), pathPrefix).handler(ctx -> {

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
@@ -120,11 +120,13 @@ public final class SigfoxProtocolAdapter
         router.route("/data/telemetry/:" + SIGFOX_PARAM_TENANT)
                 .method(HttpMethod.GET)
                 .handler(dataCorsHandler())
+                .handler(getBodyHandler())
                 .handler(ctx -> dataHandler(HttpContext.from(ctx), this::uploadTelemetryMessage));
 
         router.route("/data/event/:" + SIGFOX_PARAM_TENANT)
                 .method(HttpMethod.GET)
                 .handler(dataCorsHandler())
+                .handler(getBodyHandler())
                 .handler(ctx -> dataHandler(HttpContext.from(ctx), this::uploadEventMessage));
 
         router.errorHandler(500, t -> LOG.warn("Unhandled exception", t.failure()));

--- a/service-base/src/main/java/org/eclipse/hono/service/http/AbstractHttpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/AbstractHttpEndpoint.java
@@ -52,6 +52,11 @@ public abstract class AbstractHttpEndpoint<T extends ServiceConfigProperties> ex
         implements HttpEndpoint {
 
     /**
+     * Default file uploads directory used by Vert.x Web.
+     */
+    protected static final String DEFAULT_UPLOADS_DIRECTORY = "/tmp";
+
+    /**
      * The key that is used to put a valid JSON payload to the RoutingContext.
      */
     protected static final String KEY_REQUEST_BODY = "KEY_REQUEST_BODY";

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
@@ -37,7 +37,6 @@ import io.vertx.ext.healthchecks.HealthCheckHandler;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.AuthenticationHandler;
-import io.vertx.ext.web.handler.BodyHandler;
 
 /**
  * A base class for implementing services using HTTP.
@@ -45,11 +44,6 @@ import io.vertx.ext.web.handler.BodyHandler;
  * @param <T> The type of configuration properties used by this service.
  */
 public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends AbstractServiceBase<T> {
-
-    /**
-     * Default file uploads directory used by Vert.x Web.
-     */
-    protected static final String DEFAULT_UPLOADS_DIRECTORY = "/tmp";
 
     private final Map<String, HttpEndpoint> endpoints = new HashMap<>();
 
@@ -191,8 +185,6 @@ public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends
      * <ul>
      * <li>a handler and failure handler that creates tracing data for all server requests,</li>
      * <li>a default failure handler,</li>
-     * <li>a handler limiting the body size of requests to the maximum payload size set in the <em>config</em>
-     * properties.</li>
      * </ul>
      *
      * @return The newly created router (never {@code null}).
@@ -207,11 +199,7 @@ public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends
         matchAllRoute.handler(tracingHandler).failureHandler(tracingHandler);
         // 2. default handler for failed routes
         matchAllRoute.failureHandler(new DefaultFailureHandler());
-        // 3. BodyHandler with request size limit
-        log.info("limiting size of inbound request body to {} bytes", getConfig().getMaxPayloadSize());
-        matchAllRoute.handler(BodyHandler.create().setUploadsDirectory(DEFAULT_UPLOADS_DIRECTORY)
-                .setBodyLimit(getConfig().getMaxPayloadSize()));
-        //4. AuthHandler
+        // 3. AuthHandler
         addAuthHandler(router);
         return router;
     }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/DelegatingCredentialsManagementHttpEndpoint.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/DelegatingCredentialsManagementHttpEndpoint.java
@@ -88,7 +88,7 @@ public class DelegatingCredentialsManagementHttpEndpoint<S extends CredentialsMa
         // Add CORS handler
         router.route(pathWithTenantAndDeviceId).handler(createCorsHandler(config.getCorsAllowedOrigin(), Set.of(HttpMethod.GET, HttpMethod.PUT)));
 
-        final BodyHandler bodyHandler = BodyHandler.create();
+        final BodyHandler bodyHandler = BodyHandler.create(DEFAULT_UPLOADS_DIRECTORY);
         bodyHandler.setBodyLimit(config.getMaxPayloadSize());
 
         // get all credentials for a given device

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DelegatingDeviceManagementHttpEndpoint.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DelegatingDeviceManagementHttpEndpoint.java
@@ -98,7 +98,7 @@ public class DelegatingDeviceManagementHttpEndpoint<S extends DeviceManagementSe
         router.route(pathWithTenant).handler(createCorsHandler(config.getCorsAllowedOrigin(), Set.of(HttpMethod.POST)));
         router.route(pathWithTenantAndDeviceId).handler(createDefaultCorsHandler(config.getCorsAllowedOrigin()));
 
-        final BodyHandler bodyHandler = BodyHandler.create();
+        final BodyHandler bodyHandler = BodyHandler.create(DEFAULT_UPLOADS_DIRECTORY);
         bodyHandler.setBodyLimit(config.getMaxPayloadSize());
 
         // CREATE device with auto-generated deviceID

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/tenant/DelegatingTenantManagementHttpEndpoint.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/tenant/DelegatingTenantManagementHttpEndpoint.java
@@ -95,7 +95,7 @@ public class DelegatingTenantManagementHttpEndpoint<S extends TenantManagementSe
         router.route(path).handler(createCorsHandler(config.getCorsAllowedOrigin(), Set.of(HttpMethod.POST)));
         router.route(pathWithTenant).handler(createDefaultCorsHandler(config.getCorsAllowedOrigin()));
 
-        final BodyHandler bodyHandler = BodyHandler.create();
+        final BodyHandler bodyHandler = BodyHandler.create(DEFAULT_UPLOADS_DIRECTORY);
         bodyHandler.setBodyLimit(config.getMaxPayloadSize());
 
         // ADD tenant with auto-generated ID


### PR DESCRIPTION
Remove the BodyHandler in createRouter because it is already added.
Add a default uploads directory when creating a bodyhandler.
Fix javadoc(createRouter).

Signed-off-by: Ivanova Suzana <Suzana.Ivanova@bosch.io>