### PR TITLE
[#3314] Fix skipping command or error subscription in MQTT adapter

### DIFF
--- a/adapters/mqtt-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractSubscription.java
+++ b/adapters/mqtt-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractSubscription.java
@@ -186,19 +186,27 @@ public abstract class AbstractSubscription implements Subscription {
      */
     static final class DefaultKey implements Key {
 
+        enum Type {
+          COMMAND,
+          ERROR
+        }
+
         private final String tenant;
         private final String deviceId;
+        private final Type type;
 
         /**
          * Creates a new Key.
          *
          * @param tenant The tenant identifier.
          * @param deviceId The device identifier.
+         * @param type The type of the subscription.
          * @throws NullPointerException If any of the parameters is {@code null}.
          */
-        DefaultKey(final String tenant, final String deviceId) {
+        DefaultKey(final String tenant, final String deviceId, final Type type) {
             this.tenant = Objects.requireNonNull(tenant);
             this.deviceId = Objects.requireNonNull(deviceId);
+            this.type = Objects.requireNonNull(type);
         }
 
         @Override
@@ -220,12 +228,12 @@ public abstract class AbstractSubscription implements Subscription {
                 return false;
             }
             final DefaultKey that = (DefaultKey) o;
-            return tenant.equals(that.tenant) && deviceId.equals(that.deviceId);
+            return tenant.equals(that.tenant) && deviceId.equals(that.deviceId) && type == that.type;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(tenant, deviceId);
+            return Objects.hash(tenant, deviceId, type);
         }
     }
 }

--- a/adapters/mqtt-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -1334,7 +1334,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
          */
         protected final void onSubscribe(final MqttSubscribeMessage subscribeMsg) {
             Objects.requireNonNull(subscribeMsg);
-            final Map<Object, Future<Subscription>> uniqueSubscriptions = new HashMap<>();
+            final Map<Subscription.Key, Future<Subscription>> uniqueSubscriptions = new HashMap<>();
             final Deque<Future<Subscription>> subscriptionOutcomes = new ArrayDeque<>(subscribeMsg.topicSubscriptions().size());
 
             final Span span = newSpan("SUBSCRIBE");

--- a/adapters/mqtt-base/src/main/java/org/eclipse/hono/adapter/mqtt/CommandSubscription.java
+++ b/adapters/mqtt-base/src/main/java/org/eclipse/hono/adapter/mqtt/CommandSubscription.java
@@ -65,7 +65,7 @@ public final class CommandSubscription extends AbstractSubscription {
             final MqttQoS qos) {
         super(topicResource, qos, authenticatedDevice);
         this.req = topicResource.elementAt(3);
-        this.key = new DefaultKey(getTenant(), getDeviceId());
+        this.key = new DefaultKey(getTenant(), getDeviceId(), DefaultKey.Type.COMMAND);
     }
 
     /**

--- a/adapters/mqtt-base/src/main/java/org/eclipse/hono/adapter/mqtt/ErrorSubscription.java
+++ b/adapters/mqtt-base/src/main/java/org/eclipse/hono/adapter/mqtt/ErrorSubscription.java
@@ -76,7 +76,7 @@ public final class ErrorSubscription extends AbstractSubscription {
             final Device authenticatedDevice,
             final MqttQoS qos) {
         super(topicResource, qos, authenticatedDevice);
-        key = new DefaultKey(getTenant(), getDeviceId());
+        key = getKey(getTenant(), getDeviceId());
     }
 
     /**
@@ -184,9 +184,7 @@ public final class ErrorSubscription extends AbstractSubscription {
      * @throws NullPointerException If tenantId or deviceId is {@code null}.
      */
     public static Key getKey(final String tenantId, final String deviceId) {
-        Objects.requireNonNull(tenantId);
-        Objects.requireNonNull(deviceId);
-        return new DefaultKey(tenantId, deviceId);
+        return new DefaultKey(tenantId, deviceId, DefaultKey.Type.ERROR);
     }
 
     @Override

--- a/adapters/mqtt-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -1100,10 +1100,27 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());
         when(commandConsumerFactory.createCommandConsumer(eq("tenant-1"), eq("device-A"), any(), any(), any()))
                         .thenReturn(Future.succeededFuture(commandConsumer));
+
+        // command and error subscription for same device, checking:
+        // - a command subscription is OK and shall pass
+        // - an error subscription with unacceptable QoS level MqttQoS.EXACTLY_ONCE - shall fail
+        // - error subscription (later, hence with priority) won't override the command subscription and
+        //   command subscription will pass
         subscriptions.add(
                 newMockTopicSubscription(getCommandSubscriptionTopic("tenant-1", "device-A"), MqttQoS.AT_MOST_ONCE));
         subscriptions.add(
+                newMockTopicSubscription(getErrorSubscriptionTopic("tenant-1", "device-A"), MqttQoS.EXACTLY_ONCE));
+
+        // command and error subscription for same device, checking:
+        // - a command subscription with unacceptable QoS level MqttQoS.EXACTLY_ONCE - shall fail
+        // - an error subscription shall be accepted with its QoS MqttQoS.AT_MOST_ONCE
+        // - error subscription (later, hence with priority) won't override the command subscription and
+        //   command subscription will fail
+        subscriptions.add(
                 newMockTopicSubscription(getCommandSubscriptionTopic("tenant-1", "device-B"), MqttQoS.EXACTLY_ONCE));
+        subscriptions.add(
+                newMockTopicSubscription(getErrorSubscriptionTopic("tenant-1", "device-B"), MqttQoS.AT_MOST_ONCE));
+
         final MqttSubscribeMessage msg = mock(MqttSubscribeMessage.class);
         when(msg.messageId()).thenReturn(15);
         when(msg.topicSubscriptions()).thenReturn(subscriptions);
@@ -1115,11 +1132,14 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
         // which contains a failure status code for each unsupported filter
         final ArgumentCaptor<List<MqttQoS>> codeCaptor = ArgumentCaptor.forClass(List.class);
         verify(endpoint).subscribeAcknowledge(eq(15), codeCaptor.capture());
-        assertThat(codeCaptor.getValue()).hasSize(5);
+        assertThat(codeCaptor.getValue()).hasSize(subscriptions.size());
         assertThat(codeCaptor.getValue().get(0)).isEqualTo(MqttQoS.FAILURE);
         assertThat(codeCaptor.getValue().get(1)).isEqualTo(MqttQoS.FAILURE);
         assertThat(codeCaptor.getValue().get(2)).isEqualTo(MqttQoS.FAILURE);
         assertThat(codeCaptor.getValue().get(3)).isEqualTo(MqttQoS.AT_MOST_ONCE);
+        assertThat(codeCaptor.getValue().get(4)).isEqualTo(MqttQoS.FAILURE);
+        assertThat(codeCaptor.getValue().get(5)).isEqualTo(MqttQoS.FAILURE);
+        assertThat(codeCaptor.getValue().get(6)).isEqualTo(MqttQoS.AT_MOST_ONCE);
         // and sends an empty notification downstream with TTD -1
         assertEmptyNotificationHasBeenSentDownstream("tenant-1", "device-A", -1);
     }
@@ -1468,6 +1488,13 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
 
     private String getCommandEndpoint() {
         return CommandConstants.COMMAND_ENDPOINT;
+    }
+
+    private String getErrorSubscriptionTopic(final String tenantId, final String deviceId) {
+        return String.format("%s/%s/%s/#", getErrorEndpoint(), tenantId, deviceId);
+    }
+    private String getErrorEndpoint() {
+        return ErrorSubscription.ERROR_ENDPOINT;
     }
 
     private MqttEndpoint getMqttEndpointAuthenticated(final String username, final String password) {

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -15,6 +15,7 @@ description = "Information about changes in recent Hono releases. Includes new f
   The timeout is configured with the property `idleTimeout`. This determines if a connection will timeout and be closed
   if no data is received or sent within the idle timeout period. The idle timeout is in seconds.
   A zero value means no timeout is used.
+* The MQTT adapter skipped command or error (the first one) subscription if both are requested for the same device. This has been fixed.
 
 ## 2.0.0
 


### PR DESCRIPTION
when both are requested for same device

Signed-off-by: Marinov Avgustin <Avgustin.Marinov@bosch.io>