### PR TITLE
Fix missing span context injection in Pub/Sub message sender

### DIFF
--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/AbstractPubSubBasedMessageSender.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/AbstractPubSubBasedMessageSender.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.pubsub.publisher.PubSubPublisherClient;
 import org.eclipse.hono.client.pubsub.publisher.PubSubPublisherFactory;
+import org.eclipse.hono.client.pubsub.tracing.PubSubTracingHelper;
 import org.eclipse.hono.client.util.ServiceClient;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Lifecycle;
@@ -181,6 +182,7 @@ public abstract class AbstractPubSubBasedMessageSender implements MessagingClien
         }
 
         final Map<String, String> pubSubAttributes = encodePropertiesAsPubSubAttributes(properties, currentSpan);
+        PubSubTracingHelper.injectSpanContext(tracer, pubSubAttributes, currentSpan.context());
         final PubsubMessage.Builder builder = PubsubMessage.newBuilder()
                 .putAllAttributes(pubSubAttributes)
                 .setOrderingKey(deviceId);

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/tracing/PubSubTracingHelper.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/tracing/PubSubTracingHelper.java
@@ -12,13 +12,16 @@
  */
 package org.eclipse.hono.client.pubsub.tracing;
 
+import java.util.Map;
 import java.util.Objects;
 
 import com.google.pubsub.v1.PubsubMessage;
 
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
+import io.opentracing.noop.NoopSpanContext;
 import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMapAdapter;
 
 /**
  * A helper class providing Pub/Sub-specific utility methods for interacting with the OpenTracing API.
@@ -28,6 +31,27 @@ public final class PubSubTracingHelper {
 
     private PubSubTracingHelper() {
         // prevent instantiation
+    }
+
+    /**
+     * Injects a {@code SpanContext} into a Pub/Sub message's attributes.
+     * <p>
+     * The span context will be written to the Pub/Sub message's attributes.
+     *
+     * @param tracer The Tracer to use for injecting the context.
+     * @param attributes The Pub/Sub message's attributes to inject the context into.
+     * @param spanContext The context to inject or {@code null} if no context is available.
+     * @throws NullPointerException if tracer or attributes is {@code null}.
+     */
+    public static void injectSpanContext(final Tracer tracer, final Map<String, String> attributes,
+            final SpanContext spanContext) {
+
+        Objects.requireNonNull(tracer);
+        Objects.requireNonNull(attributes);
+
+        if (spanContext != null && !(spanContext instanceof NoopSpanContext)) {
+            tracer.inject(spanContext, Format.Builtin.TEXT_MAP, new TextMapAdapter(attributes));
+        }
     }
 
     /**


### PR DESCRIPTION
This PR corrects a missing injection of the span context into Pub/Sub messages, restoring the ability for protocol adapters and other upstream applications to extract and utilize the context for distributed tracing.