### PR TITLE
[#3372] Allow building of docker images for windows

### DIFF
--- a/adapters/parent/pom.xml
+++ b/adapters/parent/pom.xml
@@ -132,8 +132,12 @@
                         <!-- use Base64 encoder/decoder that is compatible with vert.x 3 -->
                         <JAVA_OPTIONS>
                           -Dvertx.json.base64=legacy
-                          -Djava.util.logging.manager=org.jboss.logmanager.LogManager</JAVA_OPTIONS>
+                          -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+                        </JAVA_OPTIONS>
                       </env>
+                      <runCmds>
+                        <run>chmod 755 /opt/hono/run-java.sh</run>
+                      </runCmds>
                       <entryPoint>
                         <arg>/opt/hono/run-java.sh</arg>
                       </entryPoint>
@@ -148,7 +152,6 @@
                               <includes>
                                 <include>run-java.sh</include>
                               </includes>
-                              <fileMode>755</fileMode>
                             </fileSet>
                             <fileSet>
                               <directory>${project.build.directory}/quarkus-app</directory>

--- a/services/parent/pom.xml
+++ b/services/parent/pom.xml
@@ -152,6 +152,9 @@
                           -Djava.util.logging.manager=org.jboss.logmanager.LogManager
                         </JAVA_OPTIONS>
                       </env>
+                      <runCmds>
+                        <run>chmod 755 /opt/hono/run-java.sh</run>
+                      </runCmds>
                       <entryPoint>
                         <arg>/opt/hono/run-java.sh</arg>
                       </entryPoint>
@@ -166,7 +169,6 @@
                               <includes>
                                 <include>run-java.sh</include>
                               </includes>
-                              <fileMode>755</fileMode>
                             </fileSet>
                             <fileSet>
                               <directory>${project.build.directory}/quarkus-app</directory>


### PR DESCRIPTION
Images with exec permissions for ALL image files could be build by
enabling win-test-images profile:
 * -Pwin-test-images
 * env property WIN_TEST_IMAGES=true
or by explicitly overiding fabric8.permissions property
 * -Dfabric8.permissions=auto

Signed-off-by: Marinov Avgustin <Avgustin.Marinov@bosch.io