### PR TITLE
chore: add sbom generation and upload workflow

### DIFF
--- a/.github/workflows/generate-maven-sbom.yaml
+++ b/.github/workflows/generate-maven-sbom.yaml
@@ -1,0 +1,73 @@
+name: Generate Maven SBOM
+
+on:
+  push:
+    tags:
+      - "**" # triggers on any tag push
+
+  workflow_dispatch:
+    # Provide custom 'Version' input, to allow running the workflow for older
+    # git refs, where the workflow file did not exist yet. This is not possible
+    # with the builtin "Use workflow from" input field.
+    inputs:
+      version:
+        description: "Version"
+        default: "master"
+        required: true
+
+env:
+  JAVA_VERSION: '17'
+  JAVA_DISTRO: 'temurin'
+  PLUGIN_VERSION: '2.9.1'
+  SBOM_TYPE: 'makeAggregateBom'
+  PROJECT_VERSION: "${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.version }}"
+
+permissions:
+  contents: read
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    outputs:
+      # Make env var available in re-usuable workflow (see actions/runner#2372)
+      project-version: ${{ env.PROJECT_VERSION }}
+    steps:
+      - name: Checkout repository at '${{ env.PROJECT_VERSION }}'
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ env.PROJECT_VERSION }}
+          persist-credentials: false
+
+      - name: Setup Java SDK
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
+
+      - name: Generate
+        run: |
+          # Generate SBOMs in expected location
+          # 'skipNotDeployed' is needed to generate SBOM outside of deployment phase.
+
+          mvn org.cyclonedx:cyclonedx-maven-plugin:${PLUGIN_VERSION}:${SBOM_TYPE} \
+              -Dcyclonedx.skipNotDeployed=false \
+              -DoutputName=Eclipse-Hono-Sbom \
+              -DoutputDirectory=target/sbom
+
+      - name: Upload
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom
+          path: target/sbom/Eclipse-Hono-Sbom.json
+
+  # Store SBOM and metadata in a predefined format for otterdog to pick up
+  store-sbom-data:
+    needs: ['generate-sbom']
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    with:
+      projectName: 'hono'
+      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      bomArtifact: 'sbom'
+      bomFilename: 'Eclipse-Hono-Sbom.json'
+      parentProject: 'abe9ce77-f603-45ae-bd3c-c83f2d3c080d'


### PR DESCRIPTION
This PR aims to bootstrap the **EF Security Team** initiative of generating and publishing **SBOMs** for project releases, with the goal of enhancing software **supply chain security**.

To not interfere with your existing release processes, this PR proposes a new workflow to generate and publish SBOMs autonomously, following the push of a tag, e.g. coming from the Jenkins [release pipeline](https://github.com/eclipse-hono/hono/blob/8ed222fc594307b073b0885300c2a8058e665ad1/jenkins/Hono-Release-Pipeline.groovy#L234).

In addition to the release event, the workflow can be triggered manually to test SBOM generation, or to generate SBOMs for past releases.

Following a workflow run, the EF self-service system automatically publishes the SBOM on our DependencyTrack [instance](https://sbom.eclipse.org/), under the **Eclipse Hono → hono** entry. To view the uploaded results, you can log into DependencyTrack by using your EF account credentials.

If the PR is merged, we kindly ask you to run the workflow once, so that we can confirm a successful SBOM upload from your repository. You can find instructions to [trigger a workflow manually in the GitHub documentation](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow#running-a-workflow):

- The name of the workflow is "Generate Maven SBOM”
- Enter an existing release tag in the “Version” input field of the “Run workflow” UI, e.g. `2.6.0`

Also note that edits by maintainers are enabled for this PR, so feel free to update the workflow as you see fit, and do let us know if you have any questions!

More details about our SBOM Early Adopters initiative at EF can be found in our [Security Handbook](https://eclipse-csi.github.io/security-handbook/sbom/index.html).
