### PR TITLE
Add support for disabling protocol adapters selectively in ITs

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -635,6 +635,16 @@
       </properties>
     </profile>
     <profile>
+      <id>no-adapters</id>
+      <properties>
+        <hono.amqp-adapter.disabled>true</hono.amqp-adapter.disabled>
+        <hono.coap-adapter.disabled>true</hono.coap-adapter.disabled>
+        <hono.http-adapter.disabled>true</hono.http-adapter.disabled>
+        <hono.lora-adapter.disabled>true</hono.lora-adapter.disabled>
+        <hono.mqtt-adapter.disabled>true</hono.mqtt-adapter.disabled>
+      </properties>
+    </profile>
+    <profile>
       <id>run-tests</id>
       <build>
         <plugins>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -150,12 +150,14 @@
     <hono.amqp-adapter.max-mem>314572800</hono.amqp-adapter.max-mem>
     <hono.amqp-adapter.java-options>${default.java-options}</hono.amqp-adapter.java-options>
     <hono.amqp-adapter.native-image-args></hono.amqp-adapter.native-image-args>
+    <hono.amqp-adapter.disabled>false</hono.amqp-adapter.disabled>
 
     <hono.coap-adapter.host>hono-adapter-coap</hono.coap-adapter.host>
     <hono.coap-adapter.image>hono-adapter-coap</hono.coap-adapter.image>
     <hono.coap-adapter.max-mem>314572800</hono.coap-adapter.max-mem>
     <hono.coap-adapter.java-options>${default.java-options}</hono.coap-adapter.java-options>
     <hono.coap-adapter.native-image-args></hono.coap-adapter.native-image-args>
+    <hono.coap-adapter.disabled>false</hono.coap-adapter.disabled>
 
     <hono.http-adapter.host>hono-adapter-http</hono.http-adapter.host>
     <hono.http-adapter.image>hono-adapter-http</hono.http-adapter.image>
@@ -163,6 +165,7 @@
     <hono.http-adapter.nativeTlsRequired>true</hono.http-adapter.nativeTlsRequired>
     <hono.http-adapter.java-options>${default.java-options}</hono.http-adapter.java-options>
     <hono.http-adapter.native-image-args></hono.http-adapter.native-image-args>
+    <hono.http-adapter.disabled>false</hono.http-adapter.disabled>
 
     <hono.lora-adapter.host>hono-adapter-lora</hono.lora-adapter.host>
     <hono.lora-adapter.image>hono-adapter-lora</hono.lora-adapter.image>
@@ -170,12 +173,14 @@
     <hono.lora-adapter.nativeTlsRequired>false</hono.lora-adapter.nativeTlsRequired>
     <hono.lora-adapter.java-options>${default.java-options}</hono.lora-adapter.java-options>
     <hono.lora-adapter.native-image-args></hono.lora-adapter.native-image-args>
+    <hono.lora-adapter.disabled>false</hono.lora-adapter.disabled>
 
     <hono.mqtt-adapter.host>hono-adapter-mqtt</hono.mqtt-adapter.host>
     <hono.mqtt-adapter.image>hono-adapter-mqtt</hono.mqtt-adapter.image>
     <hono.mqtt-adapter.max-mem>314572800</hono.mqtt-adapter.max-mem>
     <hono.mqtt-adapter.java-options>${default.java-options}</hono.mqtt-adapter.java-options>
     <hono.mqtt-adapter.native-image-args></hono.mqtt-adapter.native-image-args>
+    <hono.mqtt-adapter.disabled>false</hono.mqtt-adapter.disabled>
 
     <hono.auth-server.image>hono-service-auth</hono.auth-server.image>
     <hono.auth-server.max-mem>205520896</hono.auth-server.max-mem>
@@ -577,6 +582,56 @@
         <hono.command-router.max-mem>67108864</hono.command-router.max-mem>
         <hono.deviceregistry.mongodb.image>hono-service-device-registry-mongodb-native</hono.deviceregistry.mongodb.image>
         <hono.deviceregistry.mongodb.max-mem>150000000</hono.deviceregistry.mongodb.max-mem>
+      </properties>
+    </profile>
+    <profile>
+      <id>amqp-only</id>
+      <properties>
+        <hono.amqp-adapter.disabled>false</hono.amqp-adapter.disabled>
+        <hono.coap-adapter.disabled>true</hono.coap-adapter.disabled>
+        <hono.http-adapter.disabled>true</hono.http-adapter.disabled>
+        <hono.lora-adapter.disabled>true</hono.lora-adapter.disabled>
+        <hono.mqtt-adapter.disabled>true</hono.mqtt-adapter.disabled>
+      </properties>
+    </profile>
+    <profile>
+      <id>coap-only</id>
+      <properties>
+        <hono.amqp-adapter.disabled>true</hono.amqp-adapter.disabled>
+        <hono.coap-adapter.disabled>false</hono.coap-adapter.disabled>
+        <hono.http-adapter.disabled>true</hono.http-adapter.disabled>
+        <hono.lora-adapter.disabled>true</hono.lora-adapter.disabled>
+        <hono.mqtt-adapter.disabled>true</hono.mqtt-adapter.disabled>
+      </properties>
+    </profile>
+    <profile>
+      <id>http-only</id>
+      <properties>
+        <hono.amqp-adapter.disabled>true</hono.amqp-adapter.disabled>
+        <hono.coap-adapter.disabled>true</hono.coap-adapter.disabled>
+        <hono.http-adapter.disabled>false</hono.http-adapter.disabled>
+        <hono.lora-adapter.disabled>true</hono.lora-adapter.disabled>
+        <hono.mqtt-adapter.disabled>true</hono.mqtt-adapter.disabled>
+      </properties>
+    </profile>
+    <profile>
+      <id>lora-only</id>
+      <properties>
+        <hono.amqp-adapter.disabled>true</hono.amqp-adapter.disabled>
+        <hono.coap-adapter.disabled>true</hono.coap-adapter.disabled>
+        <hono.http-adapter.disabled>true</hono.http-adapter.disabled>
+        <hono.lora-adapter.disabled>false</hono.lora-adapter.disabled>
+        <hono.mqtt-adapter.disabled>true</hono.mqtt-adapter.disabled>
+      </properties>
+    </profile>
+    <profile>
+      <id>mqtt-only</id>
+      <properties>
+        <hono.amqp-adapter.disabled>true</hono.amqp-adapter.disabled>
+        <hono.coap-adapter.disabled>true</hono.coap-adapter.disabled>
+        <hono.http-adapter.disabled>true</hono.http-adapter.disabled>
+        <hono.lora-adapter.disabled>true</hono.lora-adapter.disabled>
+        <hono.mqtt-adapter.disabled>false</hono.mqtt-adapter.disabled>
       </properties>
     </profile>
     <profile>
@@ -1417,6 +1472,7 @@
                 <image>
                   <name>${docker.repository}/hono-adapter-http-test:${project.version}</name>
                   <build>
+                    <skip>${hono.http-adapter.disabled}</skip>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
                     <from>${docker.repository}/${hono.http-adapter.image}:${project.version}</from>
                     <assembly>
@@ -1455,6 +1511,7 @@
                     </assembly>
                   </build>
                   <run>
+                    <skip>${hono.http-adapter.disabled}</skip>
                     <ports>
                       <port>+http.ip:http.port:8080</port>
                       <port>https.port:8443</port>
@@ -1498,6 +1555,7 @@
                 <image>
                   <name>${docker.repository}/hono-adapter-mqtt-test:${project.version}</name>
                   <build>
+                    <skip>${hono.mqtt-adapter.disabled}</skip>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
                     <from>${docker.repository}/${hono.mqtt-adapter.image}:${project.version}</from>
                     <assembly>
@@ -1526,6 +1584,7 @@
                     </assembly>
                   </build>
                   <run>
+                    <skip>${hono.mqtt-adapter.disabled}</skip>
                     <ports>
                       <port>+mqtt.ip:mqtt.port:1883</port>
                       <port>mqtts.port:8883</port>
@@ -1569,6 +1628,7 @@
                 <image>
                   <name>${docker.repository}/hono-adapter-amqp-test:${project.version}</name>
                   <build>
+                    <skip>${hono.amqp-adapter.disabled}</skip>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
                     <from>${docker.repository}/${hono.amqp-adapter.image}:${project.version}</from>
                     <assembly>
@@ -1597,6 +1657,7 @@
                     </assembly>
                   </build>
                   <run>
+                    <skip>${hono.amqp-adapter.disabled}</skip>
                     <ports>
                       <port>5005</port>
                       <port>+adapter.amqp.ip:adapter.amqp.port:5672</port>
@@ -1641,6 +1702,7 @@
                 <image>
                   <name>${docker.repository}/hono-adapter-coap-test:${project.version}</name>
                   <build>
+                    <skip>${hono.coap-adapter.disabled}</skip>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
                     <from>${docker.repository}/${hono.coap-adapter.image}:${project.version}</from>
                     <assembly>
@@ -1669,6 +1731,7 @@
                     </assembly>
                   </build>
                   <run>
+                    <skip>${hono.coap-adapter.disabled}</skip>
                     <ports>
                       <port>+coap.ip:coap.port:5683/udp</port>
                       <port>coaps.port:5684/udp</port>
@@ -1712,6 +1775,7 @@
                 <image>
                   <name>${docker.repository}/hono-adapter-lora-test:${project.version}</name>
                   <build>
+                    <skip>${hono.lora-adapter.disabled}</skip>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
                     <from>${docker.repository}/${hono.lora-adapter.image}:${project.version}</from>
                     <assembly>
@@ -1740,6 +1804,7 @@
                     </assembly>
                   </build>
                   <run>
+                    <skip>${hono.lora-adapter.disabled}</skip>
                     <ports>
                       <port>+lora.ip:lora.port:8080</port>
                       <port>lora.secure-port:8443</port>
@@ -1847,18 +1912,23 @@
                 <deviceregistry.http.port>${deviceregistry.http.port}</deviceregistry.http.port>
                 <deviceregistry.http.authConfig.username>${hono.deviceregistry.http.authConfig.username}</deviceregistry.http.authConfig.username>
                 <deviceregistry.http.authConfig.password>${hono.deviceregistry.http.authConfig.password}</deviceregistry.http.authConfig.password>
+                <adapter.coap.disabled>${hono.coap-adapter.disabled}</adapter.coap.disabled>
                 <adapter.coap.host>${coap.ip}</adapter.coap.host>
                 <adapter.coap.port>${coap.port}</adapter.coap.port>
                 <adapter.coaps.port>${coaps.port}</adapter.coaps.port>
+                <adapter.http.disabled>${hono.http-adapter.disabled}</adapter.http.disabled>
                 <adapter.http.host>${http.ip}</adapter.http.host>
                 <adapter.http.port>${http.port}</adapter.http.port>
                 <adapter.https.port>${https.port}</adapter.https.port>
+                <adapter.lora.disabled>${hono.lora-adapter.disabled}</adapter.lora.disabled>
                 <adapter.lora.host>${lora.ip}</adapter.lora.host>
                 <adapter.lora.port>${lora.port}</adapter.lora.port>
                 <adapter.lora.secure-port>${lora.secure-port}</adapter.lora.secure-port>
+                <adapter.mqtt.disabled>${hono.mqtt-adapter.disabled}</adapter.mqtt.disabled>
                 <adapter.mqtt.host>${mqtt.ip}</adapter.mqtt.host>
                 <adapter.mqtt.port>${mqtt.port}</adapter.mqtt.port>
                 <adapter.mqtts.port>${mqtts.port}</adapter.mqtts.port>
+                <adapter.amqp.disabled>${hono.amqp-adapter.disabled}</adapter.amqp.disabled>
                 <adapter.amqp.host>${adapter.amqp.ip}</adapter.amqp.host>
                 <adapter.amqp.port>${adapter.amqp.port}</adapter.amqp.port>
                 <adapter.amqps.port>${adapter.amqps.port}</adapter.amqps.port>

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -152,3 +152,21 @@ value `amqp`:
 ```sh
 mvn verify -Prun-tests -Dhono.messaging-infra.type=amqp
 ```
+
+### Run Tests for a particular Protocol Adapter only
+
+By default, all protocol adapter listed in the overview above are started as part of running the integration tests.
+However, when working on a particular protocol adapter, only the integration tests verifying that adapter's behavior
+will be of interest and thus starting all other adapters seems unnecessary.
+
+The following Maven profiles can be used to run the integration tests with a single protocol adapter only:
+
+* Profile: `amqp-only`, Maven property: `hono.amqp-adapter.disabled`
+* Profile: `coap-only`, Maven property: `hono.coap-adapter.disabled`
+* Profile: `http-only`, Maven property: `hono.http-adapter.disabled`
+* Profile: `lora-only`, Maven property: `hono.lora-adapter.disabled`
+* Profile: `mqtt-only`, Maven property: `hono.mqtt-adapter.disabled`
+
+All test cases for the other adapters will be skipped automatically.
+The corresponding Maven properties can be used to selectively disable a particular protocol adapter and do not
+run the corresponding test cases.

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -173,6 +173,9 @@ For example, the following command will run all MQTT related test cases and skip
 mvn verify -Prun-tests,mqtt-only
 ```
 
+The `no-adapters` Maven profile can be used to run no adapter (and corresponding tests) at all. This might be useful when
+working on the device registry and/or command router components.
+
 It is also possible to selectively disable one or more protocol adapters and skip the corresponding test cases
 by means of setting one or more of the following Maven properties to `true`:
 

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -153,7 +153,7 @@ value `amqp`:
 mvn verify -Prun-tests -Dhono.messaging-infra.type=amqp
 ```
 
-### Run Tests for a particular Protocol Adapter only
+### Running the Tests for a particular Protocol Adapter only
 
 By default, all protocol adapter listed in the overview above are started as part of running the integration tests.
 However, when working on a particular protocol adapter, only the integration tests verifying that adapter's behavior
@@ -161,12 +161,29 @@ will be of interest and thus starting all other adapters seems unnecessary.
 
 The following Maven profiles can be used to run the integration tests with a single protocol adapter only:
 
-* Profile: `amqp-only`, Maven property: `hono.amqp-adapter.disabled`
-* Profile: `coap-only`, Maven property: `hono.coap-adapter.disabled`
-* Profile: `http-only`, Maven property: `hono.http-adapter.disabled`
-* Profile: `lora-only`, Maven property: `hono.lora-adapter.disabled`
-* Profile: `mqtt-only`, Maven property: `hono.mqtt-adapter.disabled`
+* `amqp-only`
+* `coap-only`
+* `http-only`
+* `lora-only`
+* `mqtt-only`
 
-All test cases for the other adapters will be skipped automatically.
-The corresponding Maven properties can be used to selectively disable a particular protocol adapter and do not
-run the corresponding test cases.
+For example, the following command will run all MQTT related test cases and skip the tests for the other adapter types:
+
+```sh
+mvn verify -Prun-tests,mqtt-only
+```
+
+It is also possible to selectively disable one or more protocol adapters and skip the corresponding test cases
+by means of setting one or more of the following Maven properties to `true`:
+
+* `hono.amqp-adapter.disabled`
+* `hono.coap-adapter.disabled`
+* `hono.http-adapter.disabled`
+* `hono.lora-adapter.disabled`
+* `hono.mqtt-adapter.disabled`
+
+For example, the following command will not start the MQTT adapter and will run all tests except for the MQTT related ones:
+
+```sh
+mvn verify -Prun-tests -Dhono.mqtt-adapter.disabled=true
+```

--- a/tests/src/test/java/org/eclipse/hono/tests/EnabledIfProtocolAdaptersAreRunning.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/EnabledIfProtocolAdaptersAreRunning.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.tests;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Configures a test to run only if particular protocol adapters are up and running.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(EnabledIfProtocolAdaptersAreRunningCondition.class)
+public @interface EnabledIfProtocolAdaptersAreRunning {
+
+    /**
+     * Checks if the AMQP 1.0 protocol adapter is required to run.
+     *
+     * @return {@code true} if the test container must only be executed if the AMQP adapter is running.
+     */
+    boolean amqpAdapter() default false;
+
+    /**
+     * Checks if the CoAP protocol adapter is required to run.
+     *
+     * @return {@code true} if the test container must only be executed if the CoAP adapter is running.
+     */
+    boolean coapAdapter() default false;
+
+    /**
+     * Checks if the HTTP protocol adapter is required to run.
+     *
+     * @return {@code true} if the test container must only be executed if the HTTP adapter is running.
+     */
+    boolean httpAdapter() default false;
+
+    /**
+     * Checks if the Lora protocol adapter is required to run.
+     *
+     * @return {@code true} if the test container must only be executed if the Lora adapter is running.
+     */
+    boolean loraAdapter() default false;
+
+    /**
+     * Checks if the MQTT protocol adapter is required to run.
+     *
+     * @return {@code true} if the test container must only be executed if the MQTT adapter is running.
+     */
+    boolean mqttAdapter() default false;
+}

--- a/tests/src/test/java/org/eclipse/hono/tests/EnabledIfProtocolAdaptersAreRunningCondition.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/EnabledIfProtocolAdaptersAreRunningCondition.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.tests;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.util.AnnotationUtils;
+
+
+/**
+ * Enables or disables a test container based on particular types of protocol adapters are running.
+ *
+ * @see EnabledIfProtocolAdaptersAreRunning
+ */
+public class EnabledIfProtocolAdaptersAreRunningCondition implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(final ExtensionContext context) {
+        return AnnotationUtils.findAnnotation(
+                context.getElement(),
+                EnabledIfProtocolAdaptersAreRunning.class)
+            .map(this::checkConditions)
+            .orElseGet(() -> ConditionEvaluationResult.enabled(null));
+    }
+
+    private ConditionEvaluationResult checkConditions(final EnabledIfProtocolAdaptersAreRunning annotation) {
+
+        if (annotation.amqpAdapter() && isAdapterDisabled("amqp")) {
+            return ConditionEvaluationResult.disabled("AMQP adapter is not running");
+        }
+        if (annotation.coapAdapter() && isAdapterDisabled("coap")) {
+            return ConditionEvaluationResult.disabled("CoAP adapter is not running");
+        }
+        if (annotation.httpAdapter() && isAdapterDisabled("http")) {
+            return ConditionEvaluationResult.disabled("HTTP adapter is not running");
+        }
+        if (annotation.loraAdapter() && isAdapterDisabled("lora")) {
+            return ConditionEvaluationResult.disabled("Lora adapter is not running");
+        }
+        if (annotation.mqttAdapter() && isAdapterDisabled("mqtt")) {
+            return ConditionEvaluationResult.disabled("MQTT adapter is not running");
+        }
+        return ConditionEvaluationResult.enabled(null);
+    }
+
+    private static boolean isAdapterDisabled(final String adapterName) {
+        return Boolean.getBoolean("adapter.%s.disabled".formatted(adapterName));
+    }
+}

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpConnectionIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpConnectionIT.java
@@ -29,6 +29,7 @@ import javax.security.sasl.SaslException;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.EnabledIfDnsRebindingIsSupported;
+import org.eclipse.hono.tests.EnabledIfProtocolAdaptersAreRunning;
 import org.eclipse.hono.tests.EnabledIfRegistrySupportsFeatures;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.tests.Tenants;
@@ -56,6 +57,7 @@ import io.vertx.junit5.VertxTestContext;
  */
 @ExtendWith(VertxExtension.class)
 @Timeout(timeUnit = TimeUnit.SECONDS, value = 7)
+@EnabledIfProtocolAdaptersAreRunning(amqpAdapter = true)
 public class AmqpConnectionIT extends AmqpAdapterTestBase {
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
@@ -51,6 +51,7 @@ import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.AssumeMessagingSystem;
 import org.eclipse.hono.tests.CommandEndpointConfiguration.SubscriberRole;
 import org.eclipse.hono.tests.DownstreamMessageAssertions;
+import org.eclipse.hono.tests.EnabledIfProtocolAdaptersAreRunning;
 import org.eclipse.hono.tests.GenericKafkaSender;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.EventConstants;
@@ -85,6 +86,7 @@ import io.vertx.proton.ProtonSender;
  *
  */
 @ExtendWith(VertxExtension.class)
+@EnabledIfProtocolAdaptersAreRunning(amqpAdapter = true)
 public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
 
     private static final String REJECTED_COMMAND_ERROR_MESSAGE = "rejected command error message";

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/EventAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/EventAmqpIT.java
@@ -29,6 +29,7 @@ import org.eclipse.hono.application.client.MessageContext;
 import org.eclipse.hono.client.amqp.connection.AmqpUtils;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.DownstreamMessageAssertions;
+import org.eclipse.hono.tests.EnabledIfProtocolAdaptersAreRunning;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.ResourceLimits;
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,7 @@ import io.vertx.proton.ProtonQoS;
  * An Event based integration test for the AMQP adapter.
  */
 @ExtendWith(VertxExtension.class)
+@EnabledIfProtocolAdaptersAreRunning(amqpAdapter = true)
 public class EventAmqpIT extends AmqpUploadTestBase {
 
     private static final String EVENT_ENDPOINT = "event";

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/TelemetryAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/TelemetryAmqpIT.java
@@ -20,6 +20,7 @@ import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.application.client.MessageContext;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.DownstreamMessageAssertions;
+import org.eclipse.hono.tests.EnabledIfProtocolAdaptersAreRunning;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.ResourceLimits;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,6 +34,7 @@ import io.vertx.proton.ProtonQoS;
  * A Telemetry based integration test for the AMQP adapter.
  */
 @ExtendWith(VertxExtension.class)
+@EnabledIfProtocolAdaptersAreRunning(amqpAdapter = true)
 public class TelemetryAmqpIT extends AmqpUploadTestBase {
 
     private static final String TELEMETRY_ENDPOINT = "telemetry";

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/TelemetryJmsQoS1IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/TelemetryJmsQoS1IT.java
@@ -30,6 +30,7 @@ import javax.naming.NamingException;
 
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.AssumeMessagingSystem;
+import org.eclipse.hono.tests.EnabledIfProtocolAdaptersAreRunning;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.tests.jms.JmsBasedHonoConnection;
 import org.eclipse.hono.util.MessagingType;
@@ -52,6 +53,7 @@ import io.vertx.junit5.VertxTestContext;
  * Send and receive telemetry messages to/from Hono.
  */
 @ExtendWith(VertxExtension.class)
+@EnabledIfProtocolAdaptersAreRunning(amqpAdapter = true)
 public class TelemetryJmsQoS1IT {
 
     private static final int DEFAULT_TEST_TIMEOUT = 5000;

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/EventCoapIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/EventCoapIT.java
@@ -28,6 +28,7 @@ import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.application.client.MessageContext;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.DownstreamMessageAssertions;
+import org.eclipse.hono.tests.EnabledIfProtocolAdaptersAreRunning;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.EventConstants;
 import org.junit.jupiter.api.Test;
@@ -45,6 +46,7 @@ import io.vertx.junit5.VertxTestContext;
  *
  */
 @ExtendWith(VertxExtension.class)
+@EnabledIfProtocolAdaptersAreRunning(coapAdapter = true)
 public class EventCoapIT extends CoapTestBase {
 
     private static final String POST_URI = "/" + EventConstants.EVENT_ENDPOINT;

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
@@ -33,6 +33,7 @@ import org.eclipse.hono.application.client.MessageContext;
 import org.eclipse.hono.config.KeyLoader;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.EnabledIfDnsRebindingIsSupported;
+import org.eclipse.hono.tests.EnabledIfProtocolAdaptersAreRunning;
 import org.eclipse.hono.tests.EnabledIfRegistrySupportsFeatures;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.tests.Tenants;
@@ -54,6 +55,7 @@ import io.vertx.junit5.VertxTestContext;
  *
  */
 @ExtendWith(VertxExtension.class)
+@EnabledIfProtocolAdaptersAreRunning(coapAdapter = true)
 public class TelemetryCoapIT extends CoapTestBase {
 
     private static final String POST_URI = "/" + TelemetryConstants.TELEMETRY_ENDPOINT;

--- a/tests/src/test/java/org/eclipse/hono/tests/http/CorsIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/CorsIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.hono.tests.CrudHttpClient;
+import org.eclipse.hono.tests.EnabledIfProtocolAdaptersAreRunning;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
@@ -45,6 +46,7 @@ import io.vertx.junit5.VertxTestContext;
  */
 @ExtendWith(VertxExtension.class)
 @Timeout(timeUnit = TimeUnit.SECONDS, value = 5)
+@EnabledIfProtocolAdaptersAreRunning(httpAdapter = true)
 public class CorsIT {
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
@@ -24,6 +24,7 @@ import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.application.client.MessageContext;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.DownstreamMessageAssertions;
+import org.eclipse.hono.tests.EnabledIfProtocolAdaptersAreRunning;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
@@ -46,6 +47,7 @@ import io.vertx.junit5.VertxTestContext;
  *
  */
 @ExtendWith(VertxExtension.class)
+@EnabledIfProtocolAdaptersAreRunning(httpAdapter = true)
 public class EventHttpIT extends HttpTestBase {
 
     private static final String URI = String.format("/%s", EventConstants.EVENT_ENDPOINT);

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -83,7 +83,7 @@ import io.vertx.junit5.VertxTestContext;
  * Base class for HTTP adapter integration tests.
  *
  */
-    public abstract class HttpTestBase {
+public abstract class HttpTestBase {
 
     /**
      * The default password of devices.

--- a/tests/src/test/java/org/eclipse/hono/tests/http/TelemetryHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/TelemetryHttpIT.java
@@ -30,6 +30,7 @@ import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.AssumeMessagingSystem;
 import org.eclipse.hono.tests.EnabledIfDnsRebindingIsSupported;
+import org.eclipse.hono.tests.EnabledIfProtocolAdaptersAreRunning;
 import org.eclipse.hono.tests.EnabledIfRegistrySupportsFeatures;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.tests.Tenants;
@@ -62,6 +63,7 @@ import io.vertx.proton.ProtonDelivery;
  *
  */
 @ExtendWith(VertxExtension.class)
+@EnabledIfProtocolAdaptersAreRunning(httpAdapter = true)
 public class TelemetryHttpIT extends HttpTestBase {
 
     private static final String URI = "/" + TelemetryConstants.TELEMETRY_ENDPOINT;

--- a/tests/src/test/java/org/eclipse/hono/tests/lora/LoraIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/lora/LoraIT.java
@@ -39,6 +39,7 @@ import org.eclipse.hono.service.management.device.Device;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.CrudHttpClient;
 import org.eclipse.hono.tests.DownstreamMessageAssertions;
+import org.eclipse.hono.tests.EnabledIfProtocolAdaptersAreRunning;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.tests.Tenants;
 import org.eclipse.hono.util.Adapter;
@@ -75,6 +76,7 @@ import io.vertx.junit5.VertxTestContext;
  * Base class for Lora adapter integration tests.
  *
  */
+@EnabledIfProtocolAdaptersAreRunning(loraAdapter = true)
 @ExtendWith(VertxExtension.class)
 @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
 public class LoraIT {

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
@@ -44,6 +44,7 @@ import org.eclipse.hono.client.kafka.KafkaRecordHelper;
 import org.eclipse.hono.tests.AssumeMessagingSystem;
 import org.eclipse.hono.tests.CommandEndpointConfiguration.SubscriberRole;
 import org.eclipse.hono.tests.DownstreamMessageAssertions;
+import org.eclipse.hono.tests.EnabledIfProtocolAdaptersAreRunning;
 import org.eclipse.hono.tests.GenericKafkaSender;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.EventConstants;
@@ -80,6 +81,7 @@ import io.vertx.proton.ProtonHelper;
  *
  */
 @ExtendWith(VertxExtension.class)
+@EnabledIfProtocolAdaptersAreRunning(mqttAdapter = true)
 public class CommandAndControlMqttIT extends MqttTestBase {
 
     private static final int COMMANDS_TO_SEND = 60;

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
@@ -26,6 +26,7 @@ import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.application.client.MessageContext;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.DownstreamMessageAssertions;
+import org.eclipse.hono.tests.EnabledIfProtocolAdaptersAreRunning;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessageHelper;
@@ -47,6 +48,7 @@ import io.vertx.junit5.VertxTestContext;
  *
  */
 @ExtendWith(VertxExtension.class)
+@EnabledIfProtocolAdaptersAreRunning(mqttAdapter = true)
 public class EventMqttIT extends MqttPublishTestBase {
 
     private static final String TOPIC_TEMPLATE = "%s/%s/%s";

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttConnectionIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttConnectionIT.java
@@ -30,6 +30,7 @@ import org.eclipse.hono.service.management.credentials.X509CertificateSecret;
 import org.eclipse.hono.service.management.device.Device;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.EnabledIfDnsRebindingIsSupported;
+import org.eclipse.hono.tests.EnabledIfProtocolAdaptersAreRunning;
 import org.eclipse.hono.tests.EnabledIfRegistrySupportsFeatures;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.tests.Tenants;
@@ -59,6 +60,7 @@ import io.vertx.mqtt.MqttConnectionException;
  */
 @ExtendWith(VertxExtension.class)
 @Timeout(timeUnit = TimeUnit.SECONDS, value = 5)
+@EnabledIfProtocolAdaptersAreRunning(mqttAdapter = true)
 public class MqttConnectionIT extends MqttTestBase {
 
     private SelfSignedCertificate deviceCert;

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS0IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS0IT.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.application.client.MessageContext;
+import org.eclipse.hono.tests.EnabledIfProtocolAdaptersAreRunning;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.TelemetryConstants;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,6 +37,7 @@ import io.vertx.junit5.VertxTestContext;
  *
  */
 @ExtendWith(VertxExtension.class)
+@EnabledIfProtocolAdaptersAreRunning(mqttAdapter = true)
 public class TelemetryMqttQoS0IT extends MqttPublishTestBase {
 
     private static final String TOPIC_TEMPLATE = "%s/%s/%s";

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS1IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS1IT.java
@@ -26,6 +26,7 @@ import org.eclipse.hono.client.NoConsumerException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.AssumeMessagingSystem;
+import org.eclipse.hono.tests.EnabledIfProtocolAdaptersAreRunning;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.MessagingType;
@@ -48,6 +49,7 @@ import io.vertx.junit5.VertxTestContext;
  *
  */
 @ExtendWith(VertxExtension.class)
+@EnabledIfProtocolAdaptersAreRunning(mqttAdapter = true)
 public class TelemetryMqttQoS1IT extends MqttPublishTestBase {
 
     private static final String TOPIC_TEMPLATE = "%s/%s/%s";


### PR DESCRIPTION
The EnabledIfProtocolAdaptersAreRunning annotation has been added to
integration tests which allows to mark tests to be run only if a
particular type of protocol adapter has not been explicitly disabled.

A set of Maven properties has been added to selectively disable
particular protocol adapters. Profiles have been added to start a
particular type of protocol adapter only.
