### PR TITLE
[#3327] Apply tracing changes related to Quarkus 2.10.2 update

### DIFF
--- a/adapters/http-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -84,7 +84,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
     protected static final String DEFAULT_UPLOADS_DIRECTORY = "/tmp";
 
     private static final String KEY_TIMER_ID = "timerId";
-    private static final String MATCH_ALL_ROUTE_NAME = "/* (default route)";
+    private static final String MATCH_ALL_ROUTE_NAME = "/*";
 
     private static final String KEY_MATCH_ALL_ROUTE_APPLIED = "matchAllRouteApplied";
 
@@ -296,7 +296,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
             if (!ctx.response().closed() && !ctx.response().ended()) {
                 ctx.response().closeHandler(v -> logResponseGettingClosedPrematurely(ctx));
             }
-            ctx.next();
+            HttpUtils.nextRoute(ctx);
         });
         HttpUtils.addDefault404ErrorHandler(router);
         return router;

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -92,7 +92,8 @@ quarkus.micrometer.binder.jvm=true
 # Kafka client metrics are being managed explicitly by MicrometerKafkaClientMetricsSupport
 quarkus.micrometer.binder.kafka.enabled=false
 quarkus.micrometer.binder.system=true
-quarkus.micrometer.binder.http-server.enabled=true
+# have to explicitly set value to false - see https://github.com/quarkusio/quarkus/pull/26356#discussion_r922661619
+quarkus.micrometer.binder.http-server.enabled=false
 quarkus.micrometer.binder.vertx.enabled=true
 quarkus.micrometer.export.prometheus.path=/prometheus
 quarkus.smallrye-health.root-path=${health.check.root-path}

--- a/service-base/src/main/java/org/eclipse/hono/service/http/DefaultFailureHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/DefaultFailureHandler.java
@@ -65,7 +65,7 @@ public class DefaultFailureHandler implements Handler<RoutingContext> {
             if (ctx.response().ended()) {
                 LOG.debug("skipping processing of failed route, response already ended");
             } else {
-                LOG.debug("handling failed route for request [method: {}, URI: {}, status: {}] - {}",
+                LOG.debug("handling failed route for request [method: {}, URI: {}, status: {}]; failure: {}",
                         ctx.request().method(), HttpUtils.getAbsoluteURI(ctx.request()), ctx.statusCode(), ctx.getBody(),
                         ctx.failure());
                 final Span span = HttpServerSpanHelper.serverSpan(ctx);

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
@@ -41,7 +41,7 @@ import io.vertx.ext.web.handler.AuthenticationHandler;
  */
 public abstract class HttpServiceBase<T extends HttpServiceConfigProperties> extends AbstractServiceBase<T> {
 
-    private static final String MATCH_ALL_ROUTE_NAME = "/* (default route)";
+    private static final String MATCH_ALL_ROUTE_NAME = "/*";
 
     private static final String KEY_MATCH_ALL_ROUTE_APPLIED = "matchAllRouteApplied";
 
@@ -203,7 +203,7 @@ public abstract class HttpServiceBase<T extends HttpServiceConfigProperties> ext
             ctx.put(KEY_MATCH_ALL_ROUTE_APPLIED, true);
             // keep track of the tracing span created by the Vert.x/Quarkus instrumentation (set as active span there)
             HttpServerSpanHelper.adoptActiveSpanIntoContext(tracer, customTags, ctx);
-            ctx.next();
+            HttpUtils.nextRoute(ctx);
         });
         addAuthHandler(router);
         HttpUtils.addDefault404ErrorHandler(router);

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpUtils.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpUtils.java
@@ -377,6 +377,26 @@ public final class HttpUtils {
     }
 
     /**
+     * Invokes the next route on the given routing context, checking first whether the request path is invalid and
+     * failing the context if that is the case.
+     * <p>
+     * This check prevents exceptions thrown for invalid request paths on invoking the next route, if the route has
+     * {code useNormalizedPath} set to {@code true}, which is the default.
+     *
+     * @param ctx The routing context.
+     */
+    public static void nextRoute(final RoutingContext ctx) {
+        try {
+            ctx.normalizedPath();
+        } catch (final IllegalArgumentException ex) {
+            LOG.debug("invalid request path [{}]: {}", ctx.request().path(), ex.getMessage());
+            ctx.fail(400, ex);
+            return;
+        }
+        ctx.next();
+    }
+
+    /**
      * Adds an error handler for {@code 404} status requests to the given router.
      * The handler adds an error log entry in the request span and sets a response body (if it's not a HEAD request).
      *


### PR DESCRIPTION
Relates to #3327:
HTTP-server metrics are not needed any more for correct HTTP request span names. `MATCH_ALL_ROUTE_NAME` has been
adapted to match the name used by Quarkus.
Also the handling of requests with an invalid path gets improved here.