### PR TITLE
[#2892] Fix IllegalStateException in HTTP Adapter

### DIFF
--- a/adapters/http-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -683,6 +683,10 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
             }
         })
         .compose(proceed -> {
+            // overwrites the execution of closeHandler in setTtdRequestConnectionCloseHandler
+            // to prevent ctx.response().end() from being called twice
+            ctx.response().closeHandler(v -> logResponseGettingClosedPrematurely(ctx.getRoutingContext()));
+
             // downstream message sent and (if ttd was set) command was received or ttd has timed out
             // we wait for the CommandConsumer having been closed before delivering the response to the
             // device in order to prevent a race condition when the device immediately sends a new


### PR DESCRIPTION
 To fix the issue, it is necessary to call an empty closing handler
 that actually overwrites the execution of "closeHandler"
 in "setTtdRequestConnectionCloseHandler" to prevent "ctx.response().end()" from being called twice.

Signed-off-by: Ivanova Suzana <Suzana.Ivanova@bosch.io>