### PR TITLE
Use Kafka based messaging for running ITs by default

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -53,7 +53,7 @@
       See https://github.com/quarkusio/quarkus/issues/22000
     -->
     <kafka-client.version>2.8.1</kafka-client.version>
-    <kafka.image.name>confluentinc/cp-kafka:6.2.4</kafka.image.name>
+    <kafka.image.name>confluentinc/cp-kafka:7.2.0</kafka.image.name>
     <logback.version>1.2.9</logback.version>
     <mongodb-image.name>mongo:4.4</mongodb-image.name>
     <native.image.name>quay.io/quarkus/quarkus-micro-image:1.0</native.image.name>
@@ -73,7 +73,7 @@
     <spring-security-crypto.version>5.7.0</spring-security-crypto.version>
     <truth.version>1.1.3</truth.version>
     <vertx.version>4.2.7</vertx.version>
-    <zookeeper.image.name>confluentinc/cp-zookeeper:6.2.4</zookeeper.image.name>
+    <zookeeper.image.name>confluentinc/cp-zookeeper:7.2.0</zookeeper.image.name>
 
     <!-- The port at which the health check server should expose its resources -->
     <health.check.port>8088</health.check.port>

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -39,6 +39,20 @@
      <optional>true</optional>
     </dependency>
     <dependency>
+     <groupId>org.eclipse.hono</groupId>
+     <artifactId>hono-client-notification</artifactId>
+    </dependency>
+    <dependency>
+     <groupId>org.eclipse.hono</groupId>
+     <artifactId>hono-client-notification-amqp</artifactId>
+     <optional>true</optional>
+    </dependency>
+    <dependency>
+     <groupId>org.eclipse.hono</groupId>
+     <artifactId>hono-client-notification-kafka</artifactId>
+     <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-core</artifactId>
     </dependency>

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceApplication.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceApplication.java
@@ -23,11 +23,22 @@ import java.util.stream.Collectors;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
+import org.eclipse.hono.client.amqp.config.ClientConfigProperties;
+import org.eclipse.hono.client.amqp.connection.HonoConnection;
+import org.eclipse.hono.client.notification.amqp.ProtonBasedNotificationReceiver;
+import org.eclipse.hono.client.notification.kafka.KafkaBasedNotificationReceiver;
+import org.eclipse.hono.client.notification.kafka.NotificationKafkaConsumerConfigProperties;
+import org.eclipse.hono.client.util.ServiceClient;
+import org.eclipse.hono.notification.NotificationConstants;
+import org.eclipse.hono.notification.NotificationEventBusSupport;
+import org.eclipse.hono.notification.NotificationReceiver;
+import org.eclipse.hono.service.util.ServiceClientAdapter;
 import org.eclipse.microprofile.health.Readiness;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.opentracing.Tracer;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 import io.vertx.core.Vertx;
@@ -48,6 +59,12 @@ public abstract class AbstractServiceApplication implements ComponentNameProvide
      */
     @Inject
     protected Vertx vertx;
+
+    /**
+     * The tracer to use for tracking the processing of requests.
+     */
+    @Inject
+    protected Tracer tracer;
 
     /**
      * The meter registry managed by Quarkus.
@@ -166,6 +183,12 @@ public abstract class AbstractServiceApplication implements ComponentNameProvide
 
         logJvmDetails();
         registerVertxCloseHook();
+        if (appConfig.isKafkaMessagingDisabled()) {
+            LOG.info("Kafka based messaging has been disabled explicitly");
+        }
+        if (appConfig.isAmqpMessagingDisabled()) {
+            LOG.info("AMQP 1.0 based messaging has been disabled explicitly");
+        }
         doStart();
     }
 
@@ -196,4 +219,38 @@ public abstract class AbstractServiceApplication implements ComponentNameProvide
         });
         shutdown.join();
     }
+
+    /**
+     * Creates a notification receiver for configuration properties.
+     *
+     * @param kafkaNotificationConfig The Kafka connection properties.
+     * @param amqpNotificationConfig The AMQP 1.0 connection properties.
+     * @return the receiver.
+     * @throws IllegalStateException if both AMQP and Kafka based messaging have been disabled explicitly.
+     */
+    protected NotificationReceiver notificationReceiver(
+            final NotificationKafkaConsumerConfigProperties kafkaNotificationConfig,
+            final ClientConfigProperties amqpNotificationConfig) {
+
+        final NotificationReceiver notificationReceiver;
+        if (!appConfig.isKafkaMessagingDisabled() && kafkaNotificationConfig.isConfigured()) {
+            notificationReceiver = new KafkaBasedNotificationReceiver(vertx, kafkaNotificationConfig);
+        } else if (!appConfig.isAmqpMessagingDisabled() && amqpNotificationConfig.isHostConfigured()) {
+            final var notificationConfig = new ClientConfigProperties(amqpNotificationConfig);
+            notificationConfig.setServerRole("Notification");
+            notificationReceiver = new ProtonBasedNotificationReceiver(
+                    HonoConnection.newConnection(vertx, notificationConfig, tracer));
+        } else {
+            throw new IllegalStateException("at least one of Kafka or AMQP messaging must be configured");
+        }
+        if (notificationReceiver instanceof ServiceClient serviceClient) {
+            healthCheckServer.registerHealthCheckResources(ServiceClientAdapter.forClient(serviceClient));
+        }
+        final var notificationSender = NotificationEventBusSupport.getNotificationSender(vertx);
+        NotificationConstants.DEVICE_REGISTRY_NOTIFICATION_TYPES.forEach(notificationType -> {
+            notificationReceiver.registerConsumer(notificationType, notificationSender::handle);
+        });
+        return notificationReceiver;
+    }
+
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/ApplicationConfigProperties.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/ApplicationConfigProperties.java
@@ -20,6 +20,8 @@ package org.eclipse.hono.service;
 public class ApplicationConfigProperties {
 
     private int maxInstances = 0;
+    private boolean amqpMessagingDisabled = false;
+    private boolean kafkaMessagingDisabled = false;
 
     /**
      * Creates new properties using default values.
@@ -36,6 +38,8 @@ public class ApplicationConfigProperties {
     public ApplicationConfigProperties(final ApplicationOptions options) {
         super();
         setMaxInstances(options.maxInstances());
+        this.amqpMessagingDisabled = options.amqpMessagingDisabled();
+        this.kafkaMessagingDisabled = options.kafkaMessagingDisabled();
     }
 
     /**
@@ -70,5 +74,41 @@ public class ApplicationConfigProperties {
             throw new IllegalArgumentException("maxInstances must be >= 0");
         }
         this.maxInstances = maxVerticleInstances;
+    }
+
+    /**
+     * Checks if AMQP 1.0 based messaging has been disabled explicitly.
+     *
+     * @return {@code true} if disabled explicitly.
+     */
+    public final boolean isAmqpMessagingDisabled() {
+        return amqpMessagingDisabled;
+    }
+
+    /**
+     * Disables general support for AMQP 1.0 based messaging.
+     *
+     * @param disabled {@code true} to disable explicitly.
+     */
+    public final void setAmqpMessagingDisabled(final boolean disabled) {
+        this.amqpMessagingDisabled = disabled;
+    }
+
+    /**
+     * Checks if Kafka based messaging has been disabled explicitly.
+     *
+     * @return {@code true} if disabled explicitly.
+     */
+    public final boolean isKafkaMessagingDisabled() {
+        return kafkaMessagingDisabled;
+    }
+
+    /**
+     * Disables general support for Kafka based messaging.
+     *
+     * @param disabled {@code true} to disable explicitly.
+     */
+    public final void setKafkaMessagingDisabled(final boolean disabled) {
+        this.kafkaMessagingDisabled = disabled;
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/ApplicationOptions.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/ApplicationOptions.java
@@ -32,4 +32,20 @@ public interface ApplicationOptions {
      */
     @WithDefault("0")
     int maxInstances();
+
+    /**
+     * Checks if AMQP 1.0 based messaging has been disabled explicitly.
+     *
+     * @return {@code true} if disabled explicitly.
+     */
+    @WithDefault("false")
+    boolean amqpMessagingDisabled();
+
+    /**
+     * Checks if Kafka based messaging has been disabled explicitly.
+     *
+     * @return {@code true} if disabled explicitly.
+     */
+    @WithDefault("false")
+    boolean kafkaMessagingDisabled();
 }

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -97,12 +97,13 @@
     <hono.infinispan.password>hono-secret</hono.infinispan.password>
 
     <!--
-      Messaging related properties - AMQP is used as the default one.
+      Messaging related properties - Kafka is used as the default one.
     -->
-    <hono.messaging-infra.type>amqp</hono.messaging-infra.type>
-    <hono.kafka.disabled>true</hono.kafka.disabled>
+    <hono.messaging-infra.type>kafka</hono.messaging-infra.type>
+    <hono.amqp-messaging.disabled>false</hono.amqp-messaging.disabled>
+    <hono.kafka-messaging.disabled>true</hono.kafka-messaging.disabled>
     <hono.kafka.log-level>WARN</hono.kafka.log-level>
-    <hono.kafka.bootstrap.servers></hono.kafka.bootstrap.servers>
+    <hono.kafka.bootstrap.servers>kafka:9092</hono.kafka.bootstrap.servers>
 
     <!--
       Device Registry related properties - The MongoDB based device registry is used as the default one.
@@ -421,8 +422,8 @@
         </property>
       </activation>
       <properties>
-        <hono.kafka.disabled>false</hono.kafka.disabled>
-        <hono.kafka.bootstrap.servers>kafka:9092</hono.kafka.bootstrap.servers>
+        <hono.amqp-messaging.disabled>true</hono.amqp-messaging.disabled>
+        <hono.kafka-messaging.disabled>false</hono.kafka-messaging.disabled>
         <request.timeout>4000</request.timeout>
         <!--The max memory command router is increased to 500 MB-->
         <hono.command-router.max-mem>524288000</hono.command-router.max-mem>
@@ -900,6 +901,7 @@
                 <image>
                   <name>${docker.repository}/hono-artemis-test:${project.version}</name>
                   <build>
+                    <skip>${hono.amqp-messaging.disabled}</skip>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
                     <from>${artemis.image.name}</from>
                     <ports>
@@ -934,6 +936,7 @@
                     </assembly>
                   </build>
                   <run>
+                    <skip>${hono.amqp-messaging.disabled}</skip>
                     <ports>
                       <port>+broker.ip:broker.amqp.port:5671</port>
                     </ports>
@@ -964,6 +967,7 @@
                 <image>
                   <name>${docker.repository}/hono-dispatch-router-test:${project.version}</name>
                   <build>
+                    <skip>${hono.amqp-messaging.disabled}</skip>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
                     <from>${dispatch-router.image.name}</from>
                     <ports>
@@ -1004,6 +1008,7 @@
                     </assembly>
                   </build>
                   <run>
+                    <skip>${hono.amqp-messaging.disabled}</skip>
                     <ports>
                       <port>+qpid.ip:qpid.amqps.port:5671</port>
                       <port>+qpid.ip:qpid.amqp.port:5672</port>
@@ -1034,7 +1039,7 @@
                   <name>${zookeeper.image.name}</name>
                   <alias>hono-zookeeper-test</alias>
                   <run>
-                    <skip>${hono.kafka.disabled}</skip>
+                    <skip>${hono.kafka-messaging.disabled}</skip>
                     <network>
                       <mode>custom</mode>
                       <name>${custom.network.name}</name>
@@ -1059,7 +1064,7 @@
                   <name>${kafka.image.name}</name>
                   <alias>hono-kafka-test</alias>
                   <run>
-                    <skip>${hono.kafka.disabled}</skip>
+                    <skip>${hono.kafka-messaging.disabled}</skip>
                     <ports>
                       <port>kafka.port:9094</port>
                     </ports>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1061,7 +1061,7 @@
                   <run>
                     <skip>${hono.kafka.disabled}</skip>
                     <ports>
-                      <port>${kafka.port}:${kafka.port}</port>
+                      <port>kafka.port:9094</port>
                     </ports>
                     <network>
                       <mode>custom</mode>
@@ -1079,9 +1079,10 @@
                     <env>
                       <KAFKA_BROKER_ID>1</KAFKA_BROKER_ID>
                       <KAFKA_ZOOKEEPER_CONNECT>zookeeper:2181</KAFKA_ZOOKEEPER_CONNECT>
-                      <!-- setting the default listener, "PLAINTEXT", as this is the default value of KAFKA_INTER_BROKER_LISTENER_NAME -->
-                      <KAFKA_LISTENER_SECURITY_PROTOCOL_MAP>PLAINTEXT:PLAINTEXT,LISTENER_EXTERNAL:PLAINTEXT</KAFKA_LISTENER_SECURITY_PROTOCOL_MAP>
-                      <KAFKA_ADVERTISED_LISTENERS>PLAINTEXT://kafka:9092,LISTENER_EXTERNAL://${docker.host.address}:${kafka.port}</KAFKA_ADVERTISED_LISTENERS>
+                      <KAFKA_LISTENERS>DOCKER_INTERNAL://0.0.0.0:9092,DOCKER_EXTERNAL://0.0.0.0:9094</KAFKA_LISTENERS>
+                      <KAFKA_LISTENER_SECURITY_PROTOCOL_MAP>DOCKER_INTERNAL:PLAINTEXT,DOCKER_EXTERNAL:PLAINTEXT</KAFKA_LISTENER_SECURITY_PROTOCOL_MAP>
+                      <KAFKA_ADVERTISED_LISTENERS>DOCKER_INTERNAL://kafka:9092,DOCKER_EXTERNAL://${docker.host.address}:${kafka.port}</KAFKA_ADVERTISED_LISTENERS>
+                      <KAFKA_INTER_BROKER_LISTENER_NAME>DOCKER_INTERNAL</KAFKA_INTER_BROKER_LISTENER_NAME>
                       <KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR>1</KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR>
                       <KAFKA_TRANSACTION_STATE_LOG_MIN_ISR>1</KAFKA_TRANSACTION_STATE_LOG_MIN_ISR>
                       <KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR>1</KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR>

--- a/tests/src/test/java/org/eclipse/hono/tests/client/AmqpApplicationClientIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/client/AmqpApplicationClientIT.java
@@ -23,7 +23,9 @@ import org.eclipse.hono.application.client.amqp.ProtonBasedApplicationClient;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.amqp.config.ClientConfigProperties;
 import org.eclipse.hono.client.amqp.connection.HonoConnection;
+import org.eclipse.hono.tests.AssumeMessagingSystem;
 import org.eclipse.hono.tests.IntegrationTestSupport;
+import org.eclipse.hono.util.MessagingType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,7 +39,8 @@ import io.vertx.junit5.VertxTestContext;
  * Test cases verifying the behavior of {@link ProtonBasedApplicationClient}.
  */
 @ExtendWith(VertxExtension.class)
-public class ApplicationClientIT {
+@AssumeMessagingSystem(type = MessagingType.amqp)
+public class AmqpApplicationClientIT {
 
     private static Vertx vertx;
 

--- a/tests/src/test/resources/amqp/application.yml
+++ b/tests/src/test/resources/amqp/application.yml
@@ -1,6 +1,8 @@
 hono:
   app:
     maxInstances: 1
+    amqpMessagingDisabled: ${hono.amqp-messaging.disabled}
+    kafkaMessagingDisabled: ${hono.kafka-messaging.disabled}
   connectionEvents:
     producer: "logging"
     logLevel: "debug"

--- a/tests/src/test/resources/coap/application.yml
+++ b/tests/src/test/resources/coap/application.yml
@@ -1,6 +1,8 @@
 hono:
   app:
     maxInstances: 1
+    amqpMessagingDisabled: ${hono.amqp-messaging.disabled}
+    kafkaMessagingDisabled: ${hono.kafka-messaging.disabled}
   connectionEvents:
     producer: "none"
   coap:

--- a/tests/src/test/resources/commandrouter/clustered-cache/application.yml
+++ b/tests/src/test/resources/commandrouter/clustered-cache/application.yml
@@ -1,6 +1,8 @@
 hono:
   app:
     maxInstances: 1
+    amqpMessagingDisabled: ${hono.amqp-messaging.disabled}
+    kafkaMessagingDisabled: ${hono.kafka-messaging.disabled}
   auth:
     host: "${hono.auth.host}"
     port: 5671

--- a/tests/src/test/resources/commandrouter/embedded-cache/application.yml
+++ b/tests/src/test/resources/commandrouter/embedded-cache/application.yml
@@ -1,6 +1,9 @@
 hono:
   app:
     maxInstances: 1
+    amqpMessagingDisabled: ${hono.amqp-messaging.disabled}
+    kafkaMessagingDisabled: ${hono.kafka-messaging.disabled}
+
   auth:
     host: "${hono.auth.host}"
     port: 5671

--- a/tests/src/test/resources/deviceregistry-jdbc-h2/application.yml
+++ b/tests/src/test/resources/deviceregistry-jdbc-h2/application.yml
@@ -1,8 +1,8 @@
 hono:
-
   app:
     maxInstances: 1
-
+    amqpMessagingDisabled: ${hono.amqp-messaging.disabled}
+    kafkaMessagingDisabled: ${hono.kafka-messaging.disabled}
   messaging:
     name: "Hono Device Registry JDBC"
     host: "${hono.amqp-network.host}"

--- a/tests/src/test/resources/deviceregistry-jdbc-postgres/application.yml
+++ b/tests/src/test/resources/deviceregistry-jdbc-postgres/application.yml
@@ -2,6 +2,8 @@ hono:
 
   app:
     maxInstances: 1
+    amqpMessagingDisabled: ${hono.amqp-messaging.disabled}
+    kafkaMessagingDisabled: ${hono.kafka-messaging.disabled}
 
   messaging:
     name: "Hono Device Registry JDBC"

--- a/tests/src/test/resources/deviceregistry-mongodb/application.yml
+++ b/tests/src/test/resources/deviceregistry-mongodb/application.yml
@@ -1,6 +1,8 @@
 hono:
   app:
     maxInstances: 1
+    amqpMessagingDisabled: ${hono.amqp-messaging.disabled}
+    kafkaMessagingDisabled: ${hono.kafka-messaging.disabled}
   messaging:
     name: "Hono Device Registry MongoDb"
     host: "${hono.amqp-network.host}"

--- a/tests/src/test/resources/http/application.yml
+++ b/tests/src/test/resources/http/application.yml
@@ -1,6 +1,8 @@
 hono:
   app:
     maxInstances: 1
+    amqpMessagingDisabled: ${hono.amqp-messaging.disabled}
+    kafkaMessagingDisabled: ${hono.kafka-messaging.disabled}
   connectionEvents:
     producer: "none"
   http:

--- a/tests/src/test/resources/mqtt/application.yml
+++ b/tests/src/test/resources/mqtt/application.yml
@@ -1,6 +1,8 @@
 hono:
   app:
     maxInstances: 1
+    amqpMessagingDisabled: ${hono.amqp-messaging.disabled}
+    kafkaMessagingDisabled: ${hono.kafka-messaging.disabled}
   connectionEvents:
     producer: "logging"
     logLevel: "debug"


### PR DESCRIPTION
Added config properties for explicitly disabling AMQP 1.0 or Kafka based
messaging. This can be used to prevent Kafka/AMQP components from
starting up despite the connection properties having been set.

Fixes #3328