### PR TITLE
Rename notification 'enabled' field/getter

### DIFF
--- a/adapters/amqp/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
@@ -217,7 +217,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
         NotificationEventBusSupport.registerConsumer(vertx, DeviceChangeNotification.TYPE,
                 notification -> {
                     if (LifecycleChange.DELETE.equals(notification.getChange())
-                            || (LifecycleChange.UPDATE.equals(notification.getChange()) && !notification.isEnabled())) {
+                            || (LifecycleChange.UPDATE.equals(notification.getChange()) && !notification.isDeviceEnabled())) {
                         final String reason = LifecycleChange.DELETE.equals(notification.getChange()) ? "device deleted"
                                 : "device disabled";
                         closeDeviceConnections(connectedDevice -> connectedDevice.getTenantId().equals(notification.getTenantId())
@@ -232,7 +232,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
         NotificationEventBusSupport.registerConsumer(vertx, TenantChangeNotification.TYPE,
                 notification -> {
                     if (LifecycleChange.DELETE.equals(notification.getChange())
-                            || (LifecycleChange.UPDATE.equals(notification.getChange()) && !notification.isEnabled())) {
+                            || (LifecycleChange.UPDATE.equals(notification.getChange()) && !notification.isTenantEnabled())) {
                         final String reason = LifecycleChange.DELETE.equals(notification.getChange()) ? "tenant deleted"
                                 : "tenant disabled";
                         closeDeviceConnections(connectedDevice -> connectedDevice.getTenantId()

--- a/adapters/mqtt-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -381,7 +381,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
         NotificationEventBusSupport.registerConsumer(vertx, DeviceChangeNotification.TYPE,
                 notification -> {
                     if (LifecycleChange.DELETE.equals(notification.getChange())
-                            || (LifecycleChange.UPDATE.equals(notification.getChange()) && !notification.isEnabled())) {
+                            || (LifecycleChange.UPDATE.equals(notification.getChange()) && !notification.isDeviceEnabled())) {
                         final String reason = LifecycleChange.DELETE.equals(notification.getChange()) ? "device deleted"
                                 : "device disabled";
                         closeDeviceConnectionsOnDeviceOrTenantChange(
@@ -397,7 +397,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
         NotificationEventBusSupport.registerConsumer(vertx, TenantChangeNotification.TYPE,
                 notification -> {
                     if (LifecycleChange.DELETE.equals(notification.getChange())
-                            || (LifecycleChange.UPDATE.equals(notification.getChange()) && !notification.isEnabled())) {
+                            || (LifecycleChange.UPDATE.equals(notification.getChange()) && !notification.isTenantEnabled())) {
                         final String reason = LifecycleChange.DELETE.equals(notification.getChange()) ? "tenant deleted"
                                 : "tenant disabled";
                         closeDeviceConnectionsOnDeviceOrTenantChange(

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/DeviceChangeNotification.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/DeviceChangeNotification.java
@@ -45,7 +45,7 @@ public final class DeviceChangeNotification extends AbstractNotification {
     private final LifecycleChange change;
     private final String tenantId;
     private final String deviceId;
-    private final boolean enabled;
+    private final boolean deviceEnabled;
 
     @JsonCreator
     DeviceChangeNotification(
@@ -61,14 +61,14 @@ public final class DeviceChangeNotification extends AbstractNotification {
             @JsonProperty(value = NotificationConstants.JSON_FIELD_DEVICE_ID, required = true)
             final String deviceId,
             @JsonProperty(value = NotificationConstants.JSON_FIELD_DATA_ENABLED, required = true)
-            final boolean enabled) {
+            final boolean deviceEnabled) {
 
         super(source, creationTime);
 
         this.change = Objects.requireNonNull(change);
         this.tenantId = Objects.requireNonNull(tenantId);
         this.deviceId = Objects.requireNonNull(deviceId);
-        this.enabled = enabled;
+        this.deviceEnabled = deviceEnabled;
     }
 
     /**
@@ -78,7 +78,7 @@ public final class DeviceChangeNotification extends AbstractNotification {
      * @param tenantId The tenant ID of the device.
      * @param deviceId The ID of the device.
      * @param creationTime The creation time of the event.
-     * @param enabled {@code true} if the device is enabled.
+     * @param deviceEnabled {@code true} if the device is enabled.
      * @throws NullPointerException If any of the parameters are {@code null}.
      */
     public DeviceChangeNotification(
@@ -86,8 +86,8 @@ public final class DeviceChangeNotification extends AbstractNotification {
             final String tenantId,
             final String deviceId,
             final Instant creationTime,
-            final boolean enabled) {
-        this(NotificationConstants.SOURCE_DEVICE_REGISTRY, creationTime, change, tenantId, deviceId, enabled);
+            final boolean deviceEnabled) {
+        this(NotificationConstants.SOURCE_DEVICE_REGISTRY, creationTime, change, tenantId, deviceId, deviceEnabled);
     }
 
     /**
@@ -126,8 +126,8 @@ public final class DeviceChangeNotification extends AbstractNotification {
      * @return {@code true} if this device is enabled.
      */
     @JsonProperty(value = NotificationConstants.JSON_FIELD_DATA_ENABLED)
-    public boolean isEnabled() {
-        return enabled;
+    public boolean isDeviceEnabled() {
+        return deviceEnabled;
     }
 
     @Override
@@ -148,7 +148,7 @@ public final class DeviceChangeNotification extends AbstractNotification {
                 .append("change=").append(change)
                 .append(", tenantId='").append(tenantId).append('\'')
                 .append(", deviceId='").append(deviceId).append('\'')
-                .append(", enabled=").append(enabled)
+                .append(", deviceEnabled=").append(deviceEnabled)
                 .append(", creationTime='").append(getCreationTime()).append('\'')
                 .append(", source='").append(getSource()).append("'}")
                 .toString();

--- a/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/TenantChangeNotification.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/deviceregistry/TenantChangeNotification.java
@@ -44,7 +44,7 @@ public final class TenantChangeNotification extends AbstractNotification {
 
     private final LifecycleChange change;
     private final String tenantId;
-    private final boolean enabled;
+    private final boolean tenantEnabled;
     private final boolean invalidateCacheOnUpdate;
 
     @JsonCreator
@@ -59,7 +59,7 @@ public final class TenantChangeNotification extends AbstractNotification {
             @JsonProperty(value = NotificationConstants.JSON_FIELD_TENANT_ID, required = true)
             final String tenantId,
             @JsonProperty(value = NotificationConstants.JSON_FIELD_DATA_ENABLED, required = true)
-            final boolean enabled,
+            final boolean tenantEnabled,
             @JsonProperty(value = NotificationConstants.JSON_FIELD_DATA_INVALIDATE_CACHE_ON_UPDATE, required = true)
             final boolean invalidateCacheOnUpdate) {
 
@@ -67,7 +67,7 @@ public final class TenantChangeNotification extends AbstractNotification {
 
         this.change = Objects.requireNonNull(change);
         this.tenantId = Objects.requireNonNull(tenantId);
-        this.enabled = enabled;
+        this.tenantEnabled = tenantEnabled;
         this.invalidateCacheOnUpdate = invalidateCacheOnUpdate;
     }
 
@@ -77,13 +77,13 @@ public final class TenantChangeNotification extends AbstractNotification {
      * @param change The type of change to notify about.
      * @param tenantId The ID of the tenant.
      * @param creationTime The creation time of the event.
-     * @param enabled {@code true} if the device is enabled.
+     * @param tenantEnabled {@code true} if the tenant is enabled.
      * @param invalidateCacheOnUpdate {@code true} if cache invalidation is required on update operation.
      * @throws NullPointerException If any of the parameters are {@code null}.
      */
     public TenantChangeNotification(final LifecycleChange change, final String tenantId, final Instant creationTime,
-            final boolean enabled, final boolean invalidateCacheOnUpdate) {
-        this(NotificationConstants.SOURCE_DEVICE_REGISTRY, creationTime, change, tenantId, enabled,
+            final boolean tenantEnabled, final boolean invalidateCacheOnUpdate) {
+        this(NotificationConstants.SOURCE_DEVICE_REGISTRY, creationTime, change, tenantId, tenantEnabled,
                 invalidateCacheOnUpdate);
     }
 
@@ -113,8 +113,8 @@ public final class TenantChangeNotification extends AbstractNotification {
      * @return {@code true} if this tenant is enabled.
      */
     @JsonProperty(value = NotificationConstants.JSON_FIELD_DATA_ENABLED)
-    public boolean isEnabled() {
-        return enabled;
+    public boolean isTenantEnabled() {
+        return tenantEnabled;
     }
 
     /**
@@ -146,7 +146,7 @@ public final class TenantChangeNotification extends AbstractNotification {
         return "TenantChangeNotification{" +
                 "change=" + change +
                 ", tenantId='" + tenantId + '\'' +
-                ", enabled=" + enabled +
+                ", tenantEnabled=" + tenantEnabled +
                 ", invalidateCacheOnUpdate=" + invalidateCacheOnUpdate +
                 ", creationTime='" + getCreationTime() + '\'' +
                 '}';

--- a/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/DeviceChangeNotificationTest.java
+++ b/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/DeviceChangeNotificationTest.java
@@ -118,7 +118,7 @@ public class DeviceChangeNotificationTest {
         assertThat(newNotification.getChange()).isEqualTo(LifecycleChange.DELETE);
         assertThat(newNotification.getTenantId()).isEqualTo(TENANT_ID);
         assertThat(newNotification.getDeviceId()).isEqualTo(DEVICE_ID);
-        assertThat(newNotification.isEnabled()).isTrue();
+        assertThat(newNotification.isDeviceEnabled()).isTrue();
     }
 
 }

--- a/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/TenantChangeNotificationTest.java
+++ b/clients/notification/src/test/java/org/eclipse/hono/notification/deviceregistry/TenantChangeNotificationTest.java
@@ -112,7 +112,7 @@ public class TenantChangeNotificationTest {
 
         assertThat(newNotification.getChange()).isEqualTo(CHANGE);
         assertThat(newNotification.getTenantId()).isEqualTo(TENANT_ID);
-        assertThat(newNotification.isEnabled()).isEqualTo(ENABLED);
+        assertThat(newNotification.isTenantEnabled()).isEqualTo(ENABLED);
         assertThat(newNotification.isInvalidateCacheOnUpdate()).isEqualTo(INVALIDATE_CACHE_ON_UPDATE);
     }
 

--- a/clients/registry-amqp/src/main/java/org/eclipse/hono/client/registry/amqp/ProtonBasedCredentialsClient.java
+++ b/clients/registry-amqp/src/main/java/org/eclipse/hono/client/registry/amqp/ProtonBasedCredentialsClient.java
@@ -94,7 +94,7 @@ public class ProtonBasedCredentialsClient extends AbstractRequestResponseService
             NotificationEventBusSupport.registerConsumer(connection.getVertx(), DeviceChangeNotification.TYPE,
                     n -> {
                         if (LifecycleChange.DELETE.equals(n.getChange())
-                                || (LifecycleChange.UPDATE.equals(n.getChange()) && !n.isEnabled())) {
+                                || (LifecycleChange.UPDATE.equals(n.getChange()) && !n.isDeviceEnabled())) {
                             removeResultsForDeviceFromCache(n.getTenantId(), n.getDeviceId());
                         }
                     });

--- a/clients/registry-amqp/src/main/java/org/eclipse/hono/client/registry/amqp/ProtonBasedTenantClient.java
+++ b/clients/registry-amqp/src/main/java/org/eclipse/hono/client/registry/amqp/ProtonBasedTenantClient.java
@@ -95,7 +95,7 @@ public final class ProtonBasedTenantClient extends AbstractRequestResponseServic
                     n -> {
                         if (LifecycleChange.DELETE.equals(n.getChange())
                                 || (LifecycleChange.UPDATE.equals(n.getChange())
-                                        && (!n.isEnabled() || n.isInvalidateCacheOnUpdate()))) {
+                                        && (!n.isTenantEnabled() || n.isInvalidateCacheOnUpdate()))) {
                             removeResultFromCache(n.getTenantId());
                         }
                     });

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -251,7 +251,7 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
         NotificationEventBusSupport.registerConsumer(vertx, TenantChangeNotification.TYPE,
                 notification -> {
                     if (lifecycleStatus.isStarted() && LifecycleChange.CREATE == notification.getChange()
-                            && notification.isEnabled()) {
+                            && notification.isTenantEnabled()) {
                         // Optional optimization:
                         // Prepare Kafka consumer to receive commands for devices of a newly created tenant.
                         // If not done here, this preparation is done in the "createCommandConsumer" method below.

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/device/AbstractDeviceManagementServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/device/AbstractDeviceManagementServiceTest.java
@@ -92,7 +92,7 @@ public class AbstractDeviceManagementServiceTest {
                         assertThat(notification.getTenantId()).isEqualTo(DEFAULT_TENANT_ID);
                         assertThat(notification.getDeviceId()).isEqualTo(DEFAULT_DEVICE_ID);
                         assertThat(notification.getCreationTime()).isNotNull();
-                        assertThat(notification.isEnabled()).isFalse();
+                        assertThat(notification.isDeviceEnabled()).isFalse();
                     });
                     context.completeNow();
                 }));
@@ -125,7 +125,7 @@ public class AbstractDeviceManagementServiceTest {
                         assertThat(notification.getTenantId()).isEqualTo(DEFAULT_TENANT_ID);
                         assertThat(notification.getDeviceId()).isEqualTo(DEFAULT_DEVICE_ID);
                         assertThat(notification.getCreationTime()).isNotNull();
-                        assertThat(notification.isEnabled()).isFalse();
+                        assertThat(notification.isDeviceEnabled()).isFalse();
                     });
                     context.completeNow();
                 }));
@@ -158,7 +158,7 @@ public class AbstractDeviceManagementServiceTest {
                         assertThat(notification.getTenantId()).isEqualTo(DEFAULT_TENANT_ID);
                         assertThat(notification.getDeviceId()).isEqualTo(DEFAULT_DEVICE_ID);
                         assertThat(notification.getCreationTime()).isNotNull();
-                        assertThat(notification.isEnabled()).isFalse();
+                        assertThat(notification.isDeviceEnabled()).isFalse();
                     });
                     context.completeNow();
                 }));

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/tenant/AbstractTenantManagementServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/tenant/AbstractTenantManagementServiceTest.java
@@ -89,7 +89,7 @@ public class AbstractTenantManagementServiceTest {
                         assertThat(notification.getChange()).isEqualTo(LifecycleChange.CREATE);
                         assertThat(notification.getTenantId()).isEqualTo(DEFAULT_TENANT_ID);
                         assertThat(notification.getCreationTime()).isNotNull();
-                        assertThat(notification.isEnabled()).isFalse();
+                        assertThat(notification.isTenantEnabled()).isFalse();
                     });
                     context.completeNow();
                 }));
@@ -121,7 +121,7 @@ public class AbstractTenantManagementServiceTest {
                         assertThat(notification.getChange()).isEqualTo(LifecycleChange.UPDATE);
                         assertThat(notification.getTenantId()).isEqualTo(DEFAULT_TENANT_ID);
                         assertThat(notification.getCreationTime()).isNotNull();
-                        assertThat(notification.isEnabled()).isFalse();
+                        assertThat(notification.isTenantEnabled()).isFalse();
                     });
                     context.completeNow();
                 }));
@@ -152,7 +152,7 @@ public class AbstractTenantManagementServiceTest {
                         assertThat(notification.getChange()).isEqualTo(LifecycleChange.DELETE);
                         assertThat(notification.getTenantId()).isEqualTo(DEFAULT_TENANT_ID);
                         assertThat(notification.getCreationTime()).isNotNull();
-                        assertThat(notification.isEnabled()).isFalse();
+                        assertThat(notification.isTenantEnabled()).isFalse();
                     });
                     context.completeNow();
                 }));


### PR DESCRIPTION
Looking at the code
```
DeviceChangeNotification notification;
// ...
if (notification.isEnabled()) {
```
the `notification.isEnabled()` check always seems strange to me. Is it checking whether the notification itself is enabled?

To make things more explicit, I've renamed 
`DeviceChangeNotification.isEnabled` to `DeviceChangeNotification.isDeviceEnabled` 
and `TenantChangeNotification.isEnabled` to `TenantChangeNotification.isTenantEnabled`
here.
The serialization format has been kept the same for compatiblity reasons.
