### PR TITLE
[#3302] Support setting of alg on validating keys

### DIFF
--- a/deploy/src/main/sandbox/hono-values.yml
+++ b/deploy/src/main/sandbox/hono-values.yml
@@ -149,14 +149,14 @@ adapters:
 authServer:
   imageName: "eclipse/hono-service-auth-native"
   cmdLineArgs:
-  - "-Xmx24m"
+  - "-Xmx48m"
   resources:
     requests:
       cpu: "50m"
-      memory: "30Mi"
+      memory: "60Mi"
     limits:
       cpu:
-      memory: "30Mi"
+      memory: "60Mi"
 
 deviceRegistryExample:
   type: "embedded"

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/delegating/AuthenticationServerClientConfigProperties.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/delegating/AuthenticationServerClientConfigProperties.java
@@ -37,6 +37,7 @@ public class AuthenticationServerClientConfigProperties extends ClientConfigProp
     private String jwksEndpointUri = AuthenticationServerClientOptions.DEFAULT_JWKS_ENDPOINT_URI;
     private boolean jwksEndpointTlsEnabled = false;
     private Duration jwksPollingInterval = Duration.ofMinutes(5);
+    private boolean jwksSignatureAlgorithmRequired = true;
 
     /**
      * Creates new properties using default values.
@@ -58,6 +59,7 @@ public class AuthenticationServerClientConfigProperties extends ClientConfigProp
         this.jwksEndpointTlsEnabled = options.jwksEndpointTlsEnabled();
         this.jwksEndpointUri = options.jwksEndpointUri();
         this.jwksPollingInterval = options.jwksPollingInterval();
+        this.jwksSignatureAlgorithmRequired = options.jwksSignatureAlgorithmRequired();
     }
 
     /**
@@ -186,5 +188,29 @@ public class AuthenticationServerClientConfigProperties extends ClientConfigProp
             throw new IllegalArgumentException("polling interval must be at least 10 seconds");
         }
         this.jwksPollingInterval = interval;
+    }
+
+    /**
+     * Checks if validating JWKs must include an <em>alg</em> property that indicates
+     * the signature algorithm to use with the key as described in
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7517#section-4.4">RFC 7517, Section 4.4</a>.
+     * <p>
+     * The default value of this property is {@code true}.
+     *
+     * @return {@code true} if the property is required.
+     */
+    public final boolean isJwksSignatureAlgorithmRequired() {
+        return jwksSignatureAlgorithmRequired;
+    }
+
+    /**
+     * Sets if validating JWKs must include an <em>alg</em> property that indicates
+     * the signature algorithm to use with the key as described in
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7517#section-4.4">RFC 7517, Section 4.4</a>.
+     *
+     * @param flag {@code true} if the property is required.
+     */
+    public final void setJwksSignatureAlgorithmRequired(final boolean flag) {
+        this.jwksSignatureAlgorithmRequired = flag;
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/delegating/AuthenticationServerClientOptions.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/delegating/AuthenticationServerClientOptions.java
@@ -90,4 +90,14 @@ public interface AuthenticationServerClientOptions {
      */
     @WithDefault("PT5M")
     Duration jwksPollingInterval();
+
+    /**
+     * Checks if retrieved JWKs must include an <em>alg</em> property that indicates
+     * the signature algorithm to use with the key as described in
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7517#section-4.4">RFC 7517, Section 4.4</a>.
+     *
+     * @return {@code true} if the property is required.
+     */
+    @WithDefault("true")
+    boolean jwksSignatureAlgorithmRequired();
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/auth/delegating/AuthenticationServerClientOptionsTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/auth/delegating/AuthenticationServerClientOptionsTest.java
@@ -18,6 +18,8 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.time.Duration;
+
 import org.eclipse.hono.test.ConfigMappingSupport;
 import org.junit.jupiter.api.Test;
 
@@ -43,6 +45,11 @@ class AuthenticationServerClientOptionsTest {
         assertAll(
                 () -> assertThat(props.getServerRole()).isEqualTo("Authentication Server"),
                 () -> assertThat(props.getSupportedSaslMechanisms()).containsExactly("PLAIN"),
+                () -> assertThat(props.isJwksSignatureAlgorithmRequired()).isFalse(),
+                () -> assertThat(props.getJwksEndpointPort()).isEqualTo(12000),
+                () -> assertThat(props.getJwksEndpointUri()).isEqualTo("https://my.auth-server.io/jwks"),
+                () -> assertThat(props.isJwksEndpointTlsEnabled()).isTrue(),
+                () -> assertThat(props.getJwksPollingInterval()).isEqualTo(Duration.ofSeconds(12)),
                 () -> assertThat(props.getValidation().getAudience()).isEqualTo("hono-components"),
                 () -> assertThat(props.getValidation().getCertPath()).isEqualTo("/etc/cert.pem"),
                 () -> assertThat(props.getValidation().getKeyPath()).isEqualTo("/etc/key.pem"),

--- a/service-base/src/test/resources/auth-server-client-options.yaml
+++ b/service-base/src/test/resources/auth-server-client-options.yaml
@@ -3,6 +3,11 @@ hono:
     client:
       serverRole: "Authentication Server"
       supportedSaslMechanisms: "PLAIN"
+      jwksEndpointPort: 12000
+      jwksEndpointUri: "https://my.auth-server.io/jwks"
+      jwksEndpointTlsEnabled: true
+      jwksPollingInterval: "PT12S"
+      jwksSignatureAlgorithmRequired: false
       validation:
         audience: "hono-components"
         certPath: "/etc/cert.pem"

--- a/tests/src/test/java/org/eclipse/hono/tests/auth/AuthServerAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/auth/AuthServerAmqpIT.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.ServerErrorException;
@@ -44,6 +45,7 @@ import io.vertx.ext.auth.impl.jose.JWT;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.predicate.ResponsePredicate;
+import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
@@ -53,6 +55,7 @@ import io.vertx.junit5.VertxTestContext;
  *
  */
 @ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
 public class AuthServerAmqpIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(AuthServerAmqpIT.class);


### PR DESCRIPTION
RFC 8725 (https://datatracker.ietf.org/doc/html/rfc8725) recommends that
applications should make sure that a given key is used with exactly one
signature algorithm only. The validator has been extended with a
configuration property that enables a check which compares the signature
algorithm used in a token with the algorithm that has been specified in
the dynamically retrieved JWK set.