### PR TITLE
[#3390] Allow CLI to send empty messages with no content type

### DIFF
--- a/cli/src/main/java/org/eclipse/hono/cli/CustomConfiguration.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/CustomConfiguration.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.cli;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+import org.eclipse.hono.cli.util.CommandUtils;
+import org.eclipse.hono.client.ServiceInvocationException;
+
+import io.quarkus.picocli.runtime.PicocliCommandLineFactory;
+import picocli.CommandLine;
+
+/**
+ * A producer for Hono specific picocli objects.
+ *
+ */
+@ApplicationScoped
+public class CustomConfiguration {
+
+    /**
+     * Creates a command line with an exception handler that understands Hono's
+     * {@link ServiceInvocationException}s.
+     *
+     * @param factory The factory to use for creating the command line.
+     * @return The command line.
+     */
+    @Produces
+    CommandLine customCommandLine(final PicocliCommandLineFactory factory) {
+        return factory.create()
+                .setCommandName("hono")
+                .setExecutionExceptionHandler(CommandUtils::handleExecutionException);
+    }
+}

--- a/cli/src/main/java/org/eclipse/hono/cli/util/CommandUtils.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/util/CommandUtils.java
@@ -46,8 +46,9 @@ public final class CommandUtils {
      */
     public static void printError(final Throwable t) {
         if (t instanceof ServiceInvocationException cause) {
-            System.err.printf("Error: %d %s%n", cause.getErrorCode(),
-                    ServiceInvocationException.getErrorMessageForExternalClient(cause));
+            System.err.println("Error: %d - %s".formatted(
+                    cause.getErrorCode(),
+                    ServiceInvocationException.getErrorMessageForExternalClient(cause)));
         } else {
             System.err.println("Error: %s".formatted(t.getMessage()));
         }

--- a/clients/device-amqp/src/main/java/org/eclipse/hono/client/device/amqp/EventSender.java
+++ b/clients/device-amqp/src/main/java/org/eclipse/hono/client/device/amqp/EventSender.java
@@ -30,7 +30,7 @@ public interface EventSender {
      *
      * @param payload The data to send.
      *            <p>
-     *            The payload will be added to the message as an AMQP 1.0 <em>Data</em> section.
+     *            The payload, if not {@code null}, will be added to the message's body as an AMQP 1.0 <em>Data</em> section.
      * @param contentType The content type of the payload or {@code null} if unknown.
      *            <p>
      *            This parameter will be used as the value for the message's <em>content-type</em> property.
@@ -54,7 +54,6 @@ public interface EventSender {
      *         the future will be failed with either a {@code org.eclipse.hono.client.ServerErrorException} or a
      *         {@link org.eclipse.hono.client.ClientErrorException} depending on the reason for the failure to
      *         process the message.
-     * @throws NullPointerException if payload is {@code null}.
      * @throws IllegalArgumentException if tenant ID is not {@code null} but device ID is {@code null}.
      */
     Future<ProtonDelivery> sendEvent(

--- a/clients/device-amqp/src/main/java/org/eclipse/hono/client/device/amqp/TelemetrySender.java
+++ b/clients/device-amqp/src/main/java/org/eclipse/hono/client/device/amqp/TelemetrySender.java
@@ -33,7 +33,7 @@ public interface TelemetrySender {
      * @param qos The delivery semantics to use.
      * @param payload The data to send.
      *            <p>
-     *            The payload will be added to the message as an AMQP 1.0 <em>Data</em> section.
+     *            The payload, if not {@code null}, will be added to the message as an AMQP 1.0 <em>Data</em> section.
      * @param contentType The content type of the payload or {@code null} if unknown.
      *            <p>
      *            This parameter will be used as the value for the message's <em>content-type</em> property.
@@ -58,7 +58,7 @@ public interface TelemetrySender {
      *         will be failed with either a {@code org.eclipse.hono.client.ServerErrorException} or a
      *         {@link org.eclipse.hono.client.ClientErrorException} depending on the reason for the
      *         failure to process the message.
-     * @throws NullPointerException if quality-of-service or payload are {@code null}.
+     * @throws NullPointerException if quality-of-service is {@code null}.
      * @throws IllegalArgumentException if tenant ID is not {@code null} but device ID is {@code null}.
      */
     Future<ProtonDelivery> sendTelemetry(

--- a/clients/device-amqp/src/test/java/org/eclipse/hono/client/device/amqp/AmqpAdapterClientTestBase.java
+++ b/clients/device-amqp/src/test/java/org/eclipse/hono/client/device/amqp/AmqpAdapterClientTestBase.java
@@ -50,8 +50,6 @@ public abstract class AmqpAdapterClientTestBase {
 
     protected static final String TENANT_ID = "test-tenant";
     protected static final String DEVICE_ID = "test-device";
-    protected static final String CONTENT_TYPE = "text/plain";
-    protected static final Buffer PAYLOAD = Buffer.buffer("test-value");
     protected static final String TEST_PROPERTY_KEY = "test-key";
     protected static final String TEST_PROPERTY_VALUE = "test-value";
 
@@ -109,10 +107,15 @@ public abstract class AmqpAdapterClientTestBase {
      * Executes the assertions that check that the message created by the client conforms to the expectations of the
      * AMQP adapter.
      *
-     * @param expectedAddress The expected target address.
+     * @param expectedAddress The target address expected to be found in the message that has been sent.
+     * @param expectedContentType The content type expected to be found in the message that has been sent.
+     * @param expectedPayload The payload expected to be found in the message that has been sent.
      * @return The captured message.
      */
-    protected Message assertMessageConformsAmqpAdapterSpec(final String expectedAddress) {
+    protected Message assertMessageConformsToAmqpAdapterSpec(
+            final String expectedAddress,
+            final String expectedContentType,
+            final Buffer expectedPayload) {
 
         final ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
 
@@ -120,8 +123,20 @@ public abstract class AmqpAdapterClientTestBase {
         final Message message = messageArgumentCaptor.getValue();
 
         assertAll(() -> assertThat(message.getAddress()).isEqualTo(expectedAddress),
-                () -> assertThat(AmqpUtils.getPayload(message)).isEqualTo(PAYLOAD),
-                () -> assertThat(message.getContentType()).isEqualTo(CONTENT_TYPE));
+                () -> {
+                    if (expectedContentType != null) {
+                        assertThat(message.getContentType()).isEqualTo(expectedContentType);
+                    } else {
+                        assertThat(message.getContentType()).isNull();
+                    }
+                },
+                () -> {
+                    if (expectedPayload != null) {
+                        assertThat(AmqpUtils.getPayload(message)).isEqualTo(expectedPayload);
+                    } else {
+                        assertThat(AmqpUtils.getPayload(message)).isNull();
+                    }
+                });
 
         return message;
     }


### PR DESCRIPTION
The command line client has been changed to allow sending of messages to
the AMQP adapter that contain no body and no content-type.
It is at the discretion of the AMQP adapter to handle such messages in
an appropriate way. The CLI's error handling has been improved so that
it now always prints the error message received from the AMQP adapter.

Fixes #3390
