### PR TITLE
Update code-ql-action to v4.35.5

### DIFF
--- a/.github/workflows/scanning.yml
+++ b/.github/workflows/scanning.yml
@@ -79,7 +79,7 @@ jobs:
           trivy image "$imageName" --timeout 15m0s --ignore-unfixed --severity HIGH,CRITICAL --format sarif --output "results/${{ matrix.artifactId }}.sarif"
 
       - name: Upload Docker image scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: "results/${{ matrix.artifactId }}.sarif"
           category: "Container Image ${{ matrix.artifactId }}"


### PR DESCRIPTION
Updated the action used to upload the SARIF results from the Trivy scan to the GitHub Security tab. The previous version was v3.35.1, which had a dependency on the deprcated node20 runtime. The new version, v4.35.5, is compatible with the latest node runtimes and includes various bug fixes and improvements.