### PR TITLE
[#3312] Remove timeout on initial subscribeAndWaitForRebalance()

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -255,6 +255,12 @@
       <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-service-command-router</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.slf4j</groupId>
+          <artifactId>slf4j-jboss-logmanager</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>


### PR DESCRIPTION
This fixes #3312:
A restarting Kafka broker could have caused a timeout while waiting for the initial Kafka consumer rebalance in `subscribeAndWaitForRebalance()`, meaning that in this scenario the HonoKafkaConsumer couldn't get ready.

Also readiness-check log output in Kafka consumer classes gets improved here.

The changes are deliberately kept small here in order to reduce the potential impact when merging into 2.0.x.

I'm looking into doing some further improvements for 2.1.0, also in connection with #3349.

