### PR TITLE
[#3378] Fix NPE in case CoAP PUT URI device id is empty

### DIFF
--- a/adapters/coap/src/main/java/org/eclipse/hono/adapter/coap/AbstractHonoResource.java
+++ b/adapters/coap/src/main/java/org/eclipse/hono/adapter/coap/AbstractHonoResource.java
@@ -138,11 +138,14 @@ public abstract class AbstractHonoResource extends TracingSupportingHonoResource
         Optional.ofNullable(TracingSupportingHonoResource.getAuthenticatedDevice(exchange))
             .ifPresentOrElse(
                     authenticatedDevice -> {
-                        final String tenantFromUri = Optional.ofNullable(requestedResource.getTenantId())
+                        final String tenantId = Optional.ofNullable(requestedResource.getTenantId())
                                 .orElse(authenticatedDevice.getTenantId());
-                        if (authenticatedDevice.getTenantId().equals(tenantFromUri)) {
+                        if (Strings.isNullOrEmpty(requestedResource.getResourceId())) {
+                            result.fail(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND,
+                                    "request URI must contain device ID"));
+                        } else if (authenticatedDevice.getTenantId().equals(tenantId)) {
                             result.complete(new RequestDeviceAndAuth(
-                                    new Device(tenantFromUri, requestedResource.getResourceId()),
+                                    new Device(tenantId, requestedResource.getResourceId()),
                                     TracingSupportingHonoResource.getAuthId(exchange),
                                     authenticatedDevice));
                         } else {

--- a/adapters/coap/src/test/java/org/eclipse/hono/adapter/coap/AbstractHonoResourceTest.java
+++ b/adapters/coap/src/test/java/org/eclipse/hono/adapter/coap/AbstractHonoResourceTest.java
@@ -117,7 +117,11 @@ class AbstractHonoResourceTest extends ResourceTestBase {
     @ParameterizedTest
     @CsvSource(value = {
             "true,/telemetry/OTHER_TENANT/device_1,403",
+            "true,/telemetry/OTHER_TENANT/,404",
             "false,/telemetry//device_1,404",
+            "false,/telemetry//,404",
+            "true,/telemetry//,404",
+            "true,/telemetry/DEFAULT_TENANT/,404",
             "true,/event/OTHER_TENANT/device_1,403",
             "false,/event//device_1,404",
             "true,/command_response/OTHER_TENANT/device_1/request_id,403",


### PR DESCRIPTION
This fixed #3378.