### PR TITLE
[#3263] Move Idle Timeout Configuration

### DIFF
--- a/adapters/http-base/src/main/java/org/eclipse/hono/adapter/http/HttpProtocolAdapterOptions.java
+++ b/adapters/http-base/src/main/java/org/eclipse/hono/adapter/http/HttpProtocolAdapterOptions.java
@@ -45,4 +45,17 @@ public interface HttpProtocolAdapterOptions {
      */
     @WithDefault("Hono")
     String realm();
+
+    /**
+     * Gets the idle timeout.
+     * <p>
+     * A connection will timeout and be closed if no data is received or sent within the idle timeout period.
+     * A zero value means no timeout is used.
+     * <p>
+     * The default value is {@code 60}.The idle timeout is in seconds.
+     *
+     * @return The idle timeout.
+     */
+    @WithDefault("60")
+    int idleTimeout();
 }

--- a/adapters/http-base/src/main/java/org/eclipse/hono/adapter/http/HttpProtocolAdapterProperties.java
+++ b/adapters/http-base/src/main/java/org/eclipse/hono/adapter/http/HttpProtocolAdapterProperties.java
@@ -29,6 +29,7 @@ public class HttpProtocolAdapterProperties extends ProtocolAdapterProperties {
      */
     public static final String DEFAULT_REALM = "Hono";
     private String realm = DEFAULT_REALM;
+    private int idleTimeout = 60;
 
     /**
      * Creates properties using default values.
@@ -45,6 +46,7 @@ public class HttpProtocolAdapterProperties extends ProtocolAdapterProperties {
     public HttpProtocolAdapterProperties(final HttpProtocolAdapterOptions options) {
         super(options.adapterOptions());
         this.realm = options.realm();
+        this.idleTimeout = options.idleTimeout();
     }
 
     /**
@@ -76,4 +78,35 @@ public class HttpProtocolAdapterProperties extends ProtocolAdapterProperties {
         this.realm = Objects.requireNonNull(realm);
     }
 
+    /**
+     * Gets the idle timeout.
+     * <p>
+     * A connection will timeout and be closed if no data is received or sent within the idle timeout period.
+     * A zero value means no timeout is used.
+     * <p>
+     * The default value is {@code 60} in seconds.
+     *
+     * @return The idle timeout in seconds.
+     */
+    public final int getIdleTimeout() {
+        return idleTimeout;
+    }
+
+    /**
+     * Sets the idle timeout.
+     * <p>
+     * A connection will timeout and be closed if no data is received or sent within the idle timeout period.
+     * A zero value means no timeout is used.
+     * <p>
+     * The default value is {@code 60}. The idle timeout is in seconds.
+     *
+     * @param idleTimeout The idle timeout.
+     * @throws IllegalArgumentException if idleTimeout is less than {@code 0}.
+     */
+    public final void setIdleTimeout(final int idleTimeout) {
+        if (idleTimeout < 0) {
+            throw new IllegalArgumentException("idleTimeout must be >= 0");
+        }
+        this.idleTimeout = idleTimeout;
+    }
 }

--- a/core/src/main/java/org/eclipse/hono/config/ServerConfig.java
+++ b/core/src/main/java/org/eclipse/hono/config/ServerConfig.java
@@ -29,8 +29,6 @@ public class ServerConfig extends AbstractConfig {
     private String insecurePortBindAddress = Constants.LOOPBACK_DEVICE_ADDRESS;
     private int insecurePort = Constants.PORT_UNCONFIGURED;
     private boolean sni = false;
-    private int idleTimeout = 60;
-
     /**
      * Creates new properties using default values.
      */
@@ -56,7 +54,6 @@ public class ServerConfig extends AbstractConfig {
             setPort(options.port());
         }
         this.sni = options.sni();
-        this.idleTimeout = options.idleTimeout();
     }
 
     /**
@@ -276,37 +273,5 @@ public class ServerConfig extends AbstractConfig {
      */
     public final boolean isSni() {
         return this.sni;
-    }
-
-    /**
-     * Gets the idle timeout.
-     * <p>
-     * A connection will timeout and be closed if no data is received or sent within the idle timeout period.
-     * A zero value means no timeout is used.
-     * <p>
-     * The default value is {@code 60} in seconds.
-     *
-     * @return The idle timeout in seconds.
-     */
-    public int getIdleTimeout() {
-        return idleTimeout;
-    }
-
-    /**
-     * Sets the idle timeout.
-     * <p>
-     * A connection will timeout and be closed if no data is received or sent within the idle timeout period.
-     * A zero value means no timeout is used.
-     * <p>
-     * The default value is {@code 60}. The idle timeout is in seconds.
-     *
-     * @param idleTimeout The idle timeout.
-     * @throws IllegalArgumentException if idleTimeout is less than {@code 0}.
-     */
-    public void setIdleTimeout(final int idleTimeout) {
-        if (idleTimeout < 0) {
-            throw new IllegalArgumentException("idleTimeout must be >= 0");
-        }
-        this.idleTimeout = idleTimeout;
     }
 }

--- a/core/src/main/java/org/eclipse/hono/config/ServerOptions.java
+++ b/core/src/main/java/org/eclipse/hono/config/ServerOptions.java
@@ -108,17 +108,4 @@ public interface ServerOptions {
      */
     @WithDefault("false")
     boolean sni();
-
-    /**
-     * Gets the idle timeout.
-     * <p>
-     * A connection will timeout and be closed if no data is received or sent within the idle timeout period.
-     * A zero value means no timeout is used.
-     * <p>
-     * The default value is {@code 60}.The idle timeout is in seconds.
-     *
-     * @return The idle timeout.
-     */
-    @WithDefault("60")
-    int idleTimeout();
 }

--- a/core/src/test/java/org/eclipse/hono/config/ConfigMappingTest.java
+++ b/core/src/test/java/org/eclipse/hono/config/ConfigMappingTest.java
@@ -52,7 +52,6 @@ class ConfigMappingTest {
         assertThat(props.isNativeTlsRequired()).isTrue();
         assertThat(props.isSecurePortEnabled()).isFalse();
         assertThat(props.isSni()).isFalse();
-        assertThat(props.getIdleTimeout()).isEqualTo(60);
     }
 
     /**

--- a/core/src/test/resources/server-options.yaml
+++ b/core/src/test/resources/server-options.yaml
@@ -8,4 +8,3 @@ hono:
     nativeTlsRequired: true
     port: 11000
     trustStoreFormat: "JKS"
-    idleTimeout: 60

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.AbstractServiceBase;
 import org.eclipse.hono.util.Constants;
 
@@ -40,7 +39,7 @@ import io.vertx.ext.web.handler.AuthenticationHandler;
  *
  * @param <T> The type of configuration properties used by this service.
  */
-public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends AbstractServiceBase<T> {
+public abstract class HttpServiceBase<T extends HttpServiceConfigProperties> extends AbstractServiceBase<T> {
 
     private static final String MATCH_ALL_ROUTE_NAME = "/* (default route)";
 

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceConfigOptions.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceConfigOptions.java
@@ -54,4 +54,17 @@ public interface HttpServiceConfigOptions {
      */
     @WithDefault("Hono")
     String realm();
+
+    /**
+     * Gets the idle timeout.
+     * <p>
+     * A connection will timeout and be closed if no data is received or sent within the idle timeout period.
+     * A zero value means no timeout is used.
+     * <p>
+     * The default value is {@code 60}.The idle timeout is in seconds.
+     *
+     * @return The idle timeout.
+     */
+    @WithDefault("60")
+    int idleTimeout();
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceConfigProperties.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceConfigProperties.java
@@ -29,6 +29,7 @@ public class HttpServiceConfigProperties extends ServiceConfigProperties {
 
     private boolean authenticationRequired = true;
     private String realm = DEFAULT_REALM;
+    private int idleTimeout = 60;
 
     /**
      * Creates default properties.
@@ -47,6 +48,7 @@ public class HttpServiceConfigProperties extends ServiceConfigProperties {
         super(options.commonOptions());
         this.setAuthenticationRequired(options.authenticationRequired());
         this.setRealm(options.realm());
+        this.setIdleTimeout(options.idleTimeout());
     }
 
     /**
@@ -102,5 +104,37 @@ public class HttpServiceConfigProperties extends ServiceConfigProperties {
      */
     public final void setRealm(final String realm) {
         this.realm = Objects.requireNonNull(realm);
+    }
+
+    /**
+     * Gets the idle timeout.
+     * <p>
+     * A connection will timeout and be closed if no data is received or sent within the idle timeout period.
+     * A zero value means no timeout is used.
+     * <p>
+     * The default value is {@code 60} in seconds.
+     *
+     * @return The idle timeout in seconds.
+     */
+    public final int getIdleTimeout() {
+        return idleTimeout;
+    }
+
+    /**
+     * Sets the idle timeout.
+     * <p>
+     * A connection will timeout and be closed if no data is received or sent within the idle timeout period.
+     * A zero value means no timeout is used.
+     * <p>
+     * The default value is {@code 60}. The idle timeout is in seconds.
+     *
+     * @param idleTimeout The idle timeout.
+     * @throws IllegalArgumentException if idleTimeout is less than {@code 0}.
+     */
+    public final void setIdleTimeout(final int idleTimeout) {
+        if (idleTimeout < 0) {
+            throw new IllegalArgumentException("idleTimeout must be >= 0");
+        }
+        this.idleTimeout = idleTimeout;
     }
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/http/HttpServiceConfigOptionsTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/http/HttpServiceConfigOptionsTest.java
@@ -40,5 +40,6 @@ class HttpServiceConfigOptionsTest {
         assertThat(props.isAuthenticationRequired()).isFalse();
         assertThat(props.getRealm()).isEqualTo("test-realm");
         assertThat(props.getMaxPayloadSize()).isEqualTo(4096);
+        assertThat(props.getIdleTimeout()).isEqualTo(60);
     }
 }

--- a/service-base/src/test/resources/http-service-config-options.yaml
+++ b/service-base/src/test/resources/http-service-config-options.yaml
@@ -3,3 +3,4 @@ hono:
     authenticationRequired: false
     maxPayloadSize: 4096
     realm: "test-realm"
+    idleTimeout: 60

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/server/DeviceRegistryHttpServer.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/server/DeviceRegistryHttpServer.java
@@ -13,11 +13,11 @@
 
 package org.eclipse.hono.deviceregistry.server;
 
-import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.http.HttpServiceBase;
+import org.eclipse.hono.service.http.HttpServiceConfigProperties;
 
 /**
  * Default REST server for Hono's example device registry.
  */
-public class DeviceRegistryHttpServer extends HttpServiceBase<ServiceConfigProperties> {
+public class DeviceRegistryHttpServer extends HttpServiceBase<HttpServiceConfigProperties> {
 }


### PR DESCRIPTION
Move the idleTimeout property from ServerConfig to HttpProtocolAdapterProperties and HttpServiceConfigProperties.

Signed-off-by: Ivanova Suzana <Suzana.Ivanova@bosch.io>