### PR TITLE
Fix error in getting container id via K8s API

### DIFF
--- a/clients/command/src/main/java/org/eclipse/hono/client/command/KubernetesContainerInfoProvider.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/KubernetesContainerInfoProvider.java
@@ -124,9 +124,7 @@ public class KubernetesContainerInfoProvider {
                     "getContainerId result future will be completed with the result of an already ongoing invocation");
             return containerIdPromise.future();
         }
-        containerIdPromise.handle(context.executeBlocking(() -> {
-            return getContainerIdViaK8sApi();
-        }));
+        context.executeBlocking(this::getContainerIdViaK8sApi, containerIdPromise);
         containerIdPromise.future().onComplete(ar -> containerIdPromiseRef.set(null));
         return containerIdPromise.future();
     }


### PR DESCRIPTION
Without this fix Adapters were not starting and logging "attempt x to get K8s container id failed, trying again..." over and over again (tested with HTTP and MQTT adapter).