### PR TITLE
[#3314] Fix skipping command or error subscription in MQTT adapter

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractSubscription.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractSubscription.java
@@ -182,19 +182,27 @@ public abstract class AbstractSubscription implements Subscription {
      */
     static final class DefaultKey implements Key {
 
+        enum Type {
+          COMMAND,
+          ERROR
+        }
+
         private final String tenant;
         private final String deviceId;
+        private final Type type;
 
         /**
          * Creates a new Key.
          *
          * @param tenant The tenant identifier.
          * @param deviceId The device identifier.
+         * @param type The type of the subscription.
          * @throws NullPointerException If any of the parameters is {@code null}.
          */
-        DefaultKey(final String tenant, final String deviceId) {
+        DefaultKey(final String tenant, final String deviceId, final Type type) {
             this.tenant = Objects.requireNonNull(tenant);
             this.deviceId = Objects.requireNonNull(deviceId);
+            this.type = Objects.requireNonNull(type);
         }
 
         @Override
@@ -216,12 +224,12 @@ public abstract class AbstractSubscription implements Subscription {
                 return false;
             }
             final DefaultKey that = (DefaultKey) o;
-            return tenant.equals(that.tenant) && deviceId.equals(that.deviceId);
+            return tenant.equals(that.tenant) && deviceId.equals(that.deviceId) && type == that.type;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(tenant, deviceId);
+            return Objects.hash(tenant, deviceId, type);
         }
     }
 }

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -1249,7 +1249,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
          */
         protected final void onSubscribe(final MqttSubscribeMessage subscribeMsg) {
             Objects.requireNonNull(subscribeMsg);
-            final Map<Object, Future<Subscription>> uniqueSubscriptions = new HashMap<>();
+            final Map<Subscription.Key, Future<Subscription>> uniqueSubscriptions = new HashMap<>();
             final Deque<Future<Subscription>> subscriptionOutcomes = new ArrayDeque<>(subscribeMsg.topicSubscriptions().size());
 
             final Span span = newSpan("SUBSCRIBE");

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/CommandSubscription.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/CommandSubscription.java
@@ -50,7 +50,7 @@ public final class CommandSubscription extends AbstractSubscription {
             final MqttQoS qos) {
         super(topicResource, qos, authenticatedDevice);
         this.req = topicResource.elementAt(3);
-        this.key = new DefaultKey(getTenant(), getDeviceId());
+        this.key = new DefaultKey(getTenant(), getDeviceId(), DefaultKey.Type.COMMAND);
     }
 
     /**

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/ErrorSubscription.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/ErrorSubscription.java
@@ -76,7 +76,7 @@ public final class ErrorSubscription extends AbstractSubscription {
             final Device authenticatedDevice,
             final MqttQoS qos) {
         super(topicResource, qos, authenticatedDevice);
-        key = new DefaultKey(getTenant(), getDeviceId());
+        key = getKey(getTenant(), getDeviceId());
     }
 
     /**
@@ -184,9 +184,7 @@ public final class ErrorSubscription extends AbstractSubscription {
      * @throws NullPointerException If tenantId or deviceId is {@code null}.
      */
     public static Key getKey(final String tenantId, final String deviceId) {
-        Objects.requireNonNull(tenantId);
-        Objects.requireNonNull(deviceId);
-        return new DefaultKey(tenantId, deviceId);
+        return new DefaultKey(tenantId, deviceId, DefaultKey.Type.ERROR);
     }
 
     @Override

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -18,7 +18,8 @@ description = "Information about changes in recent Hono releases. Includes new f
   The timeout is configured with the property `idleTimeout`. This determines if a connection will timeout and be closed
   if no data is received or sent within the idle timeout period. The idle timeout is in seconds.
   A zero value means no timeout is used.
-  
+* The MQTT adapter skipped command or error (the first one) subscription if both are requested for the same device. This has been fixed.
+
 ## 1.12.2
 
 ### Fixes & Enhancements


### PR DESCRIPTION
when both are requested for same device

Signed-off-by: Marinov Avgustin <Avgustin.Marinov@bosch.io>