### PR TITLE
[#3360] Create native executable command line client

### DIFF
--- a/builder/HonoBuilder.dockerfile
+++ b/builder/HonoBuilder.dockerfile
@@ -1,0 +1,69 @@
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public Li2cense 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+
+# This Dockerfile is based on https://github.com/findepi/graalvm-docker.
+# It has been adapted to use Mandrel instead of Oracle's GraalVM distribution and has been
+# extended with steps for installing Maven, GnuPG (required for creating signatures of
+# artifacts to be deployed to Maven Central) and UPX.
+# The resulting image can be used to build Hono from source, including the native executable
+# of the hono-cli artifact.
+
+FROM debian:stable-slim
+
+ARG MANDREL_VERSION=22.2.0.0-Final
+# either java11 or java17
+ARG JDK_VERSION=java17
+ARG MVN_VERSION=3.8.6
+
+ENV GRAALVM_HOME=/graalvm
+ENV MAVEN_HOME=/maven
+ENV JAVA_HOME=${GRAALVM_HOME}
+
+RUN set -xeu && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        curl \
+        gcc \
+        g++ \
+        libfreetype6-dev \
+        libz-dev \
+        gpg \
+        pinentry-tty \
+        openssh-client \
+        upx-ucl \
+        && \
+    mkdir ${GRAALVM_HOME} && \
+    curl -fsSL "https://github.com/graalvm/mandrel/releases/download/mandrel-${MANDREL_VERSION}/mandrel-${JDK_VERSION}-linux-amd64-${MANDREL_VERSION}.tar.gz" \
+        | tar -zxC ${GRAALVM_HOME} --strip-components 1 && \
+    find ${GRAALVM_HOME} -name "*src.zip"  -printf "Deleting %p\n" -exec rm {} + && \
+    { test ! -d ${GRAALVM_HOME}/legal || tar czf ${GRAALVM_HOME}/legal.tgz ${GRAALVM_HOME}/legal/; } && \
+    { test ! -d ${GRAALVM_HOME}/legal || rm -r ${GRAALVM_HOME}/legal; } && \
+    rm -rf ${GRAALVM_HOME}/man `# does not exist in java11 package` && \
+    mkdir ${MAVEN_HOME} && \
+    curl -fsSL "https://dlcdn.apache.org/maven/maven-3/${MVN_VERSION}/binaries/apache-maven-${MVN_VERSION}-bin.tar.gz" \
+        | tar -zxC ${MAVEN_HOME} --strip-components 1 && \
+    echo Cleaning up... && \
+    apt-get remove -y \
+        curl \
+        && \
+    apt-get autoremove -y && \
+    apt-get clean && rm -r "/var/lib/apt/lists"/* && \
+    echo 'PATH="${GRAALVM_HOME}/bin:$PATH"' | install --mode 0644 /dev/stdin /etc/profile.d/graal-on-path.sh && \
+    echo 'PATH="${MAVEN_HOME}/bin:$PATH"' | install --mode 0644 /dev/stdin /etc/profile.d/maven-on-path.sh && \
+    echo OK
+
+# This applies to all container processes. However, `bash -l` will source `/etc/profile` and set $PATH on its own. For this reason, we
+# *also* set $PATH in /etc/profile.d/*
+ENV PATH=${GRAALVM_HOME}/bin:${MAVEN_HOME}/bin:$PATH
+ENV SHELL=/bin/bash

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -6,7 +6,7 @@
     information regarding copyright ownership.
    
     This program and the accompanying materials are made available under the
-    terms of the Eclipse Public Li2cense 2.0 which is available at
+    terms of the Eclipse Public License 2.0 which is available at
     http://www.eclipse.org/legal/epl-2.0
    
     SPDX-License-Identifier: EPL-2.0

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -30,6 +30,19 @@
   <description>Quarkus based Hono Command line Interface</description>
 
   <properties>
+    <!-- 
+      this property prevents the Nexus Staging Maven Plugin to
+      deploy this module's artifacts to Maven Central' staging repo
+     -->
+    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+    <!-- 
+      this property prevents the Nexus Staging Maven Plugin to
+      deploy this module's artifacts to the configured project repository
+     -->
+    <skipStaging>true</skipStaging>
+    <maven.source.skip>true</maven.source.skip>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+    <gpg.skip>true</gpg.skip>
     <quarkus.package.type>uber-jar</quarkus.package.type>
     <quarkus.package.runner-suffix>-exec</quarkus.package.runner-suffix>
   </properties>
@@ -124,50 +137,16 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
       </plugin>
       <plugin>
-        <!-- Copy legal documents from "legal" module to "target/classes" folder so that we make sure to include 
-          legal docs in all modules. -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <!-- Execution and configuration for copying certificates from related module to "target/classes" folder 
-              so that we can include them in the image. -->
-            <id>copy_demo_certs</id>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>unpack-dependencies</goal>
-            </goals>
-            <configuration>
-              <includeArtifactIds>
-                hono-demo-certs
-              </includeArtifactIds>
-              <outputDirectory>${project.build.directory}/config</outputDirectory>
-              <includes>
-                *.pem,
-                *.jks,
-                *.p12
-              </includes>
-              <useSubDirectoryPerArtifact>true</useSubDirectoryPerArtifact>
-              <stripClassifier>true</stripClassifier>
-              <stripVersion>true</stripVersion>
-              <excludeTransitive>true</excludeTransitive>
-            </configuration>
-          </execution>
-        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jboss.jandex</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <extensions>true</extensions>
-        <executions>
-          <execution>
-            <goals>
-              <goal>build</goal>
-              <goal>generate-code</goal>
-              <goal>generate-code-tests</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -175,69 +154,45 @@
   <profiles>
 
     <profile>
-      <id>build-native-image</id>
+      <id>build-cli-native-executable</id>
+      <!-- 
+        This profile can be used to build a native executable from the hono-cli jar file.
+      -->
       <properties>
-        <!-- build native image inside of a container, doesn't require GraalVM SDK to be installed locally -->
-        <quarkus.native.remote-container-build>true</quarkus.native.remote-container-build>
-        <quarkus.native.builder-image>${native.builder-image.name}</quarkus.native.builder-image>
         <quarkus.package.type>native</quarkus.package.type>
+        <!--
+          By default, use remote container based build which does not require local installation of the GraalVM SDK
+          and native-image compiler.
+        -->
+        <quarkus.native.remote-container-build>true</quarkus.native.remote-container-build>
         <!--  include all JSSE related classes -->
         <quarkus.native.enable-all-security-services>true</quarkus.native.enable-all-security-services>
-        <!-- allow incomplete class path in order to not require (optional) compression codec dependencies of Netty -->
-        <!-- use Base64 encoder/decoder that is compatible with vert.x 3 -->
+        <!--
+          allow incomplete class path in order to not require (optional) compression codec dependencies of Netty,
+          open up certain modules' packages as required by native-image builder
+          (see https://www.graalvm.org/release-notes/22_2/#native-image)
+        -->
         <quarkus.native.additional-build-args>
           --initialize-at-run-time=io.netty.internal.tcnative.SSL\,org.apache.kafka.common.security.authenticator.SaslClientAuthenticator,
-          --allow-incomplete-classpath,
-          -Dvertx.json.base64=legacy
+          -J--add-opens=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED,
+          -J--add-opens=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.localization=ALL-UNNAMED,
+          -J--add-opens=org.graalvm.nativeimage.base/com.oracle.svm.util=ALL-UNNAMED,
+          -J--add-opens=org.graalvm.sdk/org.graalvm.nativeimage.impl=ALL-UNNAMED
         </quarkus.native.additional-build-args>
+        <quarkus.native.resources.includes>hono-cli-build.properties</quarkus.native.resources.includes>
       </properties>
-
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>io.fabric8</groupId>
-            <artifactId>docker-maven-plugin</artifactId>
-            <configuration>
-              <images>
-                <image>
-                  <name>${docker.repository}/%a-native:%v</name>
-                  <build>
-                    <maintainer>The Eclipse Hono project</maintainer>
-                    <labels>
-                      <project>Eclipse Hono</project>
-                    </labels>
-                    <tags>
-                      <tag>${docker.image.additional.tag}</tag>
-                    </tags>
-                    <imagePullPolicy>Always</imagePullPolicy>
-                    <from>${native.image.name}</from>
-                    <workdir>/opt/hono</workdir>
-                    <entryPoint>
-                      <arg>/opt/hono/${project.artifactId}-${project.version}-runner</arg>
-                      <arg>-Djava.util.logging.manager=org.jboss.logmanager.LogManager</arg>
-                    </entryPoint>
-                    <assembly>
-                      <mode>dir</mode>
-                      <basedir>/</basedir>
-                      <inline>
-                        <fileSets>
-                          <fileSet>
-                            <directory>${project.build.directory}</directory>
-                            <outputDirectory>opt/hono</outputDirectory>
-                            <includes>
-                              <include>${project.artifactId}-${project.version}-runner</include>
-                            </includes>
-                          </fileSet>
-                        </fileSets>
-                      </inline>
-                    </assembly>
-                  </build>
-                </image>
-              </images>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
+      <dependencies>
+        <!--
+          This is an optional dependency of picocli but without it, native executable compilation fails
+          due to unresolved classes.
+        -->
+        <dependency>
+            <groupId>com.googlecode.juniversalchardet</groupId>
+            <artifactId>juniversalchardet</artifactId>
+            <version>1.0.3</version>
+            <optional>true</optional>
+        </dependency>
+      </dependencies>
     </profile>
   </profiles>
 </project>

--- a/jenkins/Hono-Deploy-Eclipse-Pipeline-Declarative.groovy
+++ b/jenkins/Hono-Deploy-Eclipse-Pipeline-Declarative.groovy
@@ -20,65 +20,81 @@
 pipeline {
   agent {
     kubernetes {
-      label 'my-agent-pod'
-      yaml """
-apiVersion: v1
-kind: Pod
-spec:
-  containers:
-  - name: jnlp
-    volumeMounts:
-    - mountPath: "/home/jenkins"
-      name: "jenkins-home"
-    - mountPath: "/home/jenkins/.ssh"
-      name: "volume-known-hosts"
-    - mountPath: "/home/jenkins/.m2/toolchains.xml"
-      name: "m2-dir"
-      readOnly: true
-      subPath: "toolchains.xml"
-    - mountPath: "/home/jenkins/.m2/repository"
-      name: "m2-repo"
-      readOnly: false
-    - mountPath: "/home/jenkins/.m2/settings.xml"
-      name: "m2-secret-dir"
-      readOnly: true
-      subPath: "settings.xml"
-    - mountPath: "/home/jenkins/.m2/settings-security.xml"
-      name: "m2-secret-dir"
-      readOnly: true
-      subPath: "settings-security.xml"
-    - mountPath: "/opt/tools"
-      name: "tools"
-      readOnly: false
-    env:
-    - name: "HOME"
-      value: "/home/jenkins"
-    resources:
-      limits:
-        memory: "6Gi"
-        cpu: "2"
-      requests:
-        memory: "6Gi"
-        cpu: "2"
-  volumes:
-  - name: "jenkins-home"
-    emptyDir: {}
-  - name: "m2-repo"
-    emptyDir: {}
-  - name: "m2-dir"
-    configMap:
-      name: "m2-dir"
-  - name: "m2-secret-dir"
-    secret:
-      secretName: "m2-secret-dir"
-  - name: "volume-known-hosts"
-    configMap:
-      name: "known-hosts"
-  - name: "tools"
-    persistentVolumeClaim:
-      claimName: "tools-claim-jiro-hono"
-      readOnly: false
-"""
+      yaml '''
+        apiVersion: v1
+        kind: Pod
+        spec:
+          containers:
+          - name: "jnlp"
+            volumeMounts:
+            - mountPath: "/home/jenkins/.ssh"
+              name: "volume-known-hosts"
+            env:
+            - name: "HOME"
+              value: "/home/jenkins"
+          - name: "hono-builder"
+            image: "eclipse/hono-builder:2.1.0"
+            imagePullPolicy: "Always"
+            tty: true
+            command:
+            - cat
+            volumeMounts:
+            - mountPath: "/home/jenkins"
+              name: "jenkins-home"
+            - mountPath: "/home/jenkins/.ssh"
+              name: "volume-known-hosts"
+            - mountPath: "/home/jenkins/.m2/settings.xml"
+              name: "settings-xml"
+              subPath: "settings.xml"
+              readOnly: true
+            - mountPath: "/home/jenkins/.m2/settings-security.xml"
+              name: "settings-security-xml"
+              subPath: "settings-security.xml"
+              readOnly: true
+            - mountPath: "/home/jenkins/.m2/repository"
+              name: "m2-repo"
+            - mountPath: "/home/jenkins/.m2/toolchains.xml"
+              name: "toolchains-xml"
+              subPath: "toolchains.xml"
+              readOnly: true
+            env:
+            - name: "HOME"
+              value: "/home/jenkins"
+            resources:
+              limits:
+                memory: "8Gi"
+                cpu: "2"
+              requests:
+                memory: "8Gi"
+                cpu: "2"
+          volumes:
+          - name: "jenkins-home"
+            emptyDir: {}
+          - name: "m2-repo"
+            emptyDir: {}
+          - name: "volume-known-hosts"
+            configMap:
+              name: "known-hosts"
+          - name: "settings-xml"
+            secret:
+              secretName: "m2-secret-dir"
+              items:
+              - key: settings.xml
+                path: settings.xml
+          - name: "settings-security-xml"
+            secret:
+              secretName: "m2-secret-dir"
+              items:
+              - key: settings-security.xml
+                path: settings-security.xml
+          - name: "toolchains-xml"
+            configMap:
+              name: "m2-dir"
+              items:
+              - key: toolchains.xml
+                path: toolchains.xml
+        '''
+      defaultContainer 'hono-builder'
     }
   }
 
@@ -91,24 +107,31 @@ spec:
   parameters {
     string(
       name: 'BRANCH',
-      description: "The branch to retrieve the pipeline from.\nExamples:\n refs/heads/master\nrefs/heads/1.4.x",
+      description: "The branch to retrieve the pipeline from.\nExamples:\n refs/heads/master\nrefs/heads/2.1.x",
       defaultValue: 'refs/heads/master',
       trim: true)
     string(
       name: 'RELEASE_VERSION',
-      description: "The tag to build and deploy.\nExamples:\n1.0.0-M6\n1.0.0-RC1\n2.1.0",
+      description: "The tag to build and deploy.\nExamples:\n2.0.0-M6\n2.1.0-RC1\n2.0.1",
       defaultValue: '',
       trim: true)
   }
 
-  tools {
-    maven 'apache-maven-3.8.4'
-    jdk 'temurin-jdk17-latest'
-  }
-
   stages {
 
-    stage('Check out project') {
+    stage("Check build environment") {
+      steps {
+        sh '''#!/bin/bash
+          git --version
+          mvn --version
+          java --version
+          gpg --version
+          ls -al /home/jenkins
+        '''
+      }
+    }
+
+    stage("Check out project") {
       steps {
         container('maven') {
           echo "Checking out tag [refs/tags/${params.RELEASE_VERSION}]"
@@ -120,23 +143,44 @@ spec:
       }
     }
 
-    stage('Build and deploy to Eclipse Repo') {
+    stage("Build and deploy to Eclipse Repo") {
       steps {
-          sh "mvn deploy \
+          sh '''#!/bin/bash
+            mvn deploy \
                 -DskipTests=true -DnoDocker -DcreateJavadoc=true -DenableEclipseJarSigner=true -DskipStaging=true \
-                -am -pl '\
+                -am -pl "\
                   :hono-adapter-amqp,\
                   :hono-adapter-coap,\
                   :hono-adapter-http,\
                   :hono-adapter-lora,\
                   :hono-adapter-mqtt,\
                   :hono-adapter-sigfox,\
+                  :hono-client-amqp-common,\
+                  :hono-client-amqp-connection,\
+                  :hono-client-application,\
+                  :hono-client-application-amqp,\
+                  :hono-client-application-kafka,\
+                  :hono-client-command,\
+                  :hono-client-command-amqp,\
+                  :hono-client-command-kafka,\
+                  :hono-client-common,\
+                  :hono-client-device-amqp,\
+                  :hono-client-kafka-common,\
+                  :hono-client-notification,\
+                  :hono-client-notification-amqp,\
+                  :hono-client-notification-kafka,\
+                  :hono-client-registry,\
+                  :hono-client-registry-amqp,\
+                  :hono-client-telemetry,\
+                  :hono-client-telemetry-amqp,\
+                  :hono-client-telemetry-kafka,\
                   :hono-example,\
                   :hono-service-auth,\
                   :hono-service-command-router,\
                   :hono-service-device-registry-jdbc,\
                   :hono-service-device-registry-mongodb,\
-                  '"
+                  "
+          '''
       }
     }
   }

--- a/jenkins/Hono-Release-Pipeline.groovy
+++ b/jenkins/Hono-Release-Pipeline.groovy
@@ -12,87 +12,87 @@
  *******************************************************************************/
 
 /**
- * Jenkins pipeline script for Hono release.
- *
+ * Jenkins pipeline script for creating a Hono release including the CLI native executable.
  */
 
 pipeline {
   agent {
     kubernetes {
-      label 'my-agent-pod'
-      yaml """
-apiVersion: v1
-kind: Pod
-spec:
-  containers:
-  - name: "jnlp"
-    volumeMounts:
-    - mountPath: "/home/jenkins/.ssh"
-      name: "volume-known-hosts"
-    env:
-    - name: "HOME"
-      value: "/home/jenkins"
-  - name: "maven"
-    image: "maven:3.8.4-eclipse-temurin-17"
-    tty: true
-    command:
-    - cat
-    volumeMounts:
-    - mountPath: "/home/jenkins"
-      name: "jenkins-home"
-    - mountPath: "/home/jenkins/.ssh"
-      name: "volume-known-hosts"
-    - mountPath: "/home/jenkins/.m2/settings.xml"
-      name: "settings-xml"
-      subPath: "settings.xml"
-      readOnly: true
-    - mountPath: "/home/jenkins/.m2/settings-security.xml"
-      name: "settings-security-xml"
-      subPath: "settings-security.xml"
-      readOnly: true
-    - mountPath: "/home/jenkins/.m2/repository"
-      name: "m2-repo"
-    - mountPath: "/home/jenkins/.m2/toolchains.xml"
-      name: "toolchains-xml"
-      subPath: "toolchains.xml"
-      readOnly: true
-    env:
-    - name: "HOME"
-      value: "/home/jenkins"
-    resources:
-      limits:
-        memory: "6Gi"
-        cpu: "2"
-      requests:
-        memory: "6Gi"
-        cpu: "2"
-  volumes:
-  - name: "jenkins-home"
-    emptyDir: {}
-  - name: "m2-repo"
-    emptyDir: {}
-  - name: "volume-known-hosts"
-    configMap:
-      name: "known-hosts"
-  - name: "settings-xml"
-    secret:
-      secretName: "m2-secret-dir"
-      items:
-      - key: settings.xml
-        path: settings.xml
-  - name: "settings-security-xml"
-    secret:
-      secretName: "m2-secret-dir"
-      items:
-      - key: settings-security.xml
-        path: settings-security.xml
-  - name: "toolchains-xml"
-    configMap:
-      name: "m2-dir"
-      items:
-      - key: toolchains.xml
-        path: toolchains.xml
-"""
+      yaml '''
+        apiVersion: v1
+        kind: Pod
+        spec:
+          containers:
+          - name: "jnlp"
+            volumeMounts:
+            - mountPath: "/home/jenkins/.ssh"
+              name: "volume-known-hosts"
+            env:
+            - name: "HOME"
+              value: "/home/jenkins"
+          - name: "hono-builder"
+            image: "eclipse/hono-builder:2.1.0"
+            imagePullPolicy: "Always"
+            tty: true
+            command:
+            - cat
+            volumeMounts:
+            - mountPath: "/home/jenkins"
+              name: "jenkins-home"
+            - mountPath: "/home/jenkins/.ssh"
+              name: "volume-known-hosts"
+            - mountPath: "/home/jenkins/.m2/settings.xml"
+              name: "settings-xml"
+              subPath: "settings.xml"
+              readOnly: true
+            - mountPath: "/home/jenkins/.m2/settings-security.xml"
+              name: "settings-security-xml"
+              subPath: "settings-security.xml"
+              readOnly: true
+            - mountPath: "/home/jenkins/.m2/repository"
+              name: "m2-repo"
+            - mountPath: "/home/jenkins/.m2/toolchains.xml"
+              name: "toolchains-xml"
+              subPath: "toolchains.xml"
+              readOnly: true
+            env:
+            - name: "HOME"
+              value: "/home/jenkins"
+            resources:
+              limits:
+                memory: "8Gi"
+                cpu: "2"
+              requests:
+                memory: "8Gi"
+                cpu: "2"
+          volumes:
+          - name: "jenkins-home"
+            emptyDir: {}
+          - name: "m2-repo"
+            emptyDir: {}
+          - name: "volume-known-hosts"
+            configMap:
+              name: "known-hosts"
+          - name: "settings-xml"
+            secret:
+              secretName: "m2-secret-dir"
+              items:
+              - key: settings.xml
+                path: settings.xml
+          - name: "settings-security-xml"
+            secret:
+              secretName: "m2-secret-dir"
+              items:
+              - key: settings-security.xml
+                path: settings-security.xml
+          - name: "toolchains-xml"
+            configMap:
+              name: "m2-dir"
+              items:
+              - key: toolchains.xml
+                path: toolchains.xml
+        '''
+      defaultContainer 'hono-builder'
     }
   }
 
@@ -105,17 +105,17 @@ spec:
   parameters {
     string(
       name: "BRANCH",
-      description: "The branch to build and release from.\nExamples:\n refs/heads/master\nrefs/heads/1.4.x",
+      description: "The branch to build and release from.\nExamples:\n refs/heads/master\nrefs/heads/2.1.x",
       defaultValue: "refs/heads/master",
       trim: true)
     string(
       name: "RELEASE_VERSION",
-      description: "The version identifier (tag name) to use for the artifacts built and released by this job.\nExamples:\n1.0.0-M6\n1.3.0-RC1\n1.4.4",
+      description: "The version identifier (tag name) to use for the artifacts built and released by this job.\nExamples:\n2.0.0-M6\n2.1.0-RC1\n2.0.1",
       defaultValue: "",
       trim: true)
     string(
       name: "NEXT_VERSION",
-      description: "The version identifier to use during development of the next version.\nExamples:\n2.0.0-SNAPSHOT\n1.6.0-SNAPSHOT",
+      description: "The version identifier to use during development of the next version.\nExamples:\n2.2.0-SNAPSHOT",
       defaultValue: "",
       trim: true)
     booleanParam(
@@ -126,13 +126,30 @@ spec:
       name: "STABLE_DOCUMENTATION",
       description: "Set the documentation for this release as the new stable version.\nDisable for milestone release.",
       defaultValue: true)
+    booleanParam(
+      name: "COPY_ARTIFACTS",
+      description: "Copy the artifacts created by this build to the Eclipse download server.",
+      defaultValue: true)
   }
 
   stages {
 
-    stage("Print info about environment") {
+    stage("Check build environment") {
       steps {
-        sh "ls -al /home/jenkins"
+        sh '''#!/bin/bash
+          git --version
+          mvn --version
+          java --version
+          native-image --version
+          upx --version
+          ssh -V
+          if [[ "${COPY_ARTIFACTS}" =~ (t|true) ]]; then
+            echo "will deploy artifacts ..."
+          else
+            echo "will not deploy artifacts ..."
+          fi
+          ls -al /home/jenkins
+        '''
       }
     }
 
@@ -149,15 +166,32 @@ spec:
 
     stage("Build") {
       steps {
-        container("maven") {
-          sh "mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${params.RELEASE_VERSION}"
-          sh "mvn clean install javadoc:aggregate \
+        sh '''#!/bin/bash
+          mkdir artifacts
+          mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${RELEASE_VERSION}
+          mvn clean install javadoc:aggregate \
                   -Dmaven.test.failure.ignore=false \
                   -DenableEclipseJarSigner=true \
                   -DsnapshotDependencyAllowed=false \
                   -Ddocker.skip.build=true \
-                  -DnoDocker"
-        }
+                  -DnoDocker
+          chmod +r cli/target/hono-cli-${RELEASE_VERSION}-exec.jar
+          mv cli/target/hono-cli-${RELEASE_VERSION}-exec.jar artifacts/
+          # We need to build the native executable from scratch and without signing the jar files.
+          # This is to prevent the native image compiler running into signature errors when it
+          # tries to load classes of the same package from different jars having different signatures.
+          mvn clean install \
+                  -DskipTests \
+                  -Ddocker.skip.build=true \
+                  -DnoDocker \
+                  -Dquarkus.native.remote-container-build=false \
+                  -Dquarkus.native.compression.level=9 \
+                  -Dquarkus.native.native-image-xmx=6G \
+                  -Pbuild-cli-native-executable \
+                  -am -pl :hono-cli
+          chmod +r cli/target/hono-cli-${RELEASE_VERSION}-exec
+          mv cli/target/hono-cli-${RELEASE_VERSION}-exec artifacts/hono-cli-${RELEASE_VERSION}
+        '''
       }
     }
 
@@ -167,7 +201,7 @@ spec:
     */
     stage("Add version for documentation") {
       steps {
-        sh '''
+        sh '''#!/bin/bash
           echo "DEPLOY_DOCUMENTATION: ${DEPLOY_DOCUMENTATION}"
           echo "STABLE_DOCUMENTATION: ${STABLE_DOCUMENTATION}"
           if [[ "${DEPLOY_DOCUMENTATION}" =~ (t|true) ]]; then
@@ -183,7 +217,7 @@ spec:
               git add site/documentation/tag_stable.txt
             fi
           else
-            echo "skip release of documentation"
+            echo "will not publish documentation for release ..."
           fi
         '''
       }
@@ -191,31 +225,43 @@ spec:
 
     stage("Commit and tag release version") {
       steps {
-        sh '''
-           git config user.email "hono-bot@eclipse.org"
-           git config user.name "hono-bot"
-           git add pom.xml \\*/pom.xml
-           git commit -m "Release ${RELEASE_VERSION}"
-           git tag ${RELEASE_VERSION}
-           '''
+        sh '''#!/bin/bash
+           if [[ -n "${NEXT_VERSION}" ]]; then
+             git config user.email "hono-bot@eclipse.org"
+             git config user.name "hono-bot"
+             git add pom.xml \\*/pom.xml
+             git commit -m "Release ${RELEASE_VERSION}"
+             git tag ${RELEASE_VERSION}
+           else
+             echo "will not create tag for release ..."
+           fi
+        '''
       }
     }
 
     stage("Set next version") {
       steps {
-        container("maven") {
-          sh "mvn versions:set -DallowSnapshots=true -DgenerateBackupPoms=false -DnewVersion=${params.NEXT_VERSION}"
-        }
+        sh '''#!/bin/bash
+           if [[ -n "${NEXT_VERSION}" ]]; then
+             mvn versions:set -DallowSnapshots=true -DgenerateBackupPoms=false -DnewVersion=${NEXT_VERSION}
+           else
+             echo "will not create next version ..."
+           fi
+        '''
       }
     }
 
     stage("Commit and push") {
       steps {
         sshagent(credentials: [ "github-bot-ssh" ]) {
-          sh '''
-             git add pom.xml \\*/pom.xml
-             git commit -m "Bump version to ${NEXT_VERSION}"
-             git push --all ssh://git@github.com/eclipse/hono.git && git push --tags ssh://git@github.com/eclipse/hono.git
+          sh '''#!/bin/bash
+             if [[ -n "${NEXT_VERSION}" ]]; then
+               git add pom.xml \\*/pom.xml
+               git commit -m "Bump version to ${NEXT_VERSION}"
+               git push --all ssh://git@github.com/eclipse/hono.git && git push --tags ssh://git@github.com/eclipse/hono.git
+             else
+               echo "will not push newly created tag and next version ..."
+             fi
              '''
         }
       }
@@ -224,10 +270,14 @@ spec:
     stage("Copy Artifacts") {
       steps {
         sshagent(credentials: [ "projects-storage.eclipse.org-bot-ssh" ]) {
-          sh ''' 
-             chmod +r cli/target/hono-cli-${RELEASE_VERSION}-exec.jar
-             scp cli/target/hono-cli-${RELEASE_VERSION}-exec.jar \
-                 genie.hono@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/hono/
+          sh '''#!/bin/bash
+             echo "artifacts for downloading created by build process:"
+             ls -al artifacts
+             if [[ "${COPY_ARTIFACTS}" =~ (t|true) ]]; then
+               scp artifacts/* genie.hono@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/hono/
+             else
+               echo "will not copy artifacts to download server ..."
+             fi
              '''
         }
       }

--- a/jenkins/Hono-Website-Pipeline-Declarative.groovy
+++ b/jenkins/Hono-Website-Pipeline-Declarative.groovy
@@ -21,41 +21,41 @@ pipeline {
     kubernetes {
       label 'my-agent-pod'
       yaml """
-apiVersion: v1
-kind: Pod
-spec:
-  containers:
-  - name: jnlp
-    volumeMounts:
-    - mountPath: /home/jenkins/.ssh
-      name: volume-known-hosts
-    env:
-    - name: "HOME"
-      value: "/home/jenkins"
-    resources:
-      limits:
-        memory: "512Mi"
-        cpu: "1"
-      requests:
-        memory: "512Mi"
-        cpu: "1"
-  - name: hugo
-    image: cibuilds/hugo:0.97
-    command:
-    - cat
-    tty: true
-    resources:
-      limits:
-        memory: "512Mi"
-        cpu: "1"
-      requests:
-        memory: "512Mi"
-        cpu: "1"
-  volumes:
-  - configMap:
-      name: known-hosts
-    name: volume-known-hosts
-"""
+        apiVersion: v1
+        kind: Pod
+        spec:
+          containers:
+          - name: jnlp
+            volumeMounts:
+            - mountPath: /home/jenkins/.ssh
+              name: volume-known-hosts
+            env:
+            - name: "HOME"
+              value: "/home/jenkins"
+            resources:
+              limits:
+                memory: "512Mi"
+                cpu: "1"
+              requests:
+                memory: "512Mi"
+                cpu: "1"
+          - name: hugo
+            image: cibuilds/hugo:0.97
+            command:
+            - cat
+            tty: true
+            resources:
+              limits:
+                memory: "512Mi"
+                cpu: "1"
+              requests:
+                memory: "512Mi"
+                cpu: "1"
+          volumes:
+          - configMap:
+              name: known-hosts
+            name: volume-known-hosts
+        """
     }
   }
 

--- a/site/documentation/content/getting-started/_index.md
+++ b/site/documentation/content/getting-started/_index.md
@@ -45,7 +45,7 @@ The command line client is available in two variants:
 1. A Java Archive that requires a Java Runtime Environment to be installed locally and
 1. a x86_64 Linux executable that can be run from a shell directly.
 
-The former variant works on all platforms where Java is available and will be used during the reminder of this guide.
+The former variant works on all platforms where Java is available and will be used during the remainder of this guide.
 The latter variant should work on modern Linux distributions and can be used by replacing `java -jar hono-cli-*-exec.jar`
 with just the name of the executable file.
 {{% /notice %}}

--- a/site/documentation/content/getting-started/_index.md
+++ b/site/documentation/content/getting-started/_index.md
@@ -39,6 +39,17 @@ able to simulate an MQTT based device but otherwise will be able to get the same
 The Hono command line client is used in this guide for simulating an application that consumes telemetry data and events
 published by devices. The client is available from [Hono's download page]({{% homelink "downloads" %}}).
 
+{{% notice tip %}}
+The command line client is available in two variants:
+
+1. A Java Archive that requires a Java Runtime Environment to be installed locally and
+1. a x86_64 Linux executable that can be run from a shell directly.
+
+The former variant works on all platforms where Java is available and will be used during the reminder of this guide.
+The latter variant should work on modern Linux distributions and can be used by replacing `java -jar hono-cli-*-exec.jar`
+with just the name of the executable file.
+{{% /notice %}}
+
 #### Hono Instance
 
 The most important prerequisite is, of course, a Hono instance that you can work with.


### PR DESCRIPTION
Addresses #3360 

The build jobs have been changed to consistently use the
eclipse/hono-builder container image for building Hono. This image
contains specific versions of Maven, the GraalVM SDK with the
native-image compiler plugin and the UPX tool for compressing binary
artifacts.

The release build job has been extended with an additional invocation
of mvn clean install used to build the native executable of the CLI.

The native executable needs to be built in a separate run because in the
first build the JAR file artifacts are being signed by the Eclipse JAR
signer service which results in signature errors during the native
executable build.
