### PR TITLE
Remove obsolete jakarta.ws.rs-api dependency

### DIFF
--- a/adapters/parent/pom.xml
+++ b/adapters/parent/pom.xml
@@ -62,11 +62,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <!-- JAX-RS API used by quarkus-opentelemetry; preferring Jakarta impl here over 'jboss-jaxrs-api_2.1_spec' used in quarkus -->
-      <groupId>jakarta.ws.rs</groupId>
-      <artifactId>jakarta.ws.rs-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -38,7 +38,6 @@
     <guava.version>30.1-jre</guava.version>
     <infinispan-image.name>quay.io/infinispan/server-native:13.0</infinispan-image.name>
     <jaeger.image.name>jaegertracing/all-in-one:1.33</jaeger.image.name>
-    <jakarta.jaxrs-api.version>2.1.6</jakarta.jaxrs-api.version>
     <!--
       We want to allow users to run containers in a rootless Docker environment.
       For that purpose, the JVM needs to support cgroups v2 based resource limits
@@ -563,11 +562,6 @@ quarkus.vertx.resolver.cache-max-time-to-live=0
         <groupId>com.bol</groupId>
         <artifactId>cryptvault</artifactId>
         <version>${cryptvault.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>jakarta.ws.rs</groupId>
-        <artifactId>jakarta.ws.rs-api</artifactId>
-        <version>${jakarta.jaxrs-api.version}</version>
       </dependency>
 
       <!-- Testing -->

--- a/legal/src/main/resources/legal/DEPENDENCIES
+++ b/legal/src/main/resources/legal/DEPENDENCIES
@@ -193,7 +193,6 @@ maven/mavencentral/jakarta.enterprise/jakarta.enterprise.cdi-api/2.0.2, , approv
 maven/mavencentral/jakarta.inject/jakarta.inject-api/1.0, , approved, eclipse
 maven/mavencentral/jakarta.interceptor/jakarta.interceptor-api/1.2.5, , approved, eclipse
 maven/mavencentral/jakarta.transaction/jakarta.transaction-api/1.3.3, , approved, eclipse
-maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.rest
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/2.3.3, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/net.java.dev.jna/jna/5.8.0, Apache-2.0 OR LGPL-2.1-or-later, approved, CQ23217
 maven/mavencentral/org.apache.commons/commons-collections4/4.2, Apache-2.0, approved, clearlydefined

--- a/legal/src/main/resources/legal/hono-maven.deps
+++ b/legal/src/main/resources/legal/hono-maven.deps
@@ -193,7 +193,6 @@ jakarta.enterprise:jakarta.enterprise.cdi-api:jar:2.0.2
 jakarta.inject:jakarta.inject-api:jar:1.0
 jakarta.interceptor:jakarta.interceptor-api:jar:1.2.5
 jakarta.transaction:jakarta.transaction-api:jar:1.3.3
-jakarta.ws.rs:jakarta.ws.rs-api:jar:2.1.6
 jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3
 net.java.dev.jna:jna:jar:5.8.0
 org.apache.commons:commons-collections4:jar:4.2

--- a/services/parent/pom.xml
+++ b/services/parent/pom.xml
@@ -66,11 +66,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <!-- JAX-RS API used by quarkus-opentelemetry; preferring Jakarta impl here over 'jboss-jaxrs-api_2.1_spec' used in quarkus -->
-      <groupId>jakarta.ws.rs</groupId>
-      <artifactId>jakarta.ws.rs-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>


### PR DESCRIPTION
Not needed any more after Quarkus 2.10.2 update (#3327).