### PR TITLE
Bump Quarkus to 3.27.2

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -49,7 +49,7 @@
     <opentracing.version>0.33.0</opentracing.version>
     <postgresql-image.name>docker.io/library/postgres:14-alpine</postgresql-image.name>
     <qpid-jms.version>1.15.0</qpid-jms.version>
-    <quarkus.platform.version>3.27.1</quarkus.platform.version>
+    <quarkus.platform.version>3.27.2</quarkus.platform.version>
     <slf4j.version>2.0.16</slf4j.version>
     <spring-security-crypto.version>6.5.7</spring-security-crypto.version>
     <truth.version>1.4.5</truth.version>


### PR DESCRIPTION
Apply latest Quarkus service release.

This is for #3722